### PR TITLE
Set print filename to package name, png export

### DIFF
--- a/paste_templates/create/print/templates/print.mako.in_tmpl
+++ b/paste_templates/create/print/templates/print.mako.in_tmpl
@@ -27,14 +27,14 @@ hosts:
   - !localMatch
     dummy: true
   - !dnsMatch
-    host: ${vars:mapserv_host}
+    host: $${vars:mapserv_host}
     port: 80 
   - !dnsMatch
-    host: ${vars:wsgi_host}
+    host: $${vars:wsgi_host}
     port: 80
   - !dnsMatch
-    host: ${vars:wsgi_host}
-    port: ${vars:paster_port}
+    host: $${vars:wsgi_host}
+    port: $${vars:paster_port}
 
 
 #===========================================================================


### PR DESCRIPTION
output file name to `${package}`  Instead of `mapfish-print`.
Allow png and pdf export
