### PR TITLE
make it possible to create specific user validator

### DIFF
--- a/c2cgeoportal/__init__.py
+++ b/c2cgeoportal/__init__.py
@@ -49,6 +49,29 @@ def get_user_from_request(request):
                     username=username).one()
 
 
+def set_user_validator(config, user_validator):
+    """ Call this function to register a user validator function.
+
+    The validator function is passed three arguments: ``request``,
+    ``username``, and ``password``. The function should return the
+    user name if the credentials are valid, and ``None`` otherwise.
+
+    The validator should not do the actual authentication operation
+    by calling ``remember``, this is handled by the ``login`` view.
+    """
+    def register():
+        config.registry.validate_user = user_validator
+    config.action('user_validator', register)
+
+
+def default_user_validator(request, username, password):
+    """ Validate the username/password. This is c2cgeoportal's
+    default user validator. """
+    from c2cgeoportal.models import DBSession, User
+    user = DBSession.query(User).filter_by(username=username).first()
+    return username if user and user.validate_password(password) else None
+
+
 def includeme(config):
     """ This function returns a Pyramid WSGI application.
     """
@@ -86,6 +109,11 @@ def includeme(config):
     # add the "xsd" renderer
     config.add_renderer('xsd', XSD(
             sequence_callback=dbreflection._xsd_sequence_callback))
+
+    # add the set_user_validator directive, and set a default user
+    # validator
+    config.add_directive('set_user_validator', set_user_validator)
+    config.set_user_validator(default_user_validator)
 
     # add a TileCache view
     load_tilecache_config(config.get_settings())

--- a/c2cgeoportal/tests/functional/test_entry.py
+++ b/c2cgeoportal/tests/functional/test_entry.py
@@ -72,6 +72,7 @@ class TestEntryView(TestCase):
     #
 
     def test_login(self):
+        from c2cgeoportal import default_user_validator
         from c2cgeoportal.views.entry import Entry
         from pyramid.security import authenticated_userid
 
@@ -79,6 +80,7 @@ class TestEntryView(TestCase):
         request.params['login'] = u'__test_user1'
         request.params['password'] = u'__test_user1'
         request.params['came_from'] = "/came_from"
+        request.registry.validate_user = default_user_validator
         request.user = None
         response = Entry(request).login()
         self.assertEquals(response.status_int, 302) 

--- a/c2cgeoportal/tests/test_init.py
+++ b/c2cgeoportal/tests/test_init.py
@@ -1,0 +1,45 @@
+from unittest import TestCase
+from pyramid import testing
+
+
+class Test_includeme(TestCase):
+
+    def setUp(self):
+        self.config = testing.setUp(
+            # the c2cgeoportal includeme function requires a number
+            # of settings
+            settings={
+                'sqlalchemy.url': 'postgresql://u:p@h/d',
+                'srid': 900913,
+                'schema': 'main',
+                'parentschema': '',
+                'formalchemy_default_zoom': 0,
+                'formalchemy_default_lon': 0,
+                'formalchemy_default_lat': 0,
+                'formalchemy_available_functionalities': '',
+                'tilecache.cfg': 'c2cgeoportal/tests/tilecache.cfg'
+                }
+            )
+
+    def test_set_user_validator_directive(self):
+        import c2cgeoportal
+        self.config.include(c2cgeoportal.includeme)
+        self.failUnless(
+                self.config.set_user_validator.im_func.__docobj__ is
+                        c2cgeoportal.set_user_validator)
+
+    def test_default_user_validator(self):
+        import c2cgeoportal
+        self.config.include(c2cgeoportal.includeme)
+        self.assertEqual(self.config.registry.validate_user,
+                         c2cgeoportal.default_user_validator)
+
+    def test_user_validator_overwrite(self):
+        import c2cgeoportal
+        self.config.include(c2cgeoportal.includeme)
+
+        def custom_validator(username, password):
+            return False
+        self.config.set_user_validator(custom_validator)
+        self.assertEqual(self.config.registry.validate_user,
+                         custom_validator)

--- a/c2cgeoportal/tests/tilecache.cfg
+++ b/c2cgeoportal/tests/tilecache.cfg
@@ -1,0 +1,7 @@
+# A minimal TileCache configuration file that makes
+# the tilecache.load_tilecache_config succeeds.
+#
+# This is required for test_init.py.
+[cache]
+type=Disk
+base=/tmp

--- a/c2cgeoportal/views/entry.py
+++ b/c2cgeoportal/views/entry.py
@@ -18,7 +18,7 @@ from math import sqrt
 
 from c2cgeoportal.lib.functionality import get_functionality, get_functionalities
 from c2cgeoportal.models import DBSession, Layer, LayerGroup, Theme, \
-        RestrictionArea, Role, layer_ra, role_ra, User
+        RestrictionArea, Role, layer_ra, role_ra
 
 log = logging.getLogger(__name__)
 
@@ -385,10 +385,9 @@ class Entry(object):
         if not (login and password):
             return HTTPBadRequest('"login" and "password" should be " \
                     "available in request params')
-        user = DBSession.query(User).filter_by(username=login).first()
-        if user and user.validate_password(password):
+        if self.request.registry.validate_user(self.request, login, password):
             headers = remember(self.request, login)
-            log.info("User '%s' (%i) logged in." % (user.username, user.id))
+            log.info("User '%s' logged in." % login)
 
             cameFrom = self.request.params.get("came_from")
             if cameFrom:

--- a/doc/integrator/authentication.rst
+++ b/doc/integrator/authentication.rst
@@ -135,3 +135,29 @@ the value of the ``rolename`` environment variable by querying the database.
     The registered by the application overwrites it.
 
 You should be set at this point.
+
+Custom user validation
+----------------------
+
+For logging in ``c2cgeoportal`` validates the user credentials
+(username/password) by reading the user information from the ``user`` database
+table. If a c2cgeoportal application should work with another user information
+source, like LDAP, another *client validation* mechanism should be set up.
+``c2cgeoportal`` provides a specific ``Configurator`` function for that, namely
+``set_user_validator``. Here's an example::
+
+    def user_validator(request, username, password):
+        from pyramid_ldap import get_ldap_connector
+        connector = get_ldap_connector(request)
+        data = connector.authenticate(login, password)
+        if data is not None:
+            return data[0]
+        return None
+
+The validator function is passed three arguments: ``request``, ``username``,
+and ``password``. The function should return the user name if the credentials
+are valid, and ``None`` otherwise.
+
+In this example the `pyramid_ldap package
+<http://docs.pylonsproject.org/projects/pyramid_ldap/en/latest/>`_ is used as
+the user information source.


### PR DESCRIPTION
This pull request suggests adding a `Configurator` function/directive that makes it possible to set a specific user validator. This is required to support, for example, LDAP-based authentication.
