### PR TITLE
remove traceback

### DIFF
--- a/c2cgeoportal/views/entry.py
+++ b/c2cgeoportal/views/entry.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import traceback
 import urllib
 import logging
 import json
@@ -330,7 +329,6 @@ class Entry(object):
         except AttributeError:
             errors = _("WARNING! an error occured while trying to read the mapfile and recover the themes")
             self.serverError.append(errors)
-            traceback.print_stack()
             log.exception(errors)
 
             return (exportThemes, errors)


### PR DESCRIPTION
Right now the nosetests output is polluted by long stack traces:

```
  ...
  File "/usr/lib/python2.6/unittest.py", line 279, in run
    testMethod()
  File "/home/elemoine/work/c2cgeoportal/c2cgeoportal/tests/functional/test_functionalities.py", line 173, in test_web_client_functionalities
    u2 = Entry(request2)._getVars()
  File "/home/elemoine/work/c2cgeoportal/c2cgeoportal/views/entry.py", line 400, in _getVars
    d['themes'] = json.dumps(self._themes(d))
  File "/home/elemoine/work/c2cgeoportal/c2cgeoportal/views/entry.py", line 332, in _themes
    traceback.print_stack()
```

This issue suggests removing the `traceback.print_strak()` call that causes this. The exception handler already logs the error using `log.exception`, so the stack trace should be output to the logs. This should be sufficient. I don't see the need for printing the stack trace to stderr as well.
