### PR TITLE
Allow users to tap on layers label as well

### DIFF
--- a/c2cgeoportal/scaffolds/update/+package+/static/mobile/app/view/Layers.js
+++ b/c2cgeoportal/scaffolds/update/+package+/static/mobile/app/view/Layers.js
@@ -54,7 +54,7 @@ Ext.define("App.view.Layers", {
                     i, l;
                 for (i=0; i<len; i++) {
                     l = allLayers[i];
-                    this.add({
+                    var checkbox = this.add({
                         label: OpenLayers.i18n(l),
                         name: l,
                         checked: layersParam.indexOf(l) != -1,
@@ -63,7 +63,14 @@ Ext.define("App.view.Layers", {
                             uncheck: this.overlayCheckChange,
                             scope: this
                         }
-                    }).setRecord(record);
+                    });
+                    checkbox.on({
+                        element: 'label',
+                        tap: Ext.bind(function(checkbox) {
+                            checkbox.setChecked(!checkbox.isChecked());
+                        }, null, [checkbox])
+                    });
+                    checkbox.setRecord(record);
                 }
             }
         }, this);


### PR DESCRIPTION
As reported by @gnerred:

```
J'ai fait tester l'application mobile avec les thèmes et la sécurité aux vrais utilisateurs de terrain. Maintenant que nous avons un bon nombre de couches dans certains thèmes, il devient difficile avec une tablette en mode paysage (cas fréquent dans le terrain) de savoir à quelle couche correspond la case à cocher dans la liste des layers (cf. copie d'écran). Y aurait-il un moyen simple colorier une ligne sur deux avec un gris plus foncé ? Cela résoudrait le problème.
```

Please review.
