### PR TITLE
use nose plugins nose-progressive and ipdbplugin

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ cover-package = c2cgeoportal
 with-xcoverage = 1
 with-xunit = 1
 cover-erase = 1
+with-progressive = 1
 
 [compile_catalog]
 directory = c2cgeoportal/locale

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,8 @@ install_requires = [
 setup_requires = [
     'nose',
     'nosexcover',
+    'nose-progressive',
+    'ipdbplugin',
     ]
 
 tests_require = install_requires + [


### PR DESCRIPTION
Use [nose-progressive](http://pypi.python.org/pypi/nose-progressive/) and [ipdbplugin](http://pypi.python.org/pypi/ipdbplugin), as suggested by @bbinet.

Among other things nose-progressive allows for a better display of test failures. ipdbplugin adds the options `--ipdb` and `--ipdb-failure`, which can be used instead of `--pdb` and `--pdb-failure`.

See this [screenshot](http://d3j5vwomefv46c.cloudfront.net/photos/full/658195503.png?key=700545&Expires=1347953780&Key-Pair-Id=APKAIYVGSUJFNRFZBBTA&Signature=ildHZNayqFV-Mp-7MNkylWd-UzULXlgJiVOL7unG790zSoMfYHVhQALhVUzdX4KmF4bP6Cje3iRvldHsRyRxIEwqe2g0gTst9YVUBRf5FM5N8STadOftYtJEQb2mZCiGTX2XgFb2LjJfuehzxAvyDqFt3ErtykY2sb6RoOphqOo_).
