### PR TITLE
fix tests

### DIFF
--- a/c2cgeoportal/tests/functional/test_fulltextsearch.py
+++ b/c2cgeoportal/tests/functional/test_fulltextsearch.py
@@ -4,6 +4,7 @@ from nose.plugins.attrib import attr
 
 from pyramid import testing
 
+from c2cgeoportal.tests.functional import tearDownModule, setUpModule
 
 @attr(functional=True)
 class TestFulltextsearchView(TestCase):


### PR DESCRIPTION
The test suite runs with errors since b438198. This is because test_fulltextsearch.py does not do proper setUp and tearDown.
