### PR TITLE
Cache system does not take scheme/host into account

### DIFF
--- a/c2cgeoportal/lib/caching.py
+++ b/c2cgeoportal/lib/caching.py
@@ -32,7 +32,7 @@ def keygen_function(namespace, fn):
         if has_self:
             self_ = args[0]
             if hasattr(self_, 'request'):
-                parts.append(self_.request.host_url)
+                parts.append(self_.request.application_url)
             args = args[1:]
         parts.append(" ".join(map(compat.text_type, args)))
         return "|".join(parts)


### PR DESCRIPTION
The BL application may be access using various URL (http, https, intranet). Since the cache system has been enabled in the application we have observed that the generated URLs in viewer.js (for instance the themes icons) are sometimes incorrect: the scheme or host do not match the one of the application main URL.

The reason is probably that the cache system does not distinguish the cache versions for the various schemes/hosts of the application. For instance in `c2cgeoportal/views/entry.py`:

```
   @cache_region.cache_on_arguments()
    def _themes(self, role_id):
```

=> should we had the scheme/host info to the arguments?
