### PR TITLE
mobile_default_theme cannot be "None" in config.yaml

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -208,15 +208,15 @@ Version 1.3.1
    be passed to the config.js template.
 
    Even if you don't need a "default mobile theme" it is recommended to set
-   mobile_default_theme to "None" in config.yaml, with an appropriate text
+   mobile_default_theme to ``null`` in config.yaml, with an appropriate text
    describing the role of this setting. For example:
 
        # The name of the theme to use as the default theme for the
        # mobile app. The default theme is the theme loaded when no
        # theme name is specified in the mobile app URL. If unset
-       # then there's no default theme, and no theme information
-       # will be passed to the config.js template.
-       mobile_default_theme:
+       # or null then there's no default theme, and no theme
+       # information will be passed to the config.js template.
+       mobile_default_theme: null
 
 2. To make the `X-UA-Compatible` work again in the
    `<project>/template/index.html` file the following block should be moved


### PR DESCRIPTION
The doc says that mobile_default_theme can be set None, while this does not seem to work.

Reported by @kalbermattenm in https://github.com/camptocamp/sitn_c2cgeoportal/pull/164.
