### PR TITLE
Use the ext debug files for easier debugging.

### DIFF
--- a/c2cgeoportal/scaffolds/create/jsbuild/app.cfg_tmpl
+++ b/c2cgeoportal/scaffolds/create/jsbuild/app.cfg_tmpl
@@ -47,8 +47,8 @@ root =
     {{package}}/static/lib/cgxp/dygraphs
     {{package}}/static/js
 first =
-    Ext/adapter/ext/ext-base.js
-    Ext/ext-all.js
+    Ext/adapter/ext/ext-base-debug.js
+    Ext/ext-all-debug.js
     OpenLayers/SingleFile.js
     OpenLayers/Console.js
     OpenLayers/BaseTypes.js
@@ -135,8 +135,8 @@ root =
     {{package}}/static/lib/cgxp/ext.ux/base64
     {{package}}/static/js
 first =
-    Ext/adapter/ext/ext-base.js
-    Ext/ext-all.js
+    Ext/adapter/ext/ext-base-debug.js
+    Ext/ext-all-debug.js
     OpenLayers/SingleFile.js
     OpenLayers/Console.js
     OpenLayers/BaseTypes.js
@@ -453,8 +453,8 @@ root =
     {{package}}/static/lib/cgxp/ext.ux/base64
     {{package}}/static/js
 first =
-    Ext/adapter/ext/ext-base.js
-    Ext/ext-all.js
+    Ext/adapter/ext/ext-base-debug.js
+    Ext/ext-all-debug.js
     GeoExt/Lang.js
     OpenLayers/SingleFile.js
     OpenLayers/Console.js

--- a/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -224,6 +224,13 @@ localHostForward:
 
     -mobile_default_theme:
 
+10. In the `jsbuild/app.cfg` use the ext debug files (3x):
+
+    -    Ext/adapter/ext/ext-base.js
+    -    Ext/ext-all.js
+    +    Ext/adapter/ext/ext-base-debug.js
+    +    Ext/ext-all-debug.js
+
 
 Version 1.3.2
 =============


### PR DESCRIPTION
Tested on regiogis, before:

```
Writing to regiogis/static/build/edit.js (1291 KB)
Writing to regiogis/static/build/app.js (1699 KB)
Writing to regiogis/static/build/xapi.js (1422 KB)
```

After:

```
Writing to regiogis/static/build/edit.js (1402 KB)
Writing to regiogis/static/build/app.js (1810 KB)
Writing to regiogis/static/build/xapi.js (1534 KB)
```

Than we have about 111 kB extra, I think that reasonable.
