### PR TITLE
Mobile - Layer order is wrong

### DIFF
--- a/c2cgeoportal/tests/functional/test_entry.py
+++ b/c2cgeoportal/tests/functional/test_entry.py
@@ -258,9 +258,9 @@ class TestEntryView(TestCase):
         layers = response['layers'].split(',')
         self.assertEqual(len(layers), 2)
         layer = layers[0]
-        self.assertEqual(layer, u'__test_public_layer')
-        layer = layers[1]
         self.assertEqual(layer, u'__test_layer_in_group')
+        layer = layers[1]
+        self.assertEqual(layer, u'__test_public_layer')
 
         visible_layers = response['visible_layers']
         self.assertEqual(visible_layers, '__test_layer_in_group')
@@ -277,15 +277,15 @@ class TestEntryView(TestCase):
         layers = response['layers'].split(',')
         self.assertEqual(len(layers), 3)
         layer = layers[0]
-        self.assertEqual(layer, u'__test_private_layer')
+        self.assertEqual(layer, u'__test_layer_in_group')
         layer = layers[1]
         self.assertEqual(layer, u'__test_public_layer')
         layer = layers[2]
-        self.assertEqual(layer, u'__test_layer_in_group')
+        self.assertEqual(layer, u'__test_private_layer')
 
         visible_layers = response['visible_layers']
         self.assertEqual(visible_layers,
-            '__test_private_layer,__test_layer_in_group')
+            '__test_layer_in_group,__test_private_layer')
 
         info = response['info']
         self.assertEqual(info,

--- a/c2cgeoportal/views/entry.py
+++ b/c2cgeoportal/views/entry.py
@@ -591,12 +591,12 @@ class Entry(object):
 
         # comma-separated string including the names of layers of the
         # requested theme
-        layers = ','.join([li['name'] for li in layer_info])
+        layers = ','.join(reversed([li['name'] for li in layer_info]))
 
         # comma-separated string including the names of layers that
         # should visible by default in the map
         visible_layers = filter(lambda li: li['isChecked'] is True, layer_info)
-        visible_layers = ','.join(li['name'] for li in visible_layers)
+        visible_layers = ','.join(reversed([li['name'] for li in visible_layers]))
 
         # comma-separated string including the feature types supported
         # by WFS service


### PR DESCRIPTION
The layer order in mobile app is not the same as in desktop app... : 

Desktop : 
http://preprod.cartoriviera.ch

Mobile : 
http://preprod.cartoriviera.ch/preprod/wsgi/mobile/

In both app, go to theme "Infrastructures", zoom in, and you will see that layer "Assainissement - chambres" is on top of layer "Assainissement - collecteurs" in desktop app (that's right), but it is the opposite in mobile app (that's wrong)... 

Thanks
