### PR TITLE
Remove useless admin UI registration

### DIFF
--- a/c2cgeoportal/__init__.py
+++ b/c2cgeoportal/__init__.py
@@ -284,11 +284,6 @@ def includeme(config):
         ('admin_interface', 'available_functionalities'),
         formalchemy_available_functionalities)
 
-    # register an admin UI
-    config.formalchemy_admin(
-        'admin', package='c2cgeoportal',
-        view='fa.jquery.pyramid.ModelView', factory=FAModels)
-
     # scan view decorator for adding routes
     config.scan(ignore='c2cgeoportal.tests')
 


### PR DESCRIPTION
This PR suggests to remove some code that is any way overriden in the project's `__init__.py`. See in the scaffolds:
https://github.com/camptocamp/c2cgeoportal/blob/master/c2cgeoportal/scaffolds/create/%2Bpackage%2B/__init__.py_tmpl#L26

The main advantage to remove this piece of code is the possibility to deactivate (in the project's `__init__.py`) the admin UI, for instance for prod instances using some buildout param. For instance:

```
    settings = config.get_settings()
    if settings.get('enable_admin_interface', 'On') != 'Off':
        config.formalchemy_admin('admin', package='{{package}}',
                view='fa.jquery.pyramid.ModelView', factory=FAModels)
```

If the admin registration code is still available in c2cgeoportal, the change above has no effect.

Do you think it is worth adding the feature above in the scaffolds?
