### PR TITLE
Use 127.0.0.1 for mapserver Allow statement

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_buildout.cfg_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_buildout.cfg_tmpl
@@ -61,8 +61,8 @@ db = override_me
 schema = webapp
 # database parent schema
 parent_schema =
-# mapserver apache allows for clients (ex: Allow from camptocamp.com)
-mapserv_allow = Allow from localhost
+# apache/mapserver.conf "Allow" statement
+mapserv_allow = Allow from 127.0.0.1
 # mapserver connexion string
 mapserver_connection = user=${vars:dbuser} password=${vars:dbpassword} dbname=${vars:db} host=${vars:dbhost}
 # mapserver join tables


### PR DESCRIPTION
localhost may map to an IPv6 on some system, so disambiguate this by using 127.0.0.1 instead of localhost. I intially wanted to use "Allow from 127.0.0.1 ::1" but it does not work on Windows, as reported by @kalbermattenm in https://github.com/camptocamp/sitn_c2cgeoportal/pull/258#issuecomment-17800578.
