### PR TITLE
remove version_table_suffix

### DIFF
--- a/paste_templates/__init__.py
+++ b/paste_templates/__init__.py
@@ -8,10 +8,6 @@ class TemplateCreate(templates.Template):
     summary = 'Template used to create a c2cgeoportal project'
     vars = [
         templates.var('srid', 'A Spatial Reference System Identifier (e.g. 21781)'),
-        templates.var(
-            'version_table_suffix',
-            'The sqlalchemy-migrate version table name suffix (this table ' \
-                'will be named: "version_${package}${version_table_suffix}")'),
         ]
 
 class TemplateUpdate(templates.Template):

--- a/paste_templates/create/+package+/CONST_migration/migrate.cfg_tmpl
+++ b/paste_templates/create/+package+/CONST_migration/migrate.cfg_tmpl
@@ -7,7 +7,7 @@ repository_id=c2cgeoportal
 # This name shouldn't already be used by your project.
 # If this is changed once a database is under version control, you'll need to 
 # change the table name in each database too. 
-version_table=version_${package}${version_table_suffix}
+version_table=version_${package}
 
 # When committing a change script, Migrate will attempt to generate the 
 # sql for all supported databases; normally, if one of them fails - probably


### PR DESCRIPTION
if some projects have the same ${package} name, the version_table parameter
will have to be manually updated for all these projects.
