### PR TITLE
wrong content-lentgh in Printproxy.info view

### DIFF
--- a/c2cgeoportal/views/printproxy.py
+++ b/c2cgeoportal/views/printproxy.py
@@ -59,6 +59,7 @@ class Printproxy(object):
             layout['name'] in templates)
 
         headers = dict(resp)
+        del headers['content-length']
         headers["Expires"] = "-1"
         headers["Pragma"] = "no-cache"
         headers["CacheControl"] = "no-cache"


### PR DESCRIPTION
if we do not remove content-length from headers webob doesn't  recalculate the content-length from the body which can lead to bad content-length header.

Here is the fix for this problem (c2cgeoportal/views/printproxy.py):
`del headers['content-length']`

Patch coming (@bbinet)
