### PR TITLE
Add missing parameters in the overviewmap's mapOptions

### DIFF
--- a/c2cgeoportal/scaffolds/create/+package+/templates/viewer.js_tmpl
+++ b/c2cgeoportal/scaffolds/create/+package+/templates/viewer.js_tmpl
@@ -316,6 +316,9 @@ Ext.onReady(function() {
                     )],
                     mapOptions: {
                         theme: null,
+                        projection: new OpenLayers.Projection("EPSG:{{srid}}"),
+                        restrictedExtent: OpenLayers.Bounds.fromArray([420000, 30000, 900000, 350000]),
+                        units: "m",
                         numZoomLevels: 1
                     }
                 })*/


### PR DESCRIPTION
The "Image" overviewmap code provided in the scaffolds does not work (the red rectangle is not drawn and clicking on the overviewmap pan the main map outside of its maxextent). It seems necessary to add some projection/extent info.

I see in some project (nendaz [1]) that some additional params might be useful (it's OK in my case without those params):

```
maxExtent: ..., // same than restrictedExtent for instance
maxResolution: "auto",
```

[1] https://github.com/camptocamp/nendaz_migrationmapfish/blob/master/nendaz/templates/viewer.js#L261
