### PR TITLE
Use the new print file name

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -208,6 +208,13 @@ localHostForward:
 
        git add versions.cfg
 
+8. Add to git the new print file name:
+
+    mv print/print-servlet-2.0-SNAPSHOT-IMG-MAGICK.war print/print-servlet-2.0-SNAPSHOT-IMG-MAGICK.war.new
+    git mv print/print-servlet-1.2-SNAPSHOT.war print/print-servlet-2.0-SNAPSHOT-IMG-MAGICK.war
+    mv print/print-servlet-2.0-SNAPSHOT-IMG-MAGICK.war.new print/print-servlet-2.0-SNAPSHOT-IMG-MAGICK.war
+    git add print/print-servlet-2.0-SNAPSHOT-IMG-MAGICK.war
+
 
 Version 1.3.2
 =============

--- a/c2cgeoportal/scaffolds/update/CONST_buildout.cfg_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_buildout.cfg_tmpl
@@ -126,7 +126,7 @@ uninstall_cmds =
 [print-war]
 recipe = c2c.recipe.jarfile
 mode = update
-basewar = print-servlet-1.2-SNAPSHOT.war
+basewar = print-servlet-2.0-SNAPSHOT-IMG-MAGICK.war
 basedir = print/
 input = ${print-war:basewar}
     WEB-INF/classes/log4j.properties


### PR DESCRIPTION
In the merge 61605a9672d0a77bfc43f79c69f4bc028fa6a8be I updated the print to the new revision: 
https://github.com/mapfish/mapfish-print/commit/bdb3d3189f9375f2704d7d5162cf9b6e4cb9b69b

Than we should use the new file name
