### PR TITLE
Fix changelog for cgxp-install part

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -404,9 +404,20 @@ tilecache_url: http://$${vars:host}/$${vars:parent_instanceid}/wsgi/tilecache
     rm -rf /tmp/<project_name>
 
 16. The cgxp-install part is now deactivated by default, so if you still use
-    SVN, you should add in your ``bulidout.cfg`` file, section ``[buildout]``:
+    SVN, you have to add it back in your ``buildout.cfg`` file, section 
+    ``[buildout]``. Since this part needs to be run before jsbuild and cssbuild,
+    you have to override the whole parts list. For instance:
 
-        parts += cgxp-install
+        parts = eggs 
+                activate 
+                template 
+                modwsgi 
+                cgxp-install
+                jsbuild 
+                cssbuild 
+                po2mo 
+                print-template 
+                print-war
 
     If you are on Git the this line isn't needed any more in
     your ``buildout.cfg`` file, section ``[buildout]``:


### PR DESCRIPTION
We have tested alternative syntaxes such as

```
parts -= jsbuild cssbuild
parts += cgxp-install jsbuild cssbuild
```

but it doesn't work.
