### PR TITLE
integrator doc reorg

### DIFF
--- a/doc/integrator/create_application.rst
+++ b/doc/integrator/create_application.rst
@@ -103,8 +103,8 @@ main Buildout configuration file::
     served by the parent instance. Parent and child instances share
     the same database, but use dedicated schemas within that database.
 
-Add to Git
-----------
+Put the application under revision control
+------------------------------------------
 
 Now is a good time to put the application source code under revision
 control (Git preferably)::
@@ -120,7 +120,7 @@ control (Git preferably)::
     git push origin master
 
 Define the CGXP submodule
--------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Add the CGXP submodule::
 
@@ -135,44 +135,39 @@ Add the CGXP submodule::
 Configure the application
 -------------------------
 
-Edit the ``buildout.cfg`` file to configure the application, 
-especially the 'to_be_defined' values.
-
-Create the database and build the application
----------------------------------------------
-
-:ref:`integrator_install_application`
-
-Minimal setup of the application
---------------------------------
-
-This section provides the minimal set of things to do to get a working
-application.
-
-Defining background layers
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-A c2cgeoportal application has *background layers* and *overlays*. Background
-layers, also known as base layers, sit at the bottom of the map. They're
-typically cached layers. Overlays represent application-specific data. They're
-displayed on top of background layers.
-
-Background layers are created by the application integrator, while overlays are
-created by the application administrator. This is why only background layers
-are covered here in the Integrator Guide. Defining overlays is described in the
-:ref:`administrator_guide`.
-
-Create a WMTS layer (**To Be Changed**)
-
-* Make sure that ``/var/sig/tilecache/`` exists and is writeable by the user ``www-data``.
-* Add the matching layers definitions in the mapfile (``mapserver/c2cgeoportal.map.in``).
-* Add a layer entry in ``tilecache/tilecache.cfg.in``. The ``layers`` attribute 
-  must contain the list of mapserver layers defined above.
-* Update the layers list in the ``<package>/templates/viewer.js`` template. 
-  The ``layer`` parameter is the name 
-  of the tilecache layer entry just added in ``tilecache/tilecache.cfg.in``.
-
-**To Be Completed**
+Edit the ``buildout.cfg`` file to configure the application, especially the
+'to_be_defined' values.
 
 After creation and minimal setup the application is ready to be installed.
 See the next section :ref:`integrator_install_application`.
+
+.. Minimal setup of the application
+.. --------------------------------
+
+.. This section provides the minimal set of things to do to get a working
+.. application.
+
+.. Defining background layers
+.. --------------------------
+
+.. A c2cgeoportal application has *background layers* and *overlays*. Background
+.. layers, also known as base layers, sit at the bottom of the map. They're
+.. typically cached layers. Overlays represent application-specific data. They're
+.. displayed on top of background layers.
+
+.. Background layers are created by the application integrator, while overlays are
+.. created by the application administrator. This is why only background layers
+.. are covered here in the Integrator Guide. Defining overlays is described in the
+.. :ref:`administrator_guide`.
+
+.. Create a WMTS layer (**To Be Changed**)
+
+.. * Make sure that ``/var/sig/tilecache/`` exists and is writeable by the user ``www-data``.
+.. * Add the matching layers definitions in the mapfile (``mapserver/c2cgeoportal.map.in``).
+.. * Add a layer entry in ``tilecache/tilecache.cfg.in``. The ``layers`` attribute 
+..   must contain the list of mapserver layers defined above.
+.. * Update the layers list in the ``<package>/templates/viewer.js`` template. 
+..   The ``layer`` parameter is the name 
+..   of the tilecache layer entry just added in ``tilecache/tilecache.cfg.in``.
+
+.. **To Be Completed**

--- a/doc/integrator/editing.rst
+++ b/doc/integrator/editing.rst
@@ -8,10 +8,10 @@ Editing
 Any c2cgeoportal application comes with an editing interface, available at
 ``/edit`` (assuming ``/`` is the application's root URL).
 
-The editing interface requires the editing plugin (``cgxp_editing``), which is
-provided by CGXP as of commit `58c931d
+The editing interface requires the editing plugin (``cgxp.plugins.Editing``),
+which is provided by CGXP as of commit `58c931d
 <https://github.com/camptocamp/cgxp/commit/58c931de2f6397ffba223b4305d0b10a18413032>`_.
-So make sure your application uses an appropriate version (commit) of CGXP.
+Make sure your application uses an appropriate version (commit) of CGXP.
 
 The editing interface is defined in the application's ``templates/edit.html``
 and ``templates/edit.js`` files.  The integrator can edit
@@ -26,3 +26,7 @@ The integrator will probably need to:
 Other customizations, like adding tools to the toolbar, can be done. If layer
 sources and tools are added you will certainly need to edit ``jsbuild/app.cfg``
 and add scripts in the ``[edit.js]`` sections.
+
+See the `Editing API doc
+<http://docs.camptocamp.net/cgxp/lib/plugins/Editing.html>`_ for the list of
+options the plugin can receive.

--- a/doc/integrator/features.rst
+++ b/doc/integrator/features.rst
@@ -1,0 +1,30 @@
+.. _integrator_features:
+
+Add features to a c2cgeoportal application
+==========================================
+
+This section describes how to add features to a c2cgeoportal project,
+and configure them.
+
+Adding a feature requires adding a *plugin*  (CGXP plugin) to the user
+interface's *viewer*. It may also require additional steps, like adding and
+populating tables in the database.
+
+A c2cgeoportal project may define multiple viewers. By default a project
+includes two viewers: the *main viewer* and the *editing viewer*. The main
+viewer is defined in the ``<package>/templates/viewer.js`` file, while the
+editing viewer is defined in the ``<package>/templates/edit.js`` file. Each
+viewer includes a number of plugins by default; adding/removing features
+involve adding/removing plugins to/from the viewer.
+
+See http://docs.camptocamp.net/cgxp/ for the list of available CGXP plugins.
+
+Features that require additional steps (most of the time):
+
+.. toctree::
+   :maxdepth: 1
+
+   fulltext_search
+   editing
+   print
+

--- a/doc/integrator/fulltext_search.rst
+++ b/doc/integrator/fulltext_search.rst
@@ -3,14 +3,28 @@
 Full-text search
 ================
 
-If *full-text search* is enabled in the application, a PostgreSQL table
-dedicated to full-text search is required.
+Enabling the *full-text search* feature involves adding a ``FullTextSearch``
+plugin to the viewer, and creating and populating a dedicated table in the
+database.
+
+The FullTextSearch plugin
+-------------------------
+
+The viewer should include a ``FullTextSearch`` plugin for the *text search*
+feature to be available in the user interface.
+
+See the `FullTextSearch API doc
+<http://docs.camptocamp.net/cgxp/lib/plugins/FullTextSearch.html>`_ for the
+list of options the plugin can receive.
+
+*The main viewer includes a FullTextSearch plugin by default.*
 
 The full-text search table
 --------------------------
 
-This full-text search table should be named ``tsearch`` (for *text search*) and
-should be in the application-specific schema.
+The *text search* feature requires a dedicated PostgreSQL table. The full-text
+search table should be named ``tsearch`` (for *text search*) and should be in
+the application-specific schema.
 
 You don't need to create the table yourself, as it is created by the
 ``create_db`` command line (see the section
@@ -66,3 +80,4 @@ Here's another example where rows from a ``SELECT`` are inserted::
     database the application's ``default_language`` should be ``fr``. In other
     words c2cgeoportal assumes that the database language and the application's
     default language match.
+

--- a/doc/integrator/index.rst
+++ b/doc/integrator/index.rst
@@ -7,16 +7,14 @@ Integrator Guide
 Content:
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
    create_application
    install_application
-   extend_data_model
+   features
+   tileforge
    customize_ui
-   print
+   extend_data_model
    internationalization
    update_application
-   fulltext_search
-   editing
-   tileforge
    deploy

--- a/doc/integrator/install_application.rst
+++ b/doc/integrator/install_application.rst
@@ -3,8 +3,8 @@
 Install an existing application
 ===============================
 
-Database
---------
+Set up the database
+-------------------
 
 Any c2cgeoportal application requires a PostgreSQL/PostGIS database. The
 application works with its own tables, which store users, layers, etc. These
@@ -51,8 +51,8 @@ Give the rights to the user::
     GRANT ALL ON ALL TABLES IN SCHEMA <schema_name> TO "<db_user>";
     \q 
 
-Application
------------
+Install the application
+-----------------------
 
 System requirements
 ~~~~~~~~~~~~~~~~~~~

--- a/doc/integrator/print.rst
+++ b/doc/integrator/print.rst
@@ -1,10 +1,26 @@
-.. _print:
+.. _integrator_print:
 
-Print config.yaml templating
-============================
+Print
+=====
 
-Introduction
-------------
+Adding the *print* feature to a c2cgeoportal project involves adding
+a ``cgxp.plugins.Print`` plugin to the viewer, and configuring the MapFish
+Print.
+
+The Print plugin
+----------------
+
+The viewer should include a ``Print`` plugin for the *print* feature feature to
+be available in the user interface.
+
+See the `Print API doc
+<http://docs.camptocamp.net/cgxp/lib/plugins/Print.html>`_ for the
+list of options the plugin can receive.
+
+*The main viewer includes a Print plugin by default.*
+
+MapFish Print configuration
+---------------------------
 
 All print-related files are located in the ``print/`` folder.
 
@@ -18,7 +34,7 @@ The main file (``print/config.yaml``) used to define your print template written
 
 
 Mako templating
----------------
+~~~~~~~~~~~~~~~
 
 If you intend to have more than one paper format for your PDF
 print output, a templating system is implemented to allow you to use mako
@@ -52,8 +68,7 @@ be redefined.
 The ``print.mako.in`` has the "header" part and includes the wanted templates.
 
 Using backgroundPdf parameter
-------------------------------
-
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In print configuration you can use a PDF as a background image. You should put the 
 PDF file in the print directory and use '<%text>$</%text>{configDir}/template_A4_portrait.pdf' 
@@ -67,7 +82,7 @@ In your buildout.cfg file you should add this parts::
 The print.mako.in has the "header" part and includes the wanted templates.
 
 Using one printserver in a set of site
-======================================
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For memory issue we can use only one print server for a set of site.
 

--- a/doc/integrator/tileforge.rst
+++ b/doc/integrator/tileforge.rst
@@ -1,7 +1,7 @@
 .. _administrator_tileforge:
 
-Tileforge
-=========
+Work with Tileforge
+===================
 
 Configuration
 -------------

--- a/doc/integrator/update_application.rst
+++ b/doc/integrator/update_application.rst
@@ -1,10 +1,10 @@
 .. _integrator_update_application:
 
 Update a c2cgeoportal application
-=================================
+---------------------------------
 
 Update the application code
----------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To get the changes done by other people, we need to ``pull`` the new code::
 
@@ -26,7 +26,7 @@ If you still use SVN::
    fix the revision of CGXP.
 
 Update c2cgeoportal
--------------------
+~~~~~~~~~~~~~~~~~~~
 
 Upgrading an application to a new version of c2cgeoportal requires several
 steps:
@@ -71,7 +71,7 @@ steps:
        $ ./buildout/bin/buildout -c <buildout_config_file>
 
 Update CGXP
------------
+~~~~~~~~~~~
 
 To update CGXP in the application use the following::
 


### PR DESCRIPTION
This pull request suggests some reorg in the integrator doc. It also suggests adding an "add features to a c2cgeoportal application" section that provides a link to the CGXP API docs, and list the features that require extra configuration.
