### PR TITLE
SERVICE param is not mandatory

### DIFF
--- a/c2cgeoportal/views/mapserverproxy.py
+++ b/c2cgeoportal/views/mapserverproxy.py
@@ -77,9 +77,9 @@ def proxy(request):
             (k.lower(), unicode(v).lower()) for k, v in params.iteritems()
             )
 
-        # For GET requests, params are added only if REQUEST and
-        # SERVICE params are actually provided.
-        if 'service' not in _params or 'request' not in _params:
+        # For GET requests, params are added only if the REQUEST
+        # parameter is actually provided.
+        if 'request' not in _params:
             params = {}
         else:
             # WMS GetLegendGraphic request?


### PR DESCRIPTION
It seems that "SERVICE=WMS" can be omitted in WMS requests. See for instance:
 http://webhelp.esri.com/arcims/9.3/general/mergedprojects/wms_connect/wms_connector/get_map.htm

The client at BL has tested his WMS service with an iphone app (ApliCAD WMS) and according to the logs the latter provides no SERVICE param in the GetMap request. Mapserverproxy then blocks the params and mapserver returns the default "Noquery information to decode. QUERY_STRING is set, but empty."
