### PR TITLE
add a test mixing using DBSession and db reflection

### DIFF
--- a/c2cgeoportal/tests/functional/test_dbreflection.py
+++ b/c2cgeoportal/tests/functional/test_dbreflection.py
@@ -100,3 +100,23 @@ class TestReflection(TestCase):
         self.assertEquals(modelclass.__name__, 'Table_b')
         self.assertEquals(modelclass.__table__.name, 'table_b')
         self.assertEquals(modelclass.__table__.schema, 'public')
+
+    def test_mixing_get_class_and_queries(self):
+        """ This test shows that we can mix the use of DBSession
+        and the db reflection API. """
+        from c2cgeoportal.lib.dbreflection import get_class
+        from c2cgeoportal.models import DBSession
+        from sqlalchemy import text
+        import transaction
+
+        self._create_table('table_c')
+
+        DBSession.execute(text('SELECT id FROM table_c'))
+
+        modelclass = get_class('table_c')
+        self.assertEquals(modelclass.__name__, 'Table_c')
+
+        # This commits the transaction created by DBSession.execute. This
+        # is required here in the test because tearDown does table.drop,
+        # which will block forever if the transaction is not committed.
+        transaction.commit()


### PR DESCRIPTION
@twpayne and I faced locking issues when using both the DBSession and the db reflection in the same test. The problem was related to the test calling `table.drop` in the tearDown function. This additional test show this. We won't face this problem in an actual view.
