### PR TITLE
Print center settings in checker_pdf

### DIFF
--- a/c2cgeoportal/scaffolds/create/config.yaml.in_tmpl
+++ b/c2cgeoportal/scaffolds/create/config.yaml.in_tmpl
@@ -85,6 +85,9 @@ tilecache_url:
 # Checker configuration
 checker:
     print_template: 1 A4 portrait
+    print_center_lon: to be defined
+    print_center_lat: to be defined
+    print_scale: 10000
     fulltextsearch: text to search
 
 # Check collector configuration

--- a/c2cgeoportal/scaffolds/create/config_child.yaml.in_tmpl
+++ b/c2cgeoportal/scaffolds/create/config_child.yaml.in_tmpl
@@ -86,4 +86,7 @@ tilecache_url: http://${vars:host}/${vars:parent_instanceid}/wsgi/tilecache
 # Checker configuration
 checker:
     print_template: 1 A4 portrait
+    print_center_lon: to be defined
+    print_center_lat: to be defined
+    print_scale: 10000
     fulltextsearch: text to search

--- a/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -117,7 +117,7 @@ Version 1.2
 
 9. A new parameter, layerManagerUrl, has been added to the cgxp_redlining plugin,
    to fix a problem with the base url used to access various resources used in
-   the related layerManager widget :
+   the related layerManager widget:
 
         {
             ptype: "cgxp_redlining",
@@ -144,6 +144,15 @@ Version 1.2
     Also, if you used ``c2cgeoportal.lib.functionality.get_functionality``
     in your templates you no longer need to, use ``functionality`` directly.
 
+11. checker_pdf requires that the central coordinates and scale of the map to
+    print when checking the printing service are provided in ``config.yaml.in``:
+
+        checker:
+            print_template: 1 A4 portrait
+            print_center_lon: to be defined
+            print_center_lat: to be defined
+            print_scale: 10000
+            fulltextsearch: text to search
 
 Version 1.1
 ===========

--- a/c2cgeoportal/views/checker.py
+++ b/c2cgeoportal/views/checker.py
@@ -78,7 +78,7 @@ class Checker(object):
                 'center': [self.settings['print_center_lon'], self.settings['print_center_lat']],
                 'col0': '',
                 'rotation': 0,
-                'scale': 10000,
+                'scale': self.settings['print_scale'],
                 'table': {
                     'columns': ["col0"],
                     'data': [{

--- a/doc/integrator/checker.rst
+++ b/doc/integrator/checker.rst
@@ -38,6 +38,9 @@ Configuration in ``config.yaml.in``::
 
     checker:
         print_template: 1 A4 portrait
+        print_center_lon: to be defined
+        print_center_lat: to be defined
+        print_scale: 10000
         fulltextsearch: text to search
 
 Check collector


### PR DESCRIPTION
Coords provided in checker_pdf are only valid if srid=21781.
It would also be a good idea to add print_center_lon/lat examples in the checker doc.
By the way "srid" is missing as well in default config.yaml.in?
