### PR TITLE
functionality in Mako templates should be a dict

### DIFF
--- a/c2cgeoportal/scaffolds/create/+package+/templates/edit.js_tmpl
+++ b/c2cgeoportal/scaffolds/create/+package+/templates/edit.js_tmpl
@@ -32,8 +32,6 @@ Ext.onReady(function() {
     // Server errors (if any)
     var serverError = ${serverError | n};
 
-    var FUNCTIONALITY = ${functionality | n};
-
     app = new gxp.Viewer({
 
         // viewer config

--- a/c2cgeoportal/scaffolds/create/+package+/templates/viewer.js_tmpl
+++ b/c2cgeoportal/scaffolds/create/+package+/templates/viewer.js_tmpl
@@ -33,8 +33,6 @@ Ext.onReady(function() {
     // Server errors (if any)
     var serverError = ${serverError | n};
 
-    var FUNCTIONALITY = ${functionality | n};
-
     // Used to transmit event throw the application
     var EVENTS = new Ext.util.Observable();
 
@@ -189,7 +187,7 @@ Ext.onReady(function() {
         },
         {
             ptype: "cgxp_mapopacityslider",
-            defaultBaseLayerRef: FUNCTIONALITY.default_basemap[0]
+            defaultBaseLayerRef: "${functionality['default_basemap'][0] | n}"
         },
         {
             ptype: "gxp_zoomtoextent",

--- a/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -126,6 +126,25 @@ Version 1.2
             layerManagerUrl: "${request.static_url('{{package}}:static/lib/cgxp/sandbox/LayerManager/ux/')}"
         },
 
+10. The ``functionality`` variable available in Mako templates (e.g. ``viewer.js``)
+    used to be a string. It is now a dict.
+    See https://github.com/camptocamp/c2cgeoportal/pull/400. To accomodate
+    this change in your project you need to
+
+    - Remove the FUNCTIONALITY JavaScript variable from viewer.js and
+      edit.js. This line:
+
+          var FUNCTIONALITY = ${functionality | n};
+
+    - Change the value for the ``defaultBaseLayerRef`` config option of the
+      MapOpacitySlider plugin from ``FUNCTIONALITY.default_basemap[0]`` to:
+
+          defaultBaseLayerRef: "${functionality['default_basemap'][0] | n}"
+
+    Also, if you used ``c2cgeoportal.lib.functionality.get_functionality``
+    in your templates you no longer need to, use ``functionality`` directly.
+
+
 Version 1.1
 ===========
 

--- a/c2cgeoportal/tests/functional/test_functionalities.py
+++ b/c2cgeoportal/tests/functional/test_functionalities.py
@@ -190,6 +190,6 @@ class TestFunctionalities(TestCase):
         annon = Entry(request)._getVars()
         u1 = Entry(request1)._getVars()
         u2 = Entry(request2)._getVars()
-        self.assertEquals(annon['functionality'], '{"__test_s": ["anonymous"], "__test_a": ["a1", "a2"]}');
-        self.assertEquals(u1['functionality'], '{"__test_s": ["registered"], "__test_a": ["r1", "r2"]}');
-        self.assertEquals(u2['functionality'], '{"__test_s": ["db"], "__test_a": ["db1", "db2"]}');
+        self.assertEquals(annon['functionality'], {"__test_s": ["anonymous"], "__test_a": ["a1", "a2"]});
+        self.assertEquals(u1['functionality'], {"__test_s": ["registered"], "__test_a": ["r1", "r2"]});
+        self.assertEquals(u2['functionality'], {"__test_s": ["db"], "__test_a": ["db1", "db2"]});

--- a/c2cgeoportal/views/entry.py
+++ b/c2cgeoportal/views/entry.py
@@ -450,7 +450,7 @@ class Entry(object):
                 'externalWFSTypes': json.dumps(self._externalWFSTypes()),
                 'external_themes': self._external_themes(),
                 'tilecache_url': self.settings.get("tilecache_url"),
-                'functionality': json.dumps(self._functionality()),
+                'functionality': self._functionality(),
                 'serverError': json.dumps(errors),
                 }
 

--- a/doc/integrator/functionality.rst
+++ b/doc/integrator/functionality.rst
@@ -81,10 +81,3 @@ The ``config.yaml.in`` file includes variables for managing *functionality*.
     ``functionality_name``/``value1`` and ``functionality_name``/``value2``,
     then the ``functionality`` template variable will be set to a dict with one
     key/value pair: ``"functionality_name"``/``["value1","value2"]``.
-
-    .. note::
-
-        The ``viewer.js`` Mako template creates a js variable named
-        ``FUNCTIONALITY`` from the ``functionality`` dict. For example::
-
-            var FUNCTIONALITY = {"functionality_name": ["value1", "value2"]};


### PR DESCRIPTION
The `functionality` variable in Mako templates (`viewer.js`) is a string. Instead it should be a dict. This would make possible constructs like this:

```
% if functionality['enable_google_earth'][0] == True:
    {
        ptype: "cgxp_googleearth"
        ...
    }
% endif
```

The bl project works around this by calling the c2cgeoportal `get_functionality` function directly. See https://project.camptocamp.com/svn/bl_gis2012/trunk/bl_gis2012/bl_gis2012/templates/viewer.js.
