### PR TITLE
tilecache view does not work on Windows

### DIFF
--- a/c2cgeoportal/views/tilecache.py
+++ b/c2cgeoportal/views/tilecache.py
@@ -80,7 +80,7 @@ def wsgiHandler(environ, start_response):
                 start_response("200 OK", [('Content-Type','image/png')])
             else:
                 start_response("200 OK", [('Content-Type','image/jpeg')])
-            return [open(image_file).read()]
+            return [open(image_file, 'rb').read()]
         else:
             start_response("404 Tile Not Found", [('Content-Type','text/plain')])
             return ["No tile generated"]


### PR DESCRIPTION
The tilecache view does not work on Windows. If fails on `open` because it attempts to open an image without using the binary mode (`'b'`). It seems that to be safe binary mode should always be used when opening images. 

Relevant links:
- http://docs.python.org/library/functions.html#open
- http://stackoverflow.com/questions/2159794/why-python-on-windows-cant-read-an-image-in-binary-mode
