### PR TITLE
a fix for the association proxy

### DIFF
--- a/c2cgeoportal/lib/dbreflection.py
+++ b/c2cgeoportal/lib/dbreflection.py
@@ -60,7 +60,8 @@ class _association_proxy(object):
             # The code of hybrid_property in SQLAlchemy illustrates
             # how to do that.
             raise AttributeError
-        return getattr(getattr(obj, self.target), self.value_attr)
+        target = getattr(obj, self.target)
+        return getattr(target, self.value_attr) if target else None
 
     def __set__(self, obj, val):
         from c2cgeoportal.models import DBSession


### PR DESCRIPTION
The association proxy should deal with the case where the object has no related object (0-to-n relationship).

All the tests continue to pass.
