### PR TITLE
'parent' column appears in theme page

### DIFF
--- a/c2cgeoportal/forms.py
+++ b/c2cgeoportal/forms.py
@@ -436,6 +436,7 @@ LayerGroupGrid = Grid(models.LayerGroup)
 
 # ThemeGrid
 ThemeGrid = Grid(models.Theme)
+ThemeGrid.configure(exclude=[ThemeGrid.parents])
 
 # FunctionalityGrid
 FunctionalityGrid = Grid(models.Functionality)


### PR DESCRIPTION
A Theme could have a parent in the data model but it shouldn't be done.

See https://github.com/camptocamp/c2cgeoportal/blob/master/c2cgeoportal/forms.py#L438
Add this line  (or so):

```
ThemeGrid.configure(exclude=[ThemeGrid.parents])
```

to remove this information from the BO.
