### PR TITLE
[doc] reverse items 7 and 8 in update process

### DIFF
--- a/doc/integrator/update_application.rst
+++ b/doc/integrator/update_application.rst
@@ -90,7 +90,11 @@ steps:
 6. Do manual migration steps based on what's in the ``CONST_CHANGELOG.txt``
    file.
 
-7. Update the database using the ``manage_db`` script::
+7. Execute ``buildout`` to rebuild and install the application::
+
+       $ ./buildout/bin/buildout -c <buildout_config_file>
+
+8. Update the database using the ``manage_db`` script::
 
        $ ./buildout/bin/manage_db upgrade
 
@@ -107,10 +111,6 @@ steps:
    ``<package_name>`` is to be replaced by the name of the application module.
    See above for more information.
 
-8. Execute ``buildout`` one more time to rebuild and reinstall the
-   application::
-
-       $ ./buildout/bin/buildout -c <buildout_config_file>
 
 Update CGXP
 ~~~~~~~~~~~


### PR DESCRIPTION
In http://docs.camptocamp.net/c2cgeoportal/integrator/update_application.html items 7 and 8 should be reversed. After following CONST_CHANGELOG.txt information, one could need to run ./buildout/bin/buildout command once.
