### PR TITLE
Problem with recent change to support grouped layers in WFS queries?

### DIFF
--- a/c2cgeoportal/views/entry.py
+++ b/c2cgeoportal/views/entry.py
@@ -165,6 +165,8 @@ class Entry(object):
                 if 'maxResolutionHint' not in l:
                     l['maxResolutionHint'] = float('%0.2f' % resolutions[1])
             l['childLayers'] = self._get_child_layers_info(wms_layer_obj)
+        else:
+            log.warning('layer %s not defined in WMS caps doc', layer.name)
 
     def _fill_non_internal_WMS(self, l, layer):
         if layer.minResolution and layer.maxResolution:


### PR DESCRIPTION
I have just upgraded a project to the last version of c2cgeoportal, including the changes of @elemoine and @ochriste to support the grouped layers in the WFS getfeature requests.

At first i got a Server Error due to an OWSLib exception (KeyError: u'No content named Luftmessstationen') when executing

```
l['childLayers'] = self._get_child_layers_info(wms[layer.name])
```

See https://github.com/camptocamp/c2cgeoportal/blob/master/c2cgeoportal/views/entry.py#L165

I have eventually figured out that the layername was not the same in the mapfile and in the layer definition in the administration interface. Then `wms[layer.name]` is not defined.

I know it's mainly an administrator error but shouldn't we add some more user-friendly exception catch? 
