### PR TITLE
Mobile : bug when upgrading the version on the device

### DIFF
--- a/c2cgeoportal/scaffolds/update/+package+/static/mobile/app.json
+++ b/c2cgeoportal/scaffolds/update/+package+/static/mobile/app.json
@@ -30,6 +30,14 @@
      *                                      //  - "full" means full update will be made when this file changes
      *
      *      }
+     *
+     * Warning (Camptocamp):
+     *
+     * By default Sencha sets "update" to "delta". But we have experienced
+     * issues with Sencha Touch 2.0.1.1 because of the deltas, where a js
+     * error occurs at application loading time. This was reported in
+     * https://github.com/camptocamp/c2cgeoportal/issues/433. We may
+     * want to revisit when upgrading to a new version of Sencha Touch.
      */
     "js": [
         {
@@ -38,7 +46,7 @@
         {
             "path": "app.js",
             "bundle": true,  /* Indicates that all class dependencies are concatenated into this file when build */
-            "update": "delta"
+            "update": "full"
         }
     ],
 
@@ -58,7 +66,7 @@
     "css": [
         {
             "path": "resources/css/app.css",
-            "update": "delta"
+            "update": "full"
         }
     ],
 


### PR DESCRIPTION
Another bug reported by many users : when a new version of C2CGeoportal is installed, a message is given to the user to upgrade to new version. After saying yes, many users (I have reproduced myself the issue), regardless of the OS, have the 3 white points and the application does not load. The only way to workaround is to empty the cache of the browser... This issue is really annoying...

THANKS 
