### PR TITLE
Use quiet mode in fix perm

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_buildout.cfg_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_buildout.cfg_tmpl
@@ -96,8 +96,8 @@ cmds =
     >>>    from subprocess import call, Popen, PIPE
     >>>    dirs = Popen(['find', '-type', 'd'], stdout=PIPE).communicate()[0]
     >>>    for d in [d for d in dirs.split('\n') if len(d) > 0]:
-    >>>        call(['chmod', 'g+s', d])
-    >>>    call(['chmod', '-R', 'g+rw', '.'])
+    >>>        call(['chmod', '--quiet', 'g+s', d])
+    >>>    call(['chmod', '--quiet', '-R', 'g+rw', '.'])
 
 [activate]
 recipe = evg.recipe.activate


### PR DESCRIPTION
If we try to change the permission of a file owned by some one else we
receive an error event if we set what's already present.
Then we use the quiet mode to don't log those errors.
