### PR TITLE
Remove Cookie in MapServer request

### DIFF
--- a/c2cgeoportal/views/mapserverproxy.py
+++ b/c2cgeoportal/views/mapserverproxy.py
@@ -153,6 +153,9 @@ def proxy(request):
     h = dict(request.headers)
     if urlparse(_url).hostname != 'localhost':
         h.pop('Host')
+    # mapserver don't need the cookie, and sometimes it failed with it.
+    if 'Cookie' in h:
+        h.pop('Cookie')
     try:
         resp, content = http.request(_url, method=method,
                                      body=body, headers=h)


### PR DESCRIPTION
In EPFL we cant get the legend with some kind of long cookie ...
