### PR TITLE
Longpress on mobile not working

### DIFF
--- a/c2cgeoportal/scaffolds/create/+package+/static/mobile/config.js
+++ b/c2cgeoportal/scaffolds/create/+package+/static/mobile/config.js
@@ -87,6 +87,7 @@ App.info = '${info | n}';
 
 // define the map and layers
 App.map = new OpenLayers.Map({
+    fallThrough: true, // required for longpress queries
     theme: null,
     projection: 'EPSG:900913',
     controls: [

--- a/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -37,6 +37,20 @@ Version 1.3.1
                 </script>
         % endif
 
+3. The default value for `fallThrough` changed in OpenLayers. This has caused
+   a major regression in the mobile app, where longpress queries no longer
+   work.
+
+   To fix it edit {{package}}/static/mobile/config.js and add `fallThrough: true`
+   to the map config, before `theme: null` for example:
+
+
+        App.map = new OpenLayers.Map({
+            fallThrough: true, // required for longpress queries
+            theme: null,
+            ...
+        });
+
 
 Version 1.3
 ===========


### PR DESCRIPTION
We have a major regression in the mobile app. Longpress is broken. This was reported by @kalbermattenm for the sitn_c2cgeoportal project. See https://github.com/camptocamp/sitn_c2cgeoportal/issues/168 for more details.
