### PR TITLE
Make app settings available in the mako templates

### DIFF
--- a/c2cgeoportal/views/entry.py
+++ b/c2cgeoportal/views/entry.py
@@ -398,6 +398,7 @@ class Entry(object):
 
     def _getVars(self):
         d = {}
+        d['settings'] = self.settings
         self.errors = "\n"
         d['themes'] = json.dumps(self._themes(d))
         d['themesError'] = self.errors


### PR DESCRIPTION
We sometimes need to have access to some application settings in the templates (viewer.js). This PR suggests to pass the whole `settings` object to the templates so that the latter may directly use them without the need to explicitly define them in the views.
