### PR TITLE
tilecache_url of None type

### DIFF
--- a/c2cgeoportal/scaffolds/create/+package+/templates/apiviewer.js_tmpl
+++ b/c2cgeoportal/scaffolds/create/+package+/templates/apiviewer.js_tmpl
@@ -38,7 +38,7 @@ var RESTRICTED_EXTENT = [420000, 30000, 900000, 350000];
 var EVENTS = new Ext.util.Observable();
 
 var WMTS_OPTIONS = {
-% if len(tilecache_url) == 0:
+% if not tilecache_url:
     url: "${request.route_url('tilecache', path='')}",
 % else:
     url: '${tilecache_url}',

--- a/c2cgeoportal/scaffolds/create/+package+/templates/viewer.js_tmpl
+++ b/c2cgeoportal/scaffolds/create/+package+/templates/viewer.js_tmpl
@@ -44,7 +44,7 @@ Ext.onReady(function() {
     var EVENTS = new Ext.util.Observable();
 
     var WMTS_OPTIONS = {
-    % if not tilecache_url or len(tilecache_url) == 0:
+    % if not tilecache_url:
         url: "${request.route_url('tilecache', path='')}",
     % else:
         url: '${tilecache_url}',


### PR DESCRIPTION
In https://github.com/camptocamp/c2cgeoportal/blob/master/c2cgeoportal/templates/viewer_base.js#L53 shouldn't that be replaced by `% if not tilecache or len(tilecache_url) == 0:`, because the variable `tilecache_url` might be of type `None`.

In the SITN project, this is how it is configured and I had to do the same in our apiviewer.js. So I think that it should be like that in the rootC2Cgeoportal project??
