### PR TITLE
Fix encoding problem with icon path

### DIFF
--- a/c2cgeoportal/views/entry.py
+++ b/c2cgeoportal/views/entry.py
@@ -133,7 +133,7 @@ class Entry(object):
     def _getIconPath(self, icon):
         if not icon:
             return None  # pragma: no cover
-        icon = str(icon)
+        icon = unicode(icon)
         # test full URL
         if not icon[0:4] == 'http':
             try:


### PR DESCRIPTION
If the `legendImage` field of a layer (in the admin interface) contains some accentuated characters, the icon path building fails because of encoding problems. This PR makes sure the icon path actually uses Unicode. 
