### PR TITLE
[mobile] map may have a default center and zoom

### DIFF
--- a/c2cgeoportal/scaffolds/update/+package+/static/mobile/app/view/Main.js
+++ b/c2cgeoportal/scaffolds/update/+package+/static/mobile/app/view/Main.js
@@ -144,7 +144,7 @@ Ext.define("App.view.Main", {
             zoom = this.getZoom();
         if (center && zoom) {
             map.setCenter(center, zoom);
-        } else {
+        } else if (!map.getCenter()) {
             map.zoomToMaxExtent();
         }
 


### PR DESCRIPTION
This commit allows the integrator to pass a center and a zoom to the map constructor. In that case the map will be centered on this position if there's no center and zoom values in the local storage.

Refs https://github.com/camptocamp/sitn_c2cgeoportal/issues/268.
