### PR TITLE
Mobile - tiles go on and off on some iOS devices

### DIFF
--- a/c2cgeoportal/scaffolds/update/+package+/static/mobile/resources/sass/app.scss
+++ b/c2cgeoportal/scaffolds/update/+package+/static/mobile/resources/sass/app.scss
@@ -86,7 +86,11 @@ table.detail td {
 div.olMap {
     z-index: 0;
 }
-
+// Avoid tiles flickering on webkit
+.olMapViewport * {
+    -webkit-transform: translate3d(0,0,0);
+    transform: translate3d(0,0,0);
+}
 .olControlScaleLine {
     display: block;
     left: 3px;


### PR DESCRIPTION
When doing a pan on some iOS devices (tested on last iPad mini), tiles go on and off, and it is not very nice for end user... Can be reproduced on http://map.cartoriviera.ch and http://sitn.ne.ch/prepub/wsgi/mobile/. Is it an OL issue ? Is there a workaround or a bug fix ? Thanks
