### PR TITLE
Change default value for apache-entry-point.

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_buildout.cfg_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_buildout.cfg_tmpl
@@ -39,8 +39,8 @@ instanceid = override_me
 # can be overriden in development-specific buildout config files
 modwsgi_user = www-data
 # url-path where the instance must respond.
-# defaults is '/${vars:instanceid}/wsgi'.
-apache-entry-point = /${vars:instanceid}/wsgi
+# default is '/${vars:instanceid}/wsgi/'.
+apache-entry-point = /${vars:instanceid}/wsgi/
 # cookie session secret
 authtkt_secret = __import__('uuid').uuid4().hex
 # database user


### PR DESCRIPTION
This is so the RewriteRule's defined in apache/wsgi.conf.in produce correct URLs when apache-entry-point is left to its default value.

Ref https://github.com/camptocamp/sitn_c2cgeoportal/pull/26.
