### PR TITLE
Add connection info for C2C pypi

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_buildout.cfg_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_buildout.cfg_tmpl
@@ -9,8 +9,9 @@ parts = eggs
         print-template
         print-war
 develop = .
-index = http://pypi.camptocamp.net/pypi
+index = http://c2c:Ilovepython@pypi.camptocamp.net/pypi
 allow-hosts = pypi.camptocamp.net
+    c2c:Ilovepython@pypi.camptocamp.net
 find-links = http://pypi.camptocamp.net/internal-pypi/index/c2cgeoportal
     http://pypi.camptocamp.net/internal-pypi/index/tileforge
 newest = false


### PR DESCRIPTION
While installing a c2cgeoportal application from scratch at BL, I got troubles running the "buildout" command and encountered some time-out errors with http://pypi.camptocamp.net/pypi/ipython

@sbrunner suggested me some changes in CONST_buildout.cfg. Perhaps it would be interesting to propagate them in c2cgeoportal's scaffolds.
