### PR TITLE
mapserver_proxy doesn't support accentuated params

### DIFF
--- a/c2cgeoportal/views/mapserverproxy.py
+++ b/c2cgeoportal/views/mapserverproxy.py
@@ -75,7 +75,10 @@ def proxy(request):
             params = {}
 
     # get query string
-    query_string = urllib.urlencode(params)
+    params_encoded = {}
+    for k, v in params.iteritems():
+        params_encoded[k] = unicode(v).encode('utf-8')
+    query_string = urllib.urlencode(params_encoded)
 
     # get URL
     _url = request.registry.settings['external_mapserv_url'] \


### PR DESCRIPTION
In my case the problem occurs when I try to ask for a legend icon with an url like the following:
http://nendaz-migrationmapfish-dev.int.lsn.camptocamp.com/main/mapserv_proxy?LAYER=repartitionplans&scale=141732.36000000002&user_id=1&SERVICE=WMS&FORMAT=image%2Fpng&REQUEST=GetLegendGraphic&role_id=1&VERSION=1.1.1&TRANSPARENT=TRUE&RULE=R%C3%A9partition%20des%20plans

The following error is raised:
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 1: ordinal not in range(128)

By calling, the mapserv directly, no error occurs.
