### PR TITLE
Default value for parameter SERVICE in WMS requests

### DIFF
--- a/c2cgeoportal/views/mapserverproxy.py
+++ b/c2cgeoportal/views/mapserverproxy.py
@@ -82,12 +82,8 @@ def proxy(request):
         if 'request' not in _params:
             params = {}
         else:
-            # The SERVICE parameter is sometimes omitted. Use WMS as default:
-            if 'service' not in _params:
-                _params['service'] = u'wms'
-
             # WMS GetLegendGraphic request?
-            is_glg = _params['service'] == u'wms' and \
+            is_glg = ('service' not in _params or _params['service'] == u'wms') and \
                      _params['request'] == u'getlegendgraphic'
 
     # get query string


### PR DESCRIPTION
When dealing with #386, I have missed that omitting "SERVICE" in the WMS requests would make

```
is_glg = _params['service'] == u'wms' and \
               _params['request'] == u'getlegendgraphic'
```

crash.
https://github.com/camptocamp/c2cgeoportal/blob/master/c2cgeoportal/views/mapserverproxy.py#L86

I then suggest to set a default "wms" value for this param if it has been omitted. An alternate solution might be to remove the `_params['service'] == u'wms'` test in the code above (unless it doesn't make sense to check for getlegendgraphic requests if WMS is not used).
