### PR TITLE
add optional link between fulltextsearch and layertree

### DIFF
--- a/c2cgeoportal/scaffolds/create/+package+/templates/viewer.js_tmpl
+++ b/c2cgeoportal/scaffolds/create/+package+/templates/viewer.js_tmpl
@@ -220,6 +220,7 @@ Ext.onReady(function() {
         {
             ptype: "cgxp_fulltextsearch",
             url: "${request.route_url('fulltextsearch', path='')}",
+            layerTreeId: "layertree",
             actionTarget: "center.tbar"
         },
         {


### PR DESCRIPTION
added layertree ref. to fulltextsearch config to be able to autoload the related layergroup on user selection
see https://github.com/camptocamp/cgxp/pull/114
