### PR TITLE
add support for encoding and file extension for csv export

### DIFF
--- a/c2cgeoportal/tests/test_exportcsv.py
+++ b/c2cgeoportal/tests/test_exportcsv.py
@@ -29,6 +29,7 @@
 
 
 from unittest import TestCase
+import codecs
 
 class TestExportCSVView(TestCase):
 
@@ -51,7 +52,7 @@ class TestExportCSVView(TestCase):
         self.assertEqual(type(responce), HTTPBadRequest)
 
         request.params = {
-            'csv': 'éà,èç'
+            'csv': u'éà,èç'
         }
         responce = echo(request)
-        self.assertEqual(responce.body, 'éà,èç')
+        self.assertEqual(responce.body, codecs.BOM_UTF8 + u'éà,èç'.encode('UTF-8'))


### PR DESCRIPTION
this pr solver the issue https://github.com/camptocamp/cgxp/issues/521

it implement the possibility to specify the encoding and the file extension for the csv export

utf8 and .csv have been tested ok with the following programs:
Excel 2007
Excel 2010
LibreOffice 4.0.4.2
LibreOffice 3.5.7.2

not ok with:
Excel 2002 (no utf8 support at all)
OpenOffice 3.3.0 (utf8 not recognized automatically, but can chose the encoding on start)

linked to https://github.com/camptocamp/cgxp/pull/556
