### PR TITLE
Add missing root for DynamicMeasure OL addin

### DIFF
--- a/c2cgeoportal/scaffolds/create/jsbuild/app.cfg_tmpl
+++ b/c2cgeoportal/scaffolds/create/jsbuild/app.cfg_tmpl
@@ -29,6 +29,7 @@ root =
     {{package}}/static/lib/cgxp/openlayers.addins/GoogleEarthView/lib
     {{package}}/static/lib/cgxp/openlayers.addins/Spherical/lib
     {{package}}/static/lib/cgxp/openlayers.addins/URLCompressed/lib
+    {{package}}/static/lib/cgxp/openlayers.addins/DynamicMeasure/lib
     {{package}}/static/lib/cgxp/gxp/src/script
     {{package}}/static/lib/cgxp/proj4js
     {{package}}/static/lib/cgxp/geoext.ux/ux/Measure/lib
@@ -119,6 +120,7 @@ root =
     {{package}}/static/lib/cgxp/openlayers.addins/GoogleEarthView/lib
     {{package}}/static/lib/cgxp/openlayers.addins/Spherical/lib
     {{package}}/static/lib/cgxp/openlayers.addins/URLCompressed/lib
+    {{package}}/static/lib/cgxp/openlayers.addins/DynamicMeasure/lib
     {{package}}/static/lib/cgxp/gxp/src/script
     {{package}}/static/lib/cgxp/proj4js
     {{package}}/static/lib/cgxp/geoext.ux/ux/Measure/lib
@@ -185,6 +187,7 @@ root =
     {{package}}/static/lib/cgxp/openlayers.addins/GoogleEarthView/lib
     {{package}}/static/lib/cgxp/openlayers.addins/Spherical/lib
     {{package}}/static/lib/cgxp/openlayers.addins/URLCompressed/lib
+    {{package}}/static/lib/cgxp/openlayers.addins/DynamicMeasure/lib
     {{package}}/static/lib/cgxp/gxp/src/script
     {{package}}/static/lib/cgxp/proj4js
     {{package}}/static/lib/cgxp/geoext.ux/ux/Measure/lib
@@ -219,6 +222,7 @@ root =
     {{package}}/static/lib/cgxp/openlayers.addins/GoogleEarthView/lib
     {{package}}/static/lib/cgxp/openlayers.addins/Spherical/lib
     {{package}}/static/lib/cgxp/openlayers.addins/URLCompressed/lib
+    {{package}}/static/lib/cgxp/openlayers.addins/DynamicMeasure/lib
     {{package}}/static/lib/cgxp/gxp/src/script
     {{package}}/static/lib/cgxp/proj4js
     {{package}}/static/lib/cgxp/geoext.ux/ux/Measure/lib
@@ -258,6 +262,7 @@ root =
     {{package}}/static/lib/cgxp/openlayers.addins/GoogleEarthView/lib
     {{package}}/static/lib/cgxp/openlayers.addins/Spherical/lib
     {{package}}/static/lib/cgxp/openlayers.addins/URLCompressed/lib
+    {{package}}/static/lib/cgxp/openlayers.addins/DynamicMeasure/lib
     {{package}}/static/lib/cgxp/gxp/src/script
     {{package}}/static/lib/cgxp/proj4js
     {{package}}/static/lib/cgxp/geoext.ux/ux/Measure/lib
@@ -297,6 +302,7 @@ root =
     {{package}}/static/lib/cgxp/openlayers.addins/GoogleEarthView/lib
     {{package}}/static/lib/cgxp/openlayers.addins/Spherical/lib
     {{package}}/static/lib/cgxp/openlayers.addins/URLCompressed/lib
+    {{package}}/static/lib/cgxp/openlayers.addins/DynamicMeasure/lib
     {{package}}/static/lib/cgxp/gxp/src/script
     {{package}}/static/lib/cgxp/proj4js
     {{package}}/static/lib/cgxp/geoext.ux/ux/Measure/lib
@@ -348,6 +354,7 @@ root =
     {{package}}/static/lib/cgxp/openlayers.addins/GoogleEarthView/lib
     {{package}}/static/lib/cgxp/openlayers.addins/Spherical/lib
     {{package}}/static/lib/cgxp/openlayers.addins/URLCompressed/lib
+    {{package}}/static/lib/cgxp/openlayers.addins/DynamicMeasure/lib
     {{package}}/static/lib/cgxp/gxp/src/script
     {{package}}/static/lib/cgxp/proj4js
     {{package}}/static/lib/cgxp/geoext.ux/ux/Measure/lib
@@ -378,6 +385,7 @@ root =
     {{package}}/static/lib/cgxp/openlayers.addins/GoogleEarthView/lib
     {{package}}/static/lib/cgxp/openlayers.addins/Spherical/lib
     {{package}}/static/lib/cgxp/openlayers.addins/URLCompressed/lib
+    {{package}}/static/lib/cgxp/openlayers.addins/DynamicMeasure/lib
     {{package}}/static/lib/cgxp/gxp/src/script
     {{package}}/static/lib/cgxp/proj4js
     {{package}}/static/lib/cgxp/geoext.ux/ux/Measure/lib
@@ -408,6 +416,7 @@ root =
     {{package}}/static/lib/cgxp/openlayers.addins/GoogleEarthView/lib
     {{package}}/static/lib/cgxp/openlayers.addins/Spherical/lib
     {{package}}/static/lib/cgxp/openlayers.addins/URLCompressed/lib
+    {{package}}/static/lib/cgxp/openlayers.addins/DynamicMeasure/lib
     {{package}}/static/lib/cgxp/gxp/src/script
     {{package}}/static/lib/cgxp/proj4js
     {{package}}/static/lib/cgxp/geoext.ux/ux/Measure/lib
@@ -438,6 +447,7 @@ root =
     {{package}}/static/lib/cgxp/openlayers.addins/GoogleEarthView/lib
     {{package}}/static/lib/cgxp/openlayers.addins/Spherical/lib
     {{package}}/static/lib/cgxp/openlayers.addins/URLCompressed/lib
+    {{package}}/static/lib/cgxp/openlayers.addins/DynamicMeasure/lib
     {{package}}/static/lib/cgxp/gxp/src/script
     {{package}}/static/lib/cgxp/proj4js
     {{package}}/static/lib/cgxp/geoext.ux/ux/Measure/lib

--- a/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -301,6 +301,10 @@ localHostForward:
    +iconMaxWidth: 0
    +horizontalAlignment: left
 
+14. In jsbuild/app.cfg add the following line to the "root" sections:
+
+    {{package}}/static/lib/cgxp/openlayers.addins/DynamicMeasure/lib
+
 Version 1.3.2
 =============
 


### PR DESCRIPTION
A new OL addin (DynamicMeasure) is included in recent master revisions of CGXP:
https://github.com/camptocamp/cgxp/blob/master/sandbox/FeatureEditing/ux/widgets/FeatureEditingControler.js#L25
but its path is not available in jsbuild config.
