### PR TITLE
Because we have removed tileforge we should get the branch 1.3.

### DIFF
--- a/doc/integrator/create_application.rst
+++ b/doc/integrator/create_application.rst
@@ -69,6 +69,13 @@ from GitHub::
     cd c2cgeoportal
     git submodule update --init
 
+.. note::
+
+   To install c2cgeoportal version ``1.3`` and previous you should get the
+   branch ``1.3``::
+
+        git checkout 1.3
+
 Now run the ``bootstrap.py`` script to boostrap the Buildout environment::
 
     python bootstrap.py --version 1.5.2 --distribute --download-base \


### PR DESCRIPTION
To create new project.
