### PR TITLE
more valid Python code

### DIFF
--- a/c2cgeoportal/views/entry.py
+++ b/c2cgeoportal/views/entry.py
@@ -324,8 +324,9 @@ class Entry(object):
         log.info("WMS GetCapabilities for base url: %s" % wms_url)
         try:
             wms = WebMapService(wms_url, version='1.1.1')
-        except AttributeError as e:
-            errors =  _("WARNING! an error occured while trying to read the mapfile and recover the themes")
+        except AttributeError:
+            errors = "WARNING! an error occured while trying to read the "\
+                     "mapfile and recover the themes"
             self.serverError.append(errors)
             traceback.print_stack()
             log.exception(errors)
@@ -543,7 +544,7 @@ class Entry(object):
                     headers=headers)
 
     @view_config(route_name='permalinktheme', renderer='index.html')
-    def permalinktheme (self):
+    def permalinktheme(self):
         # recover themes from url route
         themes = self.request.matchdict['themes']
         d = {}

--- a/c2cgeoportal/views/mapserverproxy.py
+++ b/c2cgeoportal/views/mapserverproxy.py
@@ -47,13 +47,13 @@ def proxy(request):
 
     mss = get_functionalities('mapserver_substitution', \
             request.registry.settings, request)
-    if (mss):
+    if mss:
         for s in mss:
             index = s.find('=')
             if index > 0:
                 attribute = 's_' + s[:index]
                 value = s[index + 1:]
-                if (attribute in params):
+                if attribute in params:
                     params[attribute] += "," + value
                 else:
                     params[attribute] = value

--- a/c2cgeoportal/views/tilecache.py
+++ b/c2cgeoportal/views/tilecache.py
@@ -13,10 +13,11 @@ from tileforge import generator
 
 
 # default expiration time is set to 1 week
-DEFAULT_EXPIRATION = 3600*24*7
+DEFAULT_EXPIRATION = 3600 * 24 * 7
 
 # TileCache Service instance
 _service = None
+
 
 def load_tilecache_config(settings):
     """ Load the TileCache config.
@@ -36,6 +37,7 @@ def load_tilecache_config(settings):
         print _service.metadata['exception']
         print _service.metadata['traceback']
 
+
 def createImage(path_info):
     path = path_info.split('/')
     layername = path[3]
@@ -50,16 +52,17 @@ def createImage(path_info):
     generator.init(layer, _service.cache)
     generator.run(tile)
 
+
 def wsgiHandler(environ, start_response):
-    from paste.request import parse_formvars
     try:
         path_info = ""
 
-        if "PATH_INFO" in environ: 
+        if "PATH_INFO" in environ:
             path_info = environ["PATH_INFO"]
 
         l = len("/tilecache")
-        image_file = _service.config.get("cache", "base") + path_info[l:len(path_info)]
+        image_file = _service.config.get("cache", "base") + \
+                     path_info[l:len(path_info)]
 
         if not os.access(image_file, os.F_OK):
             # 3 trys to create image
@@ -77,17 +80,19 @@ def wsgiHandler(environ, start_response):
 
         if os.access(image_file, os.R_OK):
             if image_file[len(image_file) - 4:len(image_file)] == '.png':
-                start_response("200 OK", [('Content-Type','image/png')])
+                start_response("200 OK", [('Content-Type', 'image/png')])
             else:
-                start_response("200 OK", [('Content-Type','image/jpeg')])
+                start_response("200 OK", [('Content-Type', 'image/jpeg')])
             return [open(image_file, 'rb').read()]
         else:
-            start_response("404 Tile Not Found", [('Content-Type','text/plain')])
+            start_response("404 Tile Not Found",
+                           [('Content-Type', 'text/plain')])
             return ["No tile generated"]
 
     except TileCacheException, E:
-        start_response("404 Tile Not Found", [('Content-Type','text/plain')])
+        start_response("404 Tile Not Found", [('Content-Type', 'text/plain')])
         return ["An error occurred: %s" % (str(E))]
+
 
 @wsgiapp
 def tilecache(environ, start_response):
@@ -98,12 +103,11 @@ def tilecache(environ, start_response):
 
     # custom_start_response adds cache headers to the response
     def custom_start_response(status, headers, exc_info=None):
-        headers.append(('Cache-Control', 
+        headers.append(('Cache-Control',
                 'public, max-age=%s' % expiration))
-        headers.append(('Expires', 
-                email.Utils.formatdate(time.time() + expiration, 
+        headers.append(('Expires',
+                email.Utils.formatdate(time.time() + expiration,
                 False, True)))
         return start_response(status, headers, exc_info)
 
     return wsgiHandler(environ, custom_start_response)
-


### PR DESCRIPTION
2ef8bca fixes a number of errors and warnings reported by flake8.

There are two remaining warnings though:

```
c2cgeoportal/models.py:6: W801 redefinition of unused 'sha1' from line 4
c2cgeoportal/views/mapserverproxy.py:19:1: W901 'proxy' is too complex (15)
```

I don't know how to fix the first one. The second one is reported by the McCabe tool and is related to code complexity in the mapserver proxy.
