### PR TITLE
Admin interface: only display a subset of layer data in the layer grid

### DIFF
--- a/c2cgeoportal/forms.py
+++ b/c2cgeoportal/forms.py
@@ -473,6 +473,14 @@ User.configure(include=fieldOrder)
 
 # LayerGrid
 LayerGrid = Grid(models.Layer)
+fieldOrder = [Layer.name,
+              Layer.public,
+              Layer.isVisible,
+              Layer.isChecked,
+              Layer.icon,
+              Layer.legend,
+              Layer.identifierAttributeField]
+LayerGrid.configure(include=fieldOrder)
 
 # LayerGroupGrid
 LayerGroupGrid = Grid(models.LayerGroup)


### PR DESCRIPTION
As for now, the layergrid in the admin interface shows all layer attributes, most of them being empty, making the page quite confusing.

Displaying only a subset of significant attributes would help clarify the interface. The current pull request is based upon a change suggested by @tczaka 
