### PR TITLE
Add lastPage param for legends in default print config

### DIFF
--- a/c2cgeoportal/scaffolds/create/print/templates/A3_landscape.mako
+++ b/c2cgeoportal/scaffolds/create/print/templates/A3_landscape.mako
@@ -362,6 +362,41 @@ ${self.block_text_misc()}
             - !text
               text: ' '
 
+    lastPage:
+      pageSize: A4
+      items:
+        - !columns
+          condition: legends
+          absoluteX: 51
+          absoluteY: 700
+          width: 511
+          backgroundColor: #FF0000
+          items:
+            - !text
+              align:left
+              text: 'Legend'
+              spacingAfter: 10
+        - !columns
+          condition: legends
+          absoluteX: 51
+          absoluteY: 680
+          width: 400
+          backgroundColor: #FF0000
+          items:
+            - !legends
+              inline: false
+              defaultScale: 0.5
+              maxHeight: 550
+              maxWidth: 50
+              scale: 0.8
+              maxIconHeight: 0
+              maxIconWidth: 0
+              columnMargin: 5
+              classIndentation: 3
+              classSpace: 5
+              layerSpace: 5
+              backgroundColor: white
+
 ## end of global template code
 ## start of block specific code
 

--- a/c2cgeoportal/scaffolds/create/print/templates/A4_portrait.mako
+++ b/c2cgeoportal/scaffolds/create/print/templates/A4_portrait.mako
@@ -410,6 +410,40 @@ ${self.block_text_misc()}
             - !text
               text: ' '
 
+    lastPage:
+      pageSize: A4
+      items:
+        - !columns
+          condition: legends
+          absoluteX: 51
+          absoluteY: 700
+          width: 511
+          backgroundColor: #FF0000
+          items:
+            - !text
+              align:left
+              text: 'Legend'
+              spacingAfter: 10
+        - !columns
+          condition: legends
+          absoluteX: 51
+          absoluteY: 680
+          width: 400
+          backgroundColor: #FF0000
+          items:
+            - !legends
+              inline: false
+              defaultScale: 0.5
+              maxHeight: 550
+              maxWidth: 50
+              maxIconHeight: 0
+              maxIconWidth: 0
+              columnMargin: 5
+              classIndentation: 3
+              classSpace: 5
+              layerSpace: 5
+              backgroundColor: white
+
 ## the backslash tell mako To Not write a new line at the end
 <%def name="title()">\
 1 A4 portrait\


### PR DESCRIPTION
This PR adds a default config for legends in PDF config (A4 portrait and A3 landscape) as suggested in #304.

The config is the same for both layouts (legend is drawn in an A4 portrait page) as done in https://project.camptocamp.com/svn/jourdan_cw3/c2cgeoportal/puidoux/print/templates/

(not tested)
