### PR TITLE
Use nose-progressive 1.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,17 +36,21 @@ install_requires = [
     'dogpile.cache',
     ]
 
-# nose plugins with options set in setup.cfg cannot be in
-# tests_require, they need be in setup_requires
+# nose plugins with options set in setup.cfg cannot be in tests_require, they
+# need be in setup_requires
+#
+# Also, there's a bug in nose that forces us to stick with nose 1.1.2. This
+# also forces us to stick with nose-progressive 1.3.
+# See https://github.com/camptocamp/c2cgeoportal/pull/333.
 setup_requires = [
     'nose==1.1.2',
-    'nosexcover',
-    'nose-progressive',
-    'ipdbplugin',
+    'nosexcover==1.0.7',
+    'nose-progressive==1.3',
+    'ipdbplugin==1.2',
     ]
 
 tests_require = install_requires + [
-    'mock',
+    'mock==1.0.1',
     ]
 
 setup(name='c2cgeoportal',


### PR DESCRIPTION
We're currently forced to stick with 1.1.2. See #333. Transitively we're forced to stick with nose-progressive 1.3.

This should fix https://github.com/camptocamp/sitn_c2cgeoportal/issues/104.
