### PR TITLE
Neutralize querystring in GET mode if mandatory param is missing

### DIFF
--- a/c2cgeoportal/views/mapserverproxy.py
+++ b/c2cgeoportal/views/mapserverproxy.py
@@ -68,7 +68,7 @@ def proxy(request):
     method = request.method
     
     # For GET requests, params are added only if REQUEST and SERVICE params
-    # are not provided.
+    # are actually provided.
     if method == "GET":
         keys = [key.lower() for key in params.keys()]
         if 'service' not in keys or 'request' not in keys:


### PR DESCRIPTION
In anonymous mode, the mapserv_proxy service returns the default message for request with no param:

```
No query information to decode. QUERY_STRING is set, but empty.
```

If a user is authenticated, mapserv_proxy adds "role_id=...&user_id=..." as query string of the Mapserver request, even if no other param was submitted (default access to the service). Mapserver then returns the following error:

```
mapserv(): Web application error. Traditional BROWSE mode requires a TEMPLATE in the WEB section, but none was provided.
```

According to the Mapserver logs:

```
msWCSDispatch20(): wrong service (none)
msWCSParseRequest(): request is KVP.
msWCSDispatch(): SERVICE and REQUEST not included
```

=> adding those role/user params triggers an error because mandatory params such as SERVICE and REQUEST are missing.

This pull request makes sure that with the GET method those params are actually provided before adding params to the query string.
