### PR TITLE
Add a link to the boostrap section in the 'creating a new app' doc

### DIFF
--- a/doc/developer/bootstrap.rst
+++ b/doc/developer/bootstrap.rst
@@ -1,4 +1,4 @@
-.. _developper_bootstrap:
+.. _developer_bootstrap:
 
 Bootstrap c2cgeoportal
 ======================

--- a/doc/integrator/create_application.rst
+++ b/doc/integrator/create_application.rst
@@ -6,7 +6,8 @@ Create a new application
 Creating a c2cgeoportal application is done by applying two Paste skeletons
 (a.k.a. templates). These skeletons are provided by the ``c2cgeoportal``
 package. So to be able to create a c2cgeoportal application the
-``c2cgeoportal`` package must be installed.
+``c2cgeoportal`` package must be installed. Please follow the
+:ref:`instructions to bootstrap c2cgeoportal <developer_bootstrap>`. 
 
 This guide considers that:
  - We use a server manages by Camptocamp, meaning:


### PR DESCRIPTION
Bootstrapping c2cgeoportal [1] is required prior to create a new application. A link towards this section is missing at the beginning of the "create a new application" doc [2].

[1] http://docs.camptocamp.net/c2cgeoportal/developer/bootstrap.html
[2] http://docs.camptocamp.net/c2cgeoportal/integrator/create_application.html
