### PR TITLE
New translation files for QueryBuilder

### DIFF
--- a/c2cgeoportal/scaffolds/create/jsbuild/app.cfg_tmpl
+++ b/c2cgeoportal/scaffolds/create/jsbuild/app.cfg_tmpl
@@ -263,7 +263,7 @@ include =
     Ext/src/locale/ext-lang-en.js
 #    GeoExt/locale/GeoExt-en.js
 #    FeatureEditing/resources/lang/en.js
-    Styler/resources/lang/en.js
+    Styler/lang/en.js
     locale/en.js #GXP
     CGXP/locale/en.js
 exclude =
@@ -296,7 +296,7 @@ include =
     Ext/src/locale/ext-lang-fr.js
     GeoExt/locale/GeoExt-fr.js
     FeatureEditing/resources/lang/fr.js
-    Styler/resources/lang/fr.js
+    Styler/lang/fr.js
     locale/fr.js #GXP
     CGXP/locale/fr.js
 exclude =
@@ -329,7 +329,7 @@ include =
     Ext/src/locale/ext-lang-de.js
 #    GeoExt/locale/GeoExt-de.js
     FeatureEditing/resources/lang/de.js
-    Styler/resources/lang/de.js
+    Styler/lang/de.js
 #    locale/de.js #GXP
     CGXP/locale/de.js
 exclude =

--- a/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -62,6 +62,18 @@ Version 1.2
    will still work, it your interested in have a look at:
    https://github.com/camptocamp/c2cgeoportal/pull/354
 
+6. CGXP now uses the GeOrchestra styler, which includes its own en, fr,
+   and de translations. Edit jsbuild/app.cfg, and in the [lang-en.js],
+   [lang-fr.js], and [lang-de.js] sections replace
+
+   - Styler/resources/lang/en.js by Styler/lang/en.js
+   - Styler/resources/lang/fr.js by Styler/lang/fr.js
+   - Styler/resources/lang/de.js by Styler/lang/de.js
+
+   The Styler/resources/lang/en.js, Styler/resources/lang/fr.js, and
+   Styler/resources/lang/de.js files no longer exist, so you will get
+   an error during the execution of the jsbuild part if you do not
+   do these replacements.
 
 Version 1.1
 ===========


### PR DESCRIPTION
The CGXP QueryBuilder plugin has new translation files. This requires changes to jsbuild/app.cfg.

See https://github.com/camptocamp/cgxp/pull/266. 
