### PR TITLE
limit memory used by the sencha command

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_buildout.cfg_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_buildout.cfg_tmpl
@@ -201,7 +201,9 @@ cmds =
     >>> from subprocess import Popen
     >>> src_dir = os.path.join(buildout.get('directory', '.'), '{{package}}', 'static', 'mobile')
     >>> Popen(['compass', 'compile', 'resources/sass'], cwd=src_dir)
-    >>> Popen(['sencha', 'app', 'build', 'production'], cwd=src_dir)
+    >>> env = os.environ.copy()
+    >>> env['_JAVA_OPTIONS'] = '-Xmx128m'
+    >>> Popen(['sencha', 'app', 'build', 'production'], cwd=src_dir, env=env)
     >>> from shutil import copy
     >>> dst_dir = os.path.join(src_dir, 'build', 'production')
     >>> src = os.path.join(src_dir, 'config.js')


### PR DESCRIPTION
This pull request suggests setting the `_JAVA_OPTIONS` env var to `-Xmx128m` when executing the sencha build command. This is to limit the memory used by the JVM and prevent `Could not create the Java virtual machine.` errors because the system cannot give enough memory to the JVM.

(Depends on #242.)
