### PR TITLE
[mobile] allow using substitution variables in layer attributes

### DIFF
--- a/c2cgeoportal/scaffolds/update/+package+/static/mobile/app/model/Query.js
+++ b/c2cgeoportal/scaffolds/update/+package+/static/mobile/app/model/Query.js
@@ -18,7 +18,7 @@ Ext.define('App.model.Query', {
                                 OpenLayers.i18n(k),
                                 '</th>',
                                 '<td>',
-                                attributes[k],
+                                OpenLayers.String.format(attributes[k], App),
                                 '</td>',
                                 '</tr>'
                             ]);


### PR DESCRIPTION
This change allows using expressions like `${mySpecificServiceUrl}` in the values of layer attributes. `${}` will be substituted at field convert time.
