### PR TITLE
Make sure submodules submodules are upgraded as well when upgrading CGXP

### DIFF
--- a/doc/integrator/update_application.rst
+++ b/doc/integrator/update_application.rst
@@ -169,7 +169,7 @@ To update CGXP to a release tag (like 1.3.0) use the following::
     git fetch
     git checkout <tag>
     git submodule sync
-    git submodule update --init
+    git submodule update --init --recursive
 
 To update CGXP to a version branch (like 1.3) use the following::
 
@@ -178,7 +178,7 @@ To update CGXP to a version branch (like 1.3) use the following::
     git checkout <branch>
     git pull origin <branch>
     git submodule sync
-    git submodule update --init
+    git submodule update --init --recursive
 
 ``<package>`` is to be replaced by the name of your application package name,
 ``<tag>`` is the name of the release (in Git we use a tag),


### PR DESCRIPTION
As for now, when one upgrades CGXP using the procedure described in the doc here:
http://docs.camptocamp.net/c2cgeoportal/integrator/update_application.html#update-cgxp
only CGXP and its direct submodules are upgraded, not the submodules of the submodules.
Is there a reason for that?

This PR suggests to add a "--recursive" option to the submodules update.

By the way, would not

```
git pull
git submodule sync
git submodule update --init --recursive
```

be equivalent to

```
git pull
git submodule sync
git submodule update --init
git submodule foreach git submodule sync
git submodule foreach git submodule update --init
```

?
See http://docs.camptocamp.net/c2cgeoportal/integrator/update_application.html#update-the-application-code
