### PR TITLE
add missing content_type header for viewer.js and edit.js

### DIFF
--- a/c2cgeoportal/views/entry.py
+++ b/c2cgeoportal/views/entry.py
@@ -337,10 +337,10 @@ class Entry(object):
     @view_config(route_name='viewer', renderer='viewer.js')
     def viewer(self):
         d = self._getVars()
-
         d['lang'] = self.lang
         d['debug'] = self.debug
 
+        self.request.response.content_type = 'application/javascript'
         return d
 
     @view_config(route_name='edit', renderer='edit.html')
@@ -353,10 +353,10 @@ class Entry(object):
     @view_config(route_name='edit.js', renderer='edit.js')
     def viewer(self):
         d = self._getVars()
-
         d['lang'] = self.lang
         d['debug'] = self.debug
 
+        self.request.response.content_type = 'application/javascript'
         return d
 
     @view_config(route_name='apiloader', renderer='apiloader.js')


### PR DESCRIPTION
In recent versions of c2cgeoportal, viewer.js and edit.js are called as standalone JS files. Without the suggested change, those "files" have a "text/html" content type.
