### PR TITLE
functional tests fail when using nose 1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ install_requires = [
 # nose plugins with options set in setup.cfg cannot be in
 # tests_require, they need be in setup_requires
 setup_requires = [
-    'nose',
+    'nose==1.1.2',
     'nosexcover',
     ]
 


### PR DESCRIPTION
This is related to setUpModule/tearDownModule not being called when we expect them to be called. It looks like nose 1.2 does not have behave as nose 1.1.2 for setUpModule/tearDownModule.
