### PR TITLE
Missing closing div in apihelp.html

### DIFF
--- a/c2cgeoportal/scaffolds/create/+package+/templates/api/apihelp.html_tmpl
+++ b/c2cgeoportal/scaffolds/create/+package+/templates/api/apihelp.html_tmpl
@@ -140,6 +140,7 @@ map.addMarker({
     miniMapExpanded: true,
     showCoords: true
 });</script>
+</div>
 
 <div class="api">
     <h2>Recenter the map to given coordinates</h2>


### PR DESCRIPTION
I think that there is a `</div>` missing here, which should close:

``` html
<div class="api">
    <h2>A map with some additional controls</h2>
    <div id='map5' class="map"></div>
    <script type="text/javascript">var map = new {{package}}.Map({
    div: 'map5',
    zoom: 8,
    center: [544500, 210100],
    layers: ['mo4_pfp_3'],
    addLayerSwitcher: true,
    layerSwitcherExpanded: true,
    addMiniMap: true,
    miniMapExpanded: true,
    showCoords: true
});</script>
```
