### PR TITLE
Remove mobile  build and archive dirs before rebuilding the mobile part

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_buildout.cfg_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_buildout.cfg_tmpl
@@ -188,8 +188,15 @@ compass_cmd = compass
 sencha_cmd = sencha
 cmds =
     >>> import os
+    >>> import shutil
     >>> from subprocess import Popen
     >>> src_dir = os.path.join(buildout.get('directory', '.'), '{{package}}', 'static', 'mobile')
+    >>> build_dir = os.path.join(src_dir, 'build')
+    >>> if os.path.exists(build_dir):
+    >>>     shutil.rmtree(build_dir)
+    >>> archive_dir = os.path.join(src_dir, 'archive')
+    >>> if os.path.exists(archive_dir):
+    >>>     shutil.rmtree(archive_dir)
     >>> Popen([buildout.get('mobile').get('compass_cmd'), 'compile', 'resources/sass'], cwd=src_dir).wait()
     >>> env = os.environ.copy()
     >>> env['_JAVA_OPTIONS'] = '-Xmx128m'


### PR DESCRIPTION
This PR replaces #677 
It makes sure that `mobile/archive` and `mobile/build` directories are removed before regenerating their contents, in order to prevent permission problems when several users run the buildout command on the same instance.
