### PR TITLE
Disable filtering for tiles_url

### DIFF
--- a/c2cgeoportal/scaffolds/create/+package+/templates/viewer.js_tmpl
+++ b/c2cgeoportal/scaffolds/create/+package+/templates/viewer.js_tmpl
@@ -36,7 +36,7 @@ Ext.onReady(function() {
     var EVENTS = new Ext.util.Observable();
 
     var WMTS_OPTIONS = {
-        url: ${tiles_url},
+        url: ${tiles_url | n},
         displayInLayerSwitcher: false,
         requestEncoding: 'REST',
         buffer: 0,


### PR DESCRIPTION
The default `tiles_url` parameter in `config.yaml.in` is set to:

```
tiles_url:
- http://a.tiles.${vars:host}/${vars:instanceid}/tiles
- http://b.tiles.${vars:host}/${vars:instanceid}/tiles
- http://c.tiles.${vars:host}/${vars:instanceid}/tiles
- http://d.tiles.${vars:host}/${vars:instanceid}/tiles
```

In the `viewer.js``template, with simply

```
var WMTS_OPTIONS = {
        url: ${tiles_url},
```

we get a syntax error because `tiles_url` is rendered as an "escaped" string instead of an array.
