### PR TITLE
add missing error initialisation

### DIFF
--- a/c2cgeoportal/views/entry.py
+++ b/c2cgeoportal/views/entry.py
@@ -502,6 +502,7 @@ class Entry(object):
     def themes(self):
         d = {}
         d['role_id'] = self.request.params.get("role_id", None)
+        self.errors = "\n"
         return self._themes(d)
 
     @view_config(context=HTTPForbidden, renderer='login.html')


### PR DESCRIPTION
Actually we can crash at for example line 
https://github.com/camptocamp/c2cgeoportal/blob/master/c2cgeoportal/views/entry.py#L276

When we call the theme url
