### PR TITLE
children can no longer get their parent's themes

### DIFF
--- a/c2cgeoportal/tests/functional/test_entry.py
+++ b/c2cgeoportal/tests/functional/test_entry.py
@@ -331,25 +331,29 @@ class TestEntryView(TestCase):
         entry = Entry(request)
 
         # unautenticated
-        response = entry.themes()
-        self.assertTrue(self._find_layer(response, '__test_public_layer'))
-        self.assertFalse(self._find_layer(response, '__test_private_layer'))
+        themes = entry.themes()
+        self.assertEquals(len(entry.serverError), 0)
+        self.assertEquals(len(themes), 1)
+        self.assertTrue(self._find_layer(themes[0], '__test_public_layer'))
+        self.assertFalse(self._find_layer(themes[0], '__test_private_layer'))
 
         # autenticated on parent
         role_id = DBSession.query(User.role_id).filter_by(username=u'__test_user1').one()
         request.params = { 'role_id': role_id }
-        response = entry.themes()
-        self.assertTrue(self._find_layer(response, '__test_public_layer'))
-        self.assertTrue(self._find_layer(response, '__test_private_layer'))
+        themes = entry.themes()
+        self.assertEquals(len(entry.serverError), 0)
+        self.assertEquals(len(themes), 1)
+        self.assertTrue(self._find_layer(themes[0], '__test_public_layer'))
+        self.assertTrue(self._find_layer(themes[0], '__test_private_layer'))
 
         # mapfile error
         request.params = {}
         request.registry.settings = {
             'mapserv_url': mapserv_url + '?map=not_a_mapfile',
         }
-        response = entry._themes({})
-        self.assertEquals(response[0], [])
-        self.assertNotEquals(response[1].strip(), '')
+        themes = entry._themes({})
+        self.assertEquals(len(themes), 0)
+        self.assertEquals(len(entry.serverError), 1)
 
     def test_WFS_types(self):
         from c2cgeoportal.models import DBSession, User

--- a/c2cgeoportal/views/entry.py
+++ b/c2cgeoportal/views/entry.py
@@ -318,7 +318,6 @@ class Entry(object):
         layers = query.filter(Layer.isVisible == True).order_by(Layer.order.asc()).all()
 
         exportThemes = []
-        errors = "\n"
 
         # retrieve layers metadata via GetCapabilities
         wms_url = self.request.registry.settings['mapserv_url'] + \
@@ -327,11 +326,12 @@ class Entry(object):
         try:
             wms = WebMapService(wms_url, version='1.1.1')
         except AttributeError:
-            errors = _("WARNING! an error occured while trying to read the mapfile and recover the themes")
+            errors = _("WARNING! an error occured while trying to "
+                       "read the mapfile and recover the themes")
             self.serverError.append(errors)
             log.exception(errors)
+            return exportThemes
 
-            return (exportThemes, errors)
         wms_layers = list(wms.contents)
 
         themes = DBSession.query(Theme).order_by(Theme.order.asc())
@@ -502,7 +502,7 @@ class Entry(object):
     def themes(self):
         d = {}
         d['role_id'] = self.request.params.get("role_id", None)
-        return self._themes(d)[0]
+        return self._themes(d)
 
     @view_config(context=HTTPForbidden, renderer='login.html')
     def loginform403(self):


### PR DESCRIPTION
It looks like ca6cae19b262e1d08bb92547a81bd60aecfe95a1 introduced a major regression. The `_themes` function no longer returns a tuple, while the `themes` view (called from children) does `self._themes(d)[0]`. I think using `self._themes(d)` should fix the issue. @sbrunner, what do you think?
