### PR TITLE
Manually installing a dependency on Windows

### DIFF
--- a/doc/integrator/install_application.rst
+++ b/doc/integrator/install_application.rst
@@ -67,6 +67,7 @@ on your system:
          * `Python for Windows extensions <http://sourceforge.net/projects/pywin32/>`_
          * `Shapely <http://pypi.python.org/pypi/Shapely/1.2.13#downloads>`_
          * `Babel <http://pypi.python.org/pypi/Babel/>`_ (to be unconfirmed)
+         * `pyreadline <http://pypi.python.org/pypi/pyreadline>`_
 
 Set up the database
 -------------------


### PR DESCRIPTION
On Windows and since c2cgeoportal version 1.1dev-20121002, there is a new dependency that has to be installed manually (`pyreadline`).

This PR adds that to the doc.
