### PR TITLE
Add paths to OpenLayers addins for GoogleEarthControl

### DIFF
--- a/paste_templates/create/jsbuild/app.cfg_tmpl
+++ b/paste_templates/create/jsbuild/app.cfg_tmpl
@@ -11,6 +11,8 @@ root =
     ${package}/static/lib/cgxp/ext
     ${package}/static/lib/cgxp/geoext/lib
     ${package}/static/lib/cgxp/openlayers/lib
+    ${package}/static/lib/cgxp/openlayers.addins/GoogleEarthControl/lib
+    ${package}/static/lib/cgxp/openlayers.addins/Spherical/lib
     ${package}/static/lib/cgxp/gxp/src/script
     ${package}/static/lib/cgxp/proj4js
     ${package}/static/lib/cgxp/geoext.ux/ux/Measure/lib


### PR DESCRIPTION
This is required for the Google Earth functionality, see

https://github.com/camptocamp/cgxp/pull/9
