### PR TITLE
[doc][editing] add a note about the number of geometry columns

### DIFF
--- a/doc/administrator/editing.rst
+++ b/doc/administrator/editing.rst
@@ -29,13 +29,26 @@ To be editable a layer should satisfy the following requirements:
        -------------+-------------+----------------------------------------------------------
         id          | integer     | not null default nextval('public.table_id_seq'::regclass)
 
-4. The PostGIS table's geometry column should be declared in PostGIS'
-   ``geometry_columns`` table, which is typically done using PostGIS'
-   `AddGeometryColumn function
-   <http://postgis.refractions.net/docs/AddGeometryColumn.html>`_. c2cgeoportal
-   indeed queries the ``geometry_columns`` to get the information it needs
-   about the geometry columns.
-5. If the PostGIS table has a many-to-one relationship to another table
+4. The PostGIS table should include one geometry column only. You
+   will get errors if the table has multiple geometry columns, even
+   if one of them only is declared in PostGIS' ``geometry_columns``
+   table.
+
+5. The PostGIS table's geometry column should be declared in PostGIS'
+   ``geometry_columns`` table. c2cgeoportal indeed queries the
+   ``geometry_columns`` table to get the information it needs.
+
+   .. note::
+
+       Creating a geometry column and populating ``geometry_columns`` is
+       typically done using the `AddGeometryColumn function
+       <http://postgis.net/docs/AddGeometryColumn.html>`_.  The
+       `Populate_Geometry_Columns function
+       <http://postgis.net/docs/Populate_Geometry_Columns.html>`_ can also be
+       useful for registering already created geometry columns in
+       ``geometry_columns``.
+
+6. If the PostGIS table has a many-to-one relationship to another table
    (typically a dictionary table) there are additional requirements:
 
    * The name of the foreign key column should end with ``_id`` (e.g.


### PR DESCRIPTION
For enabling layer edition spatial table should contains only one geometry column. Add a note to the documentation to advertize this current limitation.

Y.
