### PR TITLE
Map.js scaffold error

### DIFF
--- a/c2cgeoportal/scaffolds/create/+package+/static/js/api/Map.js_tmpl
+++ b/c2cgeoportal/scaffolds/create/+package+/static/js/api/Map.js_tmpl
@@ -21,7 +21,7 @@
 
 Ext.namespace('{{package}}');
 
-${package}.Map = Ext.extend(cgxp.api.Map, {
+{{package}}.Map = Ext.extend(cgxp.api.Map, {
 
     /**
      * Constructor


### PR DESCRIPTION
when upgrading an existing project using this command:

./buildout/bin/pcreate --interactive -s c2cgeoportal_create ../morges package=morges

I noticed an oddity with the file Map.js template :

Overwrite /home/admin/morges/morges/static/js/api/Map.js [y/n/d/B/?] d
--- /home/admin/morges/morges/static/js/api/Map.js

+++ /home/admin/morges/buildout/eggs/c2cgeoportal-0.7dev_20120531-py2.6.egg/c2cgeoportal/scaffolds/create/+package+/static/js/api/Map.js_tmpl

@@ -21,7 +21,7 @@

 Ext.namespace('morges');

-morges.Map = Ext.extend(cgxp.api.Map, {
+${package}.Map = Ext.extend(cgxp.api.Map, {

```
 /**
  * Constructor
```

according to Stephane, the ${package} is not correct in this context
