### PR TITLE
Remove users from the example layers in the default mobile application

### DIFF
--- a/c2cgeoportal/scaffolds/create/+package+/static/mobile/config.js
+++ b/c2cgeoportal/scaffolds/create/+package+/static/mobile/config.js
@@ -11,7 +11,6 @@ OpenLayers.Lang.en = {
     "summits": "Summits",
     "huts": "Huts",
     "sites": "Sites",
-    "users": "Users",
 
     // base layer switcher picker (you shouldn't remove this)
     'layer_switcher.cancel': 'Cancel',
@@ -35,7 +34,6 @@ OpenLayers.Lang.fr = {
     "summits": "Sommets",
     "huts": "Cabanes",
     "sites": "Sites",
-    "users": "Utilisateurs",
 
     // base layer switcher picker (you shouldn't remove this)
     'layer_switcher.cancel': 'Annuler',
@@ -59,7 +57,6 @@ OpenLayers.Lang.de = {
     "summits": "Gipfel",
     "huts": "Hütten",
     "sites": "Sehenswürdigkeiten",
-    "users": "Benutzer",
 
     // base layer switcher picker (you shouldn't remove this)
     'layer_switcher.cancel': 'Abbrechen',
@@ -134,7 +131,7 @@ App.map = new OpenLayers.Map({
                 transparent: true
             },
             {
-                allLayers: ['summits', "huts", "sites", "users"],
+                allLayers: ['summits', "huts", "sites"],
                 singleTile: true,
                 ratio: 1
             }


### PR DESCRIPTION
I know that's public data from camptocamp.org but I would prefer that real person data are not used in that kind of demo.
