### PR TITLE
Default mobile theme

### DIFF
--- a/c2cgeoportal/scaffolds/create/config.yaml.in_tmpl
+++ b/c2cgeoportal/scaffolds/create/config.yaml.in_tmpl
@@ -68,6 +68,13 @@ functionalities:
 external_themes_url:
 external_mapserv_url:
 
+# The name of the theme to use as the default theme for the
+# mobile app. The default theme is the theme loaded when no
+# theme name is specified in the mobile app URL. If unset
+# then there's no default theme, and no theme information
+# will be passed to the config.js template.
+mobile_default_theme:
+
 # The "raster web services" configuration. See the "raster"
 # chapter in the integrator documentation.
 raster:

--- a/c2cgeoportal/scaffolds/create/config_child.yaml.in_tmpl
+++ b/c2cgeoportal/scaffolds/create/config_child.yaml.in_tmpl
@@ -68,6 +68,13 @@ functionalities:
 external_themes_url: http://${vars:host}/${vars:parent_instanceid}/wsgi/themes
 external_mapserv_url: http://${vars:host}/${vars:parent_instanceid}/mapserv
 
+# The name of the theme to use as the default theme for the
+# mobile app. The default theme is the theme loaded when no
+# theme name is specified in the mobile app URL. If unset
+# then there's no default theme, and no theme information
+# will be passed to the config.js template.
+mobile_default_theme:
+
 # The "raster web services" configuration. See the "raster"
 # chapter in the integrator documentation.
 raster:

--- a/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -34,6 +34,26 @@ Version 1.4
    * When the new configuration is done you can remove the ``tilecache``
      folder.
 
+2. One can now define a "default mobile theme" in the config.yaml configuration
+   file. The default theme is the theme loaded when no theme is specified in
+   the query string of the mobile app URL (/mobile). For example:
+
+       mobile_default_theme: my_main_mobile_theme
+
+   Not setting the mobile_default_theme in config.yaml is perfectly valid. In
+   that case there's no "default mobile theme", and no theme information will
+   be passed to the config.js template.
+
+   Even if you don't need a "default mobile theme" it is recommended to set
+   mobile_default_theme to "None" in config.yaml, with an appropriate text
+   describing the role of this setting. For example:
+
+       # The name of the theme to use as the default theme for the
+       # mobile app. The default theme is the theme loaded when no
+       # theme name is specified in the mobile app URL. If unset
+       # then there's no default theme, and no theme information
+       # will be passed to the config.js template.
+       mobile_default_theme:
 
 Version 1.3
 ===========

--- a/c2cgeoportal/tests/functional/test_entry.py
+++ b/c2cgeoportal/tests/functional/test_entry.py
@@ -272,6 +272,14 @@ class TestEntryView(TestCase):
         self.assertEqual(info,
                 '{"username": "", "publicLayersOnly": true}')
 
+    def test_mobileconfig_no_auth_default_theme(self):
+        entry = self._create_entry_obj()
+        entry.request.registry.settings['mobile_default_theme'] = u'__test_theme'
+        response = self._call_with_wms_mocked(entry.mobileconfig)
+
+        layers = response['layers'].split(',')
+        self.assertEqual(len(layers), 2)
+
     def test_mobileconfig_auth_theme(self):
         entry = self._create_entry_obj(
             params={'theme': u'__test_theme'}, username=u'__test_user1')

--- a/c2cgeoportal/views/entry.py
+++ b/c2cgeoportal/views/entry.py
@@ -566,7 +566,8 @@ class Entry(object):
         layer_info = []
         public_only = True
 
-        theme_name = self.request.params.get('theme')
+        theme_name = self.request.params.get(
+            'theme', self.settings.get('mobile_default_theme'))
         user = self.request.user
 
         if theme_name:


### PR DESCRIPTION
For the mobile app to be loaded for a specific theme the theme name must be specified with a query parameter in the URL (e.g. `/mobile?theme=water`). There's no such thing as a _default mobile theme_. If no theme name is specified in the query string then theme/layers information is passed to the `config.js` Mako template - `layers` and `visible_layers` are empty. This is good because it enables the integrator to define its layers manually, in the `config.js` file, without relying on the database. But we also need a _default mobile theme_, which will be loaded if no theme is specified in the query string. This Issue suggests adding a `default_mobile_theme` option to config.yaml. And if not set the behavior should be the same as today's.

See also https://github.com/camptocamp/sitn_c2cgeoportal/issues/103.
