### PR TITLE
Remove previous mobile config files before copying new version

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_buildout.cfg_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_buildout.cfg_tmpl
@@ -197,8 +197,14 @@ cmds =
     >>> from shutil import copy
     >>> dst_dir = os.path.join(src_dir, 'build', 'production')
     >>> src = os.path.join(src_dir, 'config.js')
+    >>> dst_file = os.path.join(dst_dir, 'config.js')
+    >>> if os.path.exists(dst_file):
+    >>>     os.remove(dst_file)
     >>> copy(src, dst_dir)
     >>> src = os.path.join(src_dir, 'openlayers-mobile.js')
+    >>> dst_file = os.path.join(dst_dir, 'openlayers-mobile.js')
+    >>> if os.path.exists(dst_file):
+    >>>     os.remove(dst_file)
     >>> copy(src, dst_dir)
 
 [cssbuild]


### PR DESCRIPTION
(because of permissions problems when several users run the buildout command)
