### PR TITLE
use $${ for buildout vars in _tmpl files

### DIFF
--- a/paste_templates/update/CONST_CHANGELOG.txt_tmpl
+++ b/paste_templates/update/CONST_CHANGELOG.txt_tmpl
@@ -16,7 +16,7 @@ set to 0.8 on the buildout configuration of c2cgeoportal projects (section
 Wed, 29 Feb 2012 11:29:12 +0100
 
 Update variable jsbuild_root_dir in production.ini.in and developement.ini.in to:
-jsbuild_root_dir = ${buildout:directory}
+jsbuild_root_dir = $${buildout:directory}
 
 -------------------------------
 Mon, 27 Feb 2012 17:09:23 +0100


### PR DESCRIPTION
Without this change applying the `update` template fails because the `buildout:directory` variable does not exist.
