### PR TITLE
the test_echoview.py tests fail

### DIFF
--- a/c2cgeoportal/tests/test_echoview.py
+++ b/c2cgeoportal/tests/test_echoview.py
@@ -1,15 +1,15 @@
 # -*- coding: utf-8 -*-
 
-def test_json_base64_encode_chunks():
+def test_json_base64_encode():
     import StringIO
-    from c2cgeoportal.views.echo import json_base64_encode_chunks
+    from c2cgeoportal.views.echo import json_base64_encode
 
     sio = StringIO.StringIO()
     sio.write('some content with non-ASCII chars ç à é')
     sio.flush()
     sio.seek(0)
 
-    a = [s for s in json_base64_encode_chunks('a file name', sio)]
+    a = [s for s in json_base64_encode('a file name', sio)]
     s = ''.join(a)
 
     assert s == '{"filename":"a file name","data":"c29tZSBjb250ZW50IHdpdGggbm9uLUFTQ0lJIGNoYXJzIMOnIMOgIMOp","success":true}'


### PR DESCRIPTION
Here's the traceback:

```
Traceback (most recent call last):
  File "/home/elemoine/work/c2cgeoportal/nose-1.1.2-py2.6.egg/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/elemoine/work/c2cgeoportal/c2cgeoportal/tests/test_echoview.py", line 5, in test_json_base64_encode_chunks
    from c2cgeoportal.views.echo import json_base64_encode_chunks
ImportError: cannot import name json_base64_encode_chunks
```
