### PR TITLE
[authentification] we can't login in two instances on the same server

### DIFF
--- a/c2cgeoportal/scaffolds/create/+package+/__init__.py_tmpl
+++ b/c2cgeoportal/scaffolds/create/+package+/__init__.py_tmpl
@@ -9,8 +9,10 @@ from {{package}}.resources import Root
 def main(global_config, **settings):
     """ This function returns a Pyramid WSGI application.
     """
-    authentication_policy = AuthTktAuthenticationPolicy(settings.get('authtkt_secret'),
-           callback=defaultgroupsfinder) 
+    authentication_policy = AuthTktAuthenticationPolicy(
+            settings.get('authtkt_secret'),
+            callback=defaultgroupsfinder,
+            cookie_name=settings.get('authtkt_cookie_name'))
     config = Configurator(root_factory=Root, settings=settings,
             locale_negotiator=locale_negotiator, 
             authentication_policy=authentication_policy)

--- a/c2cgeoportal/scaffolds/create/development.ini.in_tmpl
+++ b/c2cgeoportal/scaffolds/create/development.ini.in_tmpl
@@ -9,7 +9,8 @@ debug_templates = true
 mako.directories = {{package}}:templates
     c2cgeoportal:templates
 app.cfg = %(here)s/config.yaml
-# Used to create secured cookies
+# Authentication settings
+authtkt_cookie_name = auth_tkt_${instanceid}
 authtkt_secret = ${authtkt_secret}
 # Database information
 sqlalchemy.url = postgresql://${dbuser}:${dbpassword}@${dbhost}:${dbport}/${db}

--- a/c2cgeoportal/scaffolds/create/production.ini.in_tmpl
+++ b/c2cgeoportal/scaffolds/create/production.ini.in_tmpl
@@ -9,7 +9,8 @@ debug_templates = false
 mako.directories = {{package}}:templates
     c2cgeoportal:templates
 app.cfg = %(here)s/config.yaml
-# Used to create secured cookies
+# Authentication settings
+authtkt_cookie_name = auth_tkt_${instanceid}
 authtkt_secret = ${authtkt_secret}
 # Database informations
 sqlalchemy.url = postgresql://${dbuser}:${dbpassword}@${dbhost}:${dbport}/${db}

--- a/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -19,6 +19,30 @@ Version 1.1
    in your project's buildout config (buildout.cfg.). If it is then change that
    to "js.jquery = 1.7.1", and execute buildout again.
 
+4. Currently there are authentication-related issues when multiple instances of
+   a c2cgeoportal application are running on the same machine. Indeed, loging
+   into one instance would log you out of from the instance you're currently
+   loged into. See <https://github.com/camptocamp/c2cgeoportal/issues/196>.
+
+   Fixing the issue requires manual changes to development.ini.in,
+   production.ini.in, and {{package}}/__init__.py.
+
+   Edit development.ini.in and production.ini.in and add the following
+   variable definition to the [app:app] section:
+
+       authtkt_cookie_name = auth_tkt_${instanceid}
+
+   (It is probably a good idea to group the definitions of authtkt_secret and
+   authtkt_cookie_name together, as they're both related to authentication.)
+
+   Now edit {{package}}/__init__.py to pass a `cookie_name` to the
+   `AuthTktAuthenticationPolicy` constructor:
+
+        authentication_policy = AuthTktAuthenticationPolicy(
+                settings.get('authtkt_secret'),
+                callback=defaultgroupsfinder,
+                cookie_name=settings.get('authtkt_cookie_name'))
+
 Version 1.0
 ===========
 


### PR DESCRIPTION
Workflow:
- login in one instance (for instance a parent's one)
- go to another instance (for instance a child instance)
- login to this instance
- go to the first instance, refresh => you have been logout
