### PR TITLE
add i18n for loading message

### DIFF
--- a/c2cgeoportal/locale/c2cgeoportal.pot
+++ b/c2cgeoportal/locale/c2cgeoportal.pot
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: c2cgeoportal 1.4\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2013-05-13 14:15+0200\n"
+"POT-Creation-Date: 2013-10-23 13:29+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 0.9.6\n"
+"Generated-By: Babel 1.3\n"
 
 #: c2cgeoportal/forms.py:144
 msgid "Duplicate record"
@@ -37,213 +37,231 @@ msgstr ""
 msgid "Extent"
 msgstr ""
 
-#: c2cgeoportal/models.py:106
+#: c2cgeoportal/models.py:108
 msgid "functionality"
 msgstr ""
 
-#: c2cgeoportal/models.py:107
+#: c2cgeoportal/models.py:109
 msgid "functionalitys"
 msgstr ""
 
-#: c2cgeoportal/models.py:114 c2cgeoportal/models.py:232 c2cgeoportal/models.py:280
-#: c2cgeoportal/models.py:460 c2cgeoportal/models.py:500
+#: c2cgeoportal/models.py:116 c2cgeoportal/models.py:236 c2cgeoportal/models.py:284
+#: c2cgeoportal/models.py:467 c2cgeoportal/models.py:507
 msgid "Name"
 msgstr ""
 
-#: c2cgeoportal/models.py:115
+#: c2cgeoportal/models.py:117
 msgid "Value"
 msgstr ""
 
-#: c2cgeoportal/models.py:150
+#: c2cgeoportal/models.py:152
 msgid "user"
 msgstr ""
 
-#: c2cgeoportal/models.py:151
+#: c2cgeoportal/models.py:153
 msgid "users"
 msgstr ""
 
-#: c2cgeoportal/models.py:165 c2cgeoportal/templates/login.html:59
+#: c2cgeoportal/models.py:167 c2cgeoportal/templates/login.html:59
 msgid "Username"
 msgstr ""
 
-#: c2cgeoportal/models.py:168 c2cgeoportal/templates/login.html:62
+#: c2cgeoportal/models.py:170 c2cgeoportal/templates/login.html:62
 msgid "Password"
 msgstr ""
 
-#: c2cgeoportal/models.py:169
+#: c2cgeoportal/models.py:171
 msgid "E-mail"
 msgstr ""
 
-#: c2cgeoportal/models.py:224
+#: c2cgeoportal/models.py:172
+msgid "PasswordChanged"
+msgstr ""
+
+#: c2cgeoportal/models.py:228
 msgid "role"
 msgstr ""
 
-#: c2cgeoportal/models.py:225
+#: c2cgeoportal/models.py:229
 msgid "roles"
 msgstr ""
 
-#: c2cgeoportal/models.py:233 c2cgeoportal/models.py:461
+#: c2cgeoportal/models.py:237 c2cgeoportal/models.py:468
 msgid "Description"
 msgstr ""
 
-#: c2cgeoportal/models.py:281
+#: c2cgeoportal/models.py:285
 msgid "Order"
 msgstr ""
 
-#: c2cgeoportal/models.py:282
+#: c2cgeoportal/models.py:286
 msgid "Metadata URL"
 msgstr ""
 
-#: c2cgeoportal/models.py:326
+#: c2cgeoportal/models.py:330
 msgid "layergroup"
 msgstr ""
 
-#: c2cgeoportal/models.py:327
+#: c2cgeoportal/models.py:331
 msgid "layergroups"
 msgstr ""
 
-#: c2cgeoportal/models.py:337
+#: c2cgeoportal/models.py:341
 msgid "Expanded"
 msgstr ""
 
-#: c2cgeoportal/models.py:338
+#: c2cgeoportal/models.py:342
 msgid "Internal WMS"
 msgstr ""
 
-#: c2cgeoportal/models.py:340
+#: c2cgeoportal/models.py:344
 msgid "Group of base layers"
 msgstr ""
 
-#: c2cgeoportal/models.py:352
+#: c2cgeoportal/models.py:356
 msgid "theme"
 msgstr ""
 
-#: c2cgeoportal/models.py:353
+#: c2cgeoportal/models.py:357
 msgid "themes"
 msgstr ""
 
-#: c2cgeoportal/models.py:363 c2cgeoportal/models.py:388
+#: c2cgeoportal/models.py:367 c2cgeoportal/models.py:392
 msgid "Icon"
 msgstr ""
 
-#: c2cgeoportal/models.py:364
+#: c2cgeoportal/models.py:368
 msgid "Display"
 msgstr ""
 
-#: c2cgeoportal/models.py:373
+#: c2cgeoportal/models.py:377
 msgid "layer"
 msgstr ""
 
-#: c2cgeoportal/models.py:374
+#: c2cgeoportal/models.py:378
 msgid "layers"
 msgstr ""
 
-#: c2cgeoportal/models.py:385
+#: c2cgeoportal/models.py:389
 msgid "Public"
 msgstr ""
 
-#: c2cgeoportal/models.py:386
+#: c2cgeoportal/models.py:390
 msgid "Visible"
 msgstr ""
 
-#: c2cgeoportal/models.py:387
+#: c2cgeoportal/models.py:391
 msgid "Checked"
 msgstr ""
 
-#: c2cgeoportal/models.py:394
+#: c2cgeoportal/models.py:398
 msgid "Type"
 msgstr ""
 
-#: c2cgeoportal/models.py:395
+#: c2cgeoportal/models.py:399
 msgid "Base URL"
 msgstr ""
 
-#: c2cgeoportal/models.py:398
+#: c2cgeoportal/models.py:403
 msgid "Image type"
 msgstr ""
 
-#: c2cgeoportal/models.py:399
+#: c2cgeoportal/models.py:404
 msgid "Style"
 msgstr ""
 
-#: c2cgeoportal/models.py:400
+#: c2cgeoportal/models.py:405
 msgid "Dimensions"
 msgstr ""
 
-#: c2cgeoportal/models.py:401
+#: c2cgeoportal/models.py:406
 msgid "Matrix set"
 msgstr ""
 
-#: c2cgeoportal/models.py:402
+#: c2cgeoportal/models.py:407
 msgid "WMS server URL"
 msgstr ""
 
-#: c2cgeoportal/models.py:403
+#: c2cgeoportal/models.py:408
 msgid "WMS layers"
 msgstr ""
 
-#: c2cgeoportal/models.py:404
+#: c2cgeoportal/models.py:409
 msgid "Query layers"
 msgstr ""
 
-#: c2cgeoportal/models.py:405
+#: c2cgeoportal/models.py:410
 msgid "KML 3D"
 msgstr ""
 
-#: c2cgeoportal/models.py:406
+#: c2cgeoportal/models.py:411
 msgid "Single tile"
 msgstr ""
 
-#: c2cgeoportal/models.py:407
+#: c2cgeoportal/models.py:412
 msgid "Display legend"
 msgstr ""
 
-#: c2cgeoportal/models.py:408
+#: c2cgeoportal/models.py:413
 msgid "Legend image"
 msgstr ""
 
-#: c2cgeoportal/models.py:409
+#: c2cgeoportal/models.py:414
 msgid "Legend rule"
 msgstr ""
 
-#: c2cgeoportal/models.py:410
+#: c2cgeoportal/models.py:415
+msgid "Legend expanded"
+msgstr ""
+
+#: c2cgeoportal/models.py:416
 msgid "Min resolution"
 msgstr ""
 
-#: c2cgeoportal/models.py:411
+#: c2cgeoportal/models.py:417
 msgid "Max resolution"
 msgstr ""
 
-#: c2cgeoportal/models.py:412
+#: c2cgeoportal/models.py:418
 msgid "Disclaimer"
 msgstr ""
 
-#: c2cgeoportal/models.py:413
+#: c2cgeoportal/models.py:420
 msgid "Identifier attribute field"
 msgstr ""
 
-#: c2cgeoportal/models.py:414
+#: c2cgeoportal/models.py:421
 msgid "Related Postgres table"
 msgstr ""
 
-#: c2cgeoportal/models.py:450
+#: c2cgeoportal/models.py:457
 msgid "restrictionarea"
 msgstr ""
 
-#: c2cgeoportal/models.py:451
+#: c2cgeoportal/models.py:458
 msgid "restrictionareas"
 msgstr ""
 
-#: c2cgeoportal/models.py:462
+#: c2cgeoportal/models.py:469
 msgid "Read-write mode"
 msgstr ""
 
-#: c2cgeoportal/models.py:492
+#: c2cgeoportal/models.py:499
 msgid "parentrole"
 msgstr ""
 
-#: c2cgeoportal/models.py:493
+#: c2cgeoportal/models.py:500
 msgid "parentroles"
+msgstr ""
+
+#: c2cgeoportal/scaffolds/create/+package+/templates/edit.html_tmpl:60
+#: c2cgeoportal/scaffolds/create/+package+/templates/index.html_tmpl:71
+msgid "Loading message"
+msgstr ""
+
+#: c2cgeoportal/scaffolds/create/+package+/templates/edit.html_tmpl:74
+#: c2cgeoportal/scaffolds/create/+package+/templates/index.html_tmpl:90
+msgid "search tip message"
 msgstr ""
 
 #: c2cgeoportal/templates/login.html:6
@@ -258,11 +276,11 @@ msgstr ""
 msgid "my translation test"
 msgstr ""
 
-#: c2cgeoportal/views/entry.py:79
+#: c2cgeoportal/views/entry.py:81
 msgid "title i18n"
 msgstr ""
 
-#: c2cgeoportal/views/entry.py:119
+#: c2cgeoportal/views/entry.py:120
 msgid ""
 "WARNING! an error occured while trying to read the mapfile and recover the "
 "themes"

--- a/c2cgeoportal/locale/de/LC_MESSAGES/c2cgeoportal.po
+++ b/c2cgeoportal/locale/de/LC_MESSAGES/c2cgeoportal.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: c2cgeoportal 0.8\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2013-05-13 14:15+0200\n"
+"POT-Creation-Date: 2013-10-23 13:29+0200\n"
 "PO-Revision-Date: 2012-07-13 12:06+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: de <LL@li.org>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 0.9.6\n"
+"Generated-By: Babel 1.3\n"
 
 #: c2cgeoportal/forms.py:144
 msgid "Duplicate record"
@@ -24,7 +24,7 @@ msgstr "Datensatz duplizieren"
 
 #: c2cgeoportal/forms.py:175
 msgid "Passwords do not match"
-msgstr "Passworte stimmen nicht überein"
+msgstr "Passworte stimmen nicht überein."
 
 #: c2cgeoportal/forms.py:312
 msgid "Unlinked layers"
@@ -38,214 +38,232 @@ msgstr "geschützter Bereich"
 msgid "Extent"
 msgstr "Ausdehnung"
 
-#: c2cgeoportal/models.py:106
+#: c2cgeoportal/models.py:108
 msgid "functionality"
 msgstr "Funktionalität"
 
-#: c2cgeoportal/models.py:107
+#: c2cgeoportal/models.py:109
 msgid "functionalitys"
 msgstr "Funktionalitäten"
 
-#: c2cgeoportal/models.py:114 c2cgeoportal/models.py:232
-#: c2cgeoportal/models.py:280 c2cgeoportal/models.py:460
-#: c2cgeoportal/models.py:500
+#: c2cgeoportal/models.py:116 c2cgeoportal/models.py:236
+#: c2cgeoportal/models.py:284 c2cgeoportal/models.py:467
+#: c2cgeoportal/models.py:507
 msgid "Name"
 msgstr "Name"
 
-#: c2cgeoportal/models.py:115
+#: c2cgeoportal/models.py:117
 msgid "Value"
 msgstr "Wert"
 
-#: c2cgeoportal/models.py:150
+#: c2cgeoportal/models.py:152
 msgid "user"
 msgstr "Benutzer"
 
-#: c2cgeoportal/models.py:151
+#: c2cgeoportal/models.py:153
 msgid "users"
 msgstr "Benutzer"
 
-#: c2cgeoportal/models.py:165 c2cgeoportal/templates/login.html:59
+#: c2cgeoportal/models.py:167 c2cgeoportal/templates/login.html:59
 msgid "Username"
 msgstr "Benutzername"
 
-#: c2cgeoportal/models.py:168 c2cgeoportal/templates/login.html:62
+#: c2cgeoportal/models.py:170 c2cgeoportal/templates/login.html:62
 msgid "Password"
 msgstr "Passwort"
 
-#: c2cgeoportal/models.py:169
+#: c2cgeoportal/models.py:171
 msgid "E-mail"
 msgstr "E-Mail"
 
-#: c2cgeoportal/models.py:224
+#: c2cgeoportal/models.py:172
+msgid "PasswordChanged"
+msgstr "Passwort geändert"
+
+#: c2cgeoportal/models.py:228
 msgid "role"
 msgstr "Rolle"
 
-#: c2cgeoportal/models.py:225
+#: c2cgeoportal/models.py:229
 msgid "roles"
 msgstr "Rollen"
 
-#: c2cgeoportal/models.py:233 c2cgeoportal/models.py:461
+#: c2cgeoportal/models.py:237 c2cgeoportal/models.py:468
 msgid "Description"
 msgstr "Beschreibung"
 
-#: c2cgeoportal/models.py:281
+#: c2cgeoportal/models.py:285
 msgid "Order"
 msgstr "Reihenfolge"
 
-#: c2cgeoportal/models.py:282
+#: c2cgeoportal/models.py:286
 msgid "Metadata URL"
 msgstr "Metadaten-URL"
 
-#: c2cgeoportal/models.py:326
+#: c2cgeoportal/models.py:330
 msgid "layergroup"
 msgstr "Layer-Gruppe"
 
-#: c2cgeoportal/models.py:327
+#: c2cgeoportal/models.py:331
 msgid "layergroups"
 msgstr "Layer-Gruppen"
 
-#: c2cgeoportal/models.py:337
+#: c2cgeoportal/models.py:341
 msgid "Expanded"
 msgstr "Erweitert"
 
-#: c2cgeoportal/models.py:338
+#: c2cgeoportal/models.py:342
 msgid "Internal WMS"
 msgstr "Interner WMS"
 
-#: c2cgeoportal/models.py:340
+#: c2cgeoportal/models.py:344
 msgid "Group of base layers"
 msgstr "Gruppe von Basiskarten"
 
-#: c2cgeoportal/models.py:352
+#: c2cgeoportal/models.py:356
 msgid "theme"
 msgstr "Thema"
 
-#: c2cgeoportal/models.py:353
+#: c2cgeoportal/models.py:357
 msgid "themes"
 msgstr "Themen"
 
-#: c2cgeoportal/models.py:363 c2cgeoportal/models.py:388
+#: c2cgeoportal/models.py:367 c2cgeoportal/models.py:392
 msgid "Icon"
 msgstr "Symbol"
 
-#: c2cgeoportal/models.py:364
+#: c2cgeoportal/models.py:368
 msgid "Display"
 msgstr "Anzeige"
 
-#: c2cgeoportal/models.py:373
+#: c2cgeoportal/models.py:377
 msgid "layer"
 msgstr "Layer"
 
-#: c2cgeoportal/models.py:374
+#: c2cgeoportal/models.py:378
 msgid "layers"
 msgstr "Layer"
 
-#: c2cgeoportal/models.py:385
+#: c2cgeoportal/models.py:389
 msgid "Public"
 msgstr "Öffentlich"
 
-#: c2cgeoportal/models.py:386
+#: c2cgeoportal/models.py:390
 msgid "Visible"
 msgstr "Sichtbar"
 
-#: c2cgeoportal/models.py:387
+#: c2cgeoportal/models.py:391
 msgid "Checked"
 msgstr ""
 
-#: c2cgeoportal/models.py:394
+#: c2cgeoportal/models.py:398
 msgid "Type"
 msgstr "Typ"
 
-#: c2cgeoportal/models.py:395
+#: c2cgeoportal/models.py:399
 msgid "Base URL"
 msgstr "Basis-URL"
 
-#: c2cgeoportal/models.py:398
+#: c2cgeoportal/models.py:403
 msgid "Image type"
 msgstr "Bildtyp"
 
-#: c2cgeoportal/models.py:399
+#: c2cgeoportal/models.py:404
 msgid "Style"
 msgstr ""
 
-#: c2cgeoportal/models.py:400
+#: c2cgeoportal/models.py:405
 msgid "Dimensions"
 msgstr ""
 
-#: c2cgeoportal/models.py:401
+#: c2cgeoportal/models.py:406
 msgid "Matrix set"
 msgstr ""
 
-#: c2cgeoportal/models.py:402
+#: c2cgeoportal/models.py:407
 msgid "WMS server URL"
 msgstr ""
 
-#: c2cgeoportal/models.py:403
+#: c2cgeoportal/models.py:408
 msgid "WMS layers"
 msgstr "WMS Layer"
 
-#: c2cgeoportal/models.py:404
+#: c2cgeoportal/models.py:409
 msgid "Query layers"
 msgstr "Abfrage Layer"
 
-#: c2cgeoportal/models.py:405
+#: c2cgeoportal/models.py:410
 msgid "KML 3D"
 msgstr "KML 3D"
 
-#: c2cgeoportal/models.py:406
+#: c2cgeoportal/models.py:411
 msgid "Single tile"
 msgstr "Einzelkachel"
 
-#: c2cgeoportal/models.py:407
+#: c2cgeoportal/models.py:412
 msgid "Display legend"
 msgstr "Legende anzeigen"
 
-#: c2cgeoportal/models.py:408
+#: c2cgeoportal/models.py:413
 msgid "Legend image"
 msgstr "Legendenbild"
 
-#: c2cgeoportal/models.py:409
+#: c2cgeoportal/models.py:414
 msgid "Legend rule"
 msgstr "Legenden-Regel"
 
-#: c2cgeoportal/models.py:410
+#: c2cgeoportal/models.py:415
+msgid "Legend expanded"
+msgstr "Legende ausgeklappt"
+
+#: c2cgeoportal/models.py:416
 msgid "Min resolution"
 msgstr "Min. Auflösung"
 
-#: c2cgeoportal/models.py:411
+#: c2cgeoportal/models.py:417
 msgid "Max resolution"
 msgstr "Max. Auflösung"
 
-#: c2cgeoportal/models.py:412
+#: c2cgeoportal/models.py:418
 msgid "Disclaimer"
 msgstr ""
 
-#: c2cgeoportal/models.py:413
+#: c2cgeoportal/models.py:420
 msgid "Identifier attribute field"
 msgstr "Kennung Attributfeld (z.B. name)"
 
-#: c2cgeoportal/models.py:414
+#: c2cgeoportal/models.py:421
 msgid "Related Postgres table"
 msgstr ""
 
-#: c2cgeoportal/models.py:450
+#: c2cgeoportal/models.py:457
 msgid "restrictionarea"
 msgstr "Geschützter Bereich"
 
-#: c2cgeoportal/models.py:451
+#: c2cgeoportal/models.py:458
 msgid "restrictionareas"
 msgstr "Geschützte Bereiche"
 
-#: c2cgeoportal/models.py:462
+#: c2cgeoportal/models.py:469
 msgid "Read-write mode"
 msgstr ""
 
-#: c2cgeoportal/models.py:492
+#: c2cgeoportal/models.py:499
 msgid "parentrole"
 msgstr ""
 
-#: c2cgeoportal/models.py:493
+#: c2cgeoportal/models.py:500
 msgid "parentroles"
+msgstr ""
+
+#: c2cgeoportal/scaffolds/create/+package+/templates/edit.html_tmpl:60
+#: c2cgeoportal/scaffolds/create/+package+/templates/index.html_tmpl:71
+msgid "Loading message"
+msgstr "Laden..."
+
+#: c2cgeoportal/scaffolds/create/+package+/templates/edit.html_tmpl:74
+#: c2cgeoportal/scaffolds/create/+package+/templates/index.html_tmpl:90
+msgid "search tip message"
 msgstr ""
 
 #: c2cgeoportal/templates/login.html:6
@@ -260,12 +278,13 @@ msgstr ""
 msgid "my translation test"
 msgstr "meine Übersetzung test"
 
-#: c2cgeoportal/views/entry.py:79
+#: c2cgeoportal/views/entry.py:81
 msgid "title i18n"
 msgstr "Testen des i18n"
 
-#: c2cgeoportal/views/entry.py:119
+#: c2cgeoportal/views/entry.py:120
 msgid ""
 "WARNING! an error occured while trying to read the mapfile and recover "
 "the themes"
 msgstr ""
+

--- a/c2cgeoportal/locale/en/LC_MESSAGES/c2cgeoportal.po
+++ b/c2cgeoportal/locale/en/LC_MESSAGES/c2cgeoportal.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: c2cgeoportal 0.2\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2013-05-13 14:15+0200\n"
+"POT-Creation-Date: 2013-10-23 13:29+0200\n"
 "PO-Revision-Date: 2011-08-31 17:17+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 0.9.6\n"
+"Generated-By: Babel 1.3\n"
 
 #: c2cgeoportal/forms.py:144
 msgid "Duplicate record"
@@ -38,215 +38,233 @@ msgstr ""
 msgid "Extent"
 msgstr ""
 
-#: c2cgeoportal/models.py:106
+#: c2cgeoportal/models.py:108
 msgid "functionality"
 msgstr "Functionality"
 
-#: c2cgeoportal/models.py:107
+#: c2cgeoportal/models.py:109
 msgid "functionalitys"
 msgstr "Functionalities"
 
-#: c2cgeoportal/models.py:114 c2cgeoportal/models.py:232
-#: c2cgeoportal/models.py:280 c2cgeoportal/models.py:460
-#: c2cgeoportal/models.py:500
+#: c2cgeoportal/models.py:116 c2cgeoportal/models.py:236
+#: c2cgeoportal/models.py:284 c2cgeoportal/models.py:467
+#: c2cgeoportal/models.py:507
 msgid "Name"
 msgstr ""
 
-#: c2cgeoportal/models.py:115
+#: c2cgeoportal/models.py:117
 msgid "Value"
 msgstr ""
 
-#: c2cgeoportal/models.py:150
+#: c2cgeoportal/models.py:152
 msgid "user"
 msgstr "User"
 
-#: c2cgeoportal/models.py:151
+#: c2cgeoportal/models.py:153
 msgid "users"
 msgstr "Users"
 
-#: c2cgeoportal/models.py:165 c2cgeoportal/templates/login.html:59
+#: c2cgeoportal/models.py:167 c2cgeoportal/templates/login.html:59
 msgid "Username"
 msgstr "User name"
 
-#: c2cgeoportal/models.py:168 c2cgeoportal/templates/login.html:62
+#: c2cgeoportal/models.py:170 c2cgeoportal/templates/login.html:62
 msgid "Password"
 msgstr ""
 
-#: c2cgeoportal/models.py:169
+#: c2cgeoportal/models.py:171
 msgid "E-mail"
 msgstr ""
 
-#: c2cgeoportal/models.py:224
+#: c2cgeoportal/models.py:172
+msgid "PasswordChanged"
+msgstr ""
+
+#: c2cgeoportal/models.py:228
 msgid "role"
 msgstr "Role"
 
-#: c2cgeoportal/models.py:225
+#: c2cgeoportal/models.py:229
 msgid "roles"
 msgstr "Roles"
 
-#: c2cgeoportal/models.py:233 c2cgeoportal/models.py:461
+#: c2cgeoportal/models.py:237 c2cgeoportal/models.py:468
 msgid "Description"
 msgstr ""
 
-#: c2cgeoportal/models.py:281
+#: c2cgeoportal/models.py:285
 msgid "Order"
 msgstr ""
 
-#: c2cgeoportal/models.py:282
+#: c2cgeoportal/models.py:286
 msgid "Metadata URL"
 msgstr ""
 
-#: c2cgeoportal/models.py:326
+#: c2cgeoportal/models.py:330
 msgid "layergroup"
 msgstr "Layer Group"
 
-#: c2cgeoportal/models.py:327
+#: c2cgeoportal/models.py:331
 msgid "layergroups"
 msgstr "Layer Groups"
 
-#: c2cgeoportal/models.py:337
+#: c2cgeoportal/models.py:341
 msgid "Expanded"
 msgstr ""
 
-#: c2cgeoportal/models.py:338
+#: c2cgeoportal/models.py:342
 msgid "Internal WMS"
 msgstr ""
 
-#: c2cgeoportal/models.py:340
+#: c2cgeoportal/models.py:344
 msgid "Group of base layers"
 msgstr ""
 
-#: c2cgeoportal/models.py:352
+#: c2cgeoportal/models.py:356
 msgid "theme"
 msgstr "Theme"
 
-#: c2cgeoportal/models.py:353
+#: c2cgeoportal/models.py:357
 msgid "themes"
 msgstr "Themes"
 
-#: c2cgeoportal/models.py:363 c2cgeoportal/models.py:388
+#: c2cgeoportal/models.py:367 c2cgeoportal/models.py:392
 msgid "Icon"
 msgstr ""
 
-#: c2cgeoportal/models.py:364
+#: c2cgeoportal/models.py:368
 msgid "Display"
 msgstr ""
 
-#: c2cgeoportal/models.py:373
+#: c2cgeoportal/models.py:377
 msgid "layer"
 msgstr "Layer"
 
-#: c2cgeoportal/models.py:374
+#: c2cgeoportal/models.py:378
 msgid "layers"
 msgstr "Layers"
 
-#: c2cgeoportal/models.py:385
+#: c2cgeoportal/models.py:389
 msgid "Public"
 msgstr ""
 
-#: c2cgeoportal/models.py:386
+#: c2cgeoportal/models.py:390
 msgid "Visible"
 msgstr ""
 
-#: c2cgeoportal/models.py:387
+#: c2cgeoportal/models.py:391
 msgid "Checked"
 msgstr ""
 
-#: c2cgeoportal/models.py:394
+#: c2cgeoportal/models.py:398
 msgid "Type"
 msgstr ""
 
-#: c2cgeoportal/models.py:395
+#: c2cgeoportal/models.py:399
 msgid "Base URL"
 msgstr ""
 
-#: c2cgeoportal/models.py:398
+#: c2cgeoportal/models.py:403
 msgid "Image type"
 msgstr ""
 
-#: c2cgeoportal/models.py:399
+#: c2cgeoportal/models.py:404
 msgid "Style"
 msgstr ""
 
-#: c2cgeoportal/models.py:400
+#: c2cgeoportal/models.py:405
 msgid "Dimensions"
 msgstr ""
 
-#: c2cgeoportal/models.py:401
+#: c2cgeoportal/models.py:406
 msgid "Matrix set"
 msgstr ""
 
-#: c2cgeoportal/models.py:402
+#: c2cgeoportal/models.py:407
 msgid "WMS server URL"
 msgstr ""
 
-#: c2cgeoportal/models.py:403
+#: c2cgeoportal/models.py:408
 msgid "WMS layers"
 msgstr ""
 
-#: c2cgeoportal/models.py:404
+#: c2cgeoportal/models.py:409
 msgid "Query layers"
 msgstr ""
 
-#: c2cgeoportal/models.py:405
+#: c2cgeoportal/models.py:410
 msgid "KML 3D"
 msgstr ""
 
-#: c2cgeoportal/models.py:406
+#: c2cgeoportal/models.py:411
 msgid "Single tile"
 msgstr ""
 
-#: c2cgeoportal/models.py:407
+#: c2cgeoportal/models.py:412
 msgid "Display legend"
 msgstr ""
 
-#: c2cgeoportal/models.py:408
+#: c2cgeoportal/models.py:413
 msgid "Legend image"
 msgstr ""
 
-#: c2cgeoportal/models.py:409
+#: c2cgeoportal/models.py:414
 msgid "Legend rule"
 msgstr ""
 
-#: c2cgeoportal/models.py:410
+#: c2cgeoportal/models.py:415
+msgid "Legend expanded"
+msgstr ""
+
+#: c2cgeoportal/models.py:416
 msgid "Min resolution"
 msgstr ""
 
-#: c2cgeoportal/models.py:411
+#: c2cgeoportal/models.py:417
 msgid "Max resolution"
 msgstr ""
 
-#: c2cgeoportal/models.py:412
+#: c2cgeoportal/models.py:418
 msgid "Disclaimer"
 msgstr ""
 
-#: c2cgeoportal/models.py:413
+#: c2cgeoportal/models.py:420
 msgid "Identifier attribute field"
 msgstr ""
 
-#: c2cgeoportal/models.py:414
+#: c2cgeoportal/models.py:421
 msgid "Related Postgres table"
 msgstr ""
 
-#: c2cgeoportal/models.py:450
+#: c2cgeoportal/models.py:457
 msgid "restrictionarea"
 msgstr "Restriction Area"
 
-#: c2cgeoportal/models.py:451
+#: c2cgeoportal/models.py:458
 msgid "restrictionareas"
 msgstr "Restriction Areas"
 
-#: c2cgeoportal/models.py:462
+#: c2cgeoportal/models.py:469
 msgid "Read-write mode"
 msgstr ""
 
-#: c2cgeoportal/models.py:492
+#: c2cgeoportal/models.py:499
 msgid "parentrole"
 msgstr "Parent Role"
 
-#: c2cgeoportal/models.py:493
+#: c2cgeoportal/models.py:500
 msgid "parentroles"
 msgstr "Parent Roles"
+
+#: c2cgeoportal/scaffolds/create/+package+/templates/edit.html_tmpl:60
+#: c2cgeoportal/scaffolds/create/+package+/templates/index.html_tmpl:71
+msgid "Loading message"
+msgstr "Loading..."
+
+#: c2cgeoportal/scaffolds/create/+package+/templates/edit.html_tmpl:74
+#: c2cgeoportal/scaffolds/create/+package+/templates/index.html_tmpl:90
+msgid "search tip message"
+msgstr ""
 
 #: c2cgeoportal/templates/login.html:6
 msgid "Login to Geoportal Application"
@@ -260,11 +278,11 @@ msgstr ""
 msgid "my translation test"
 msgstr "my translation test"
 
-#: c2cgeoportal/views/entry.py:79
+#: c2cgeoportal/views/entry.py:81
 msgid "title i18n"
 msgstr "I18n test"
 
-#: c2cgeoportal/views/entry.py:119
+#: c2cgeoportal/views/entry.py:120
 msgid ""
 "WARNING! an error occured while trying to read the mapfile and recover "
 "the themes"

--- a/c2cgeoportal/locale/fr/LC_MESSAGES/c2cgeoportal.po
+++ b/c2cgeoportal/locale/fr/LC_MESSAGES/c2cgeoportal.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: c2cgeoportal 0.2\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2013-05-13 14:15+0200\n"
+"POT-Creation-Date: 2013-10-23 13:29+0200\n"
 "PO-Revision-Date: 2011-08-31 17:17+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: fr <LL@li.org>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 0.9.6\n"
+"Generated-By: Babel 1.3\n"
 
 #: c2cgeoportal/forms.py:144
 msgid "Duplicate record"
@@ -24,7 +24,7 @@ msgstr "Enregistrement dupliqué"
 
 #: c2cgeoportal/forms.py:175
 msgid "Passwords do not match"
-msgstr "Les mots de passe ne correspondent pas"
+msgstr "Les mots de passe ne correspondent pas."
 
 #: c2cgeoportal/forms.py:312
 msgid "Unlinked layers"
@@ -38,215 +38,233 @@ msgstr "Aire de restriction"
 msgid "Extent"
 msgstr "Emprise"
 
-#: c2cgeoportal/models.py:106
+#: c2cgeoportal/models.py:108
 msgid "functionality"
 msgstr "Fonctionalité"
 
-#: c2cgeoportal/models.py:107
+#: c2cgeoportal/models.py:109
 msgid "functionalitys"
 msgstr "Fonctionalités"
 
-#: c2cgeoportal/models.py:114 c2cgeoportal/models.py:232
-#: c2cgeoportal/models.py:280 c2cgeoportal/models.py:460
-#: c2cgeoportal/models.py:500
+#: c2cgeoportal/models.py:116 c2cgeoportal/models.py:236
+#: c2cgeoportal/models.py:284 c2cgeoportal/models.py:467
+#: c2cgeoportal/models.py:507
 msgid "Name"
 msgstr "Nom"
 
-#: c2cgeoportal/models.py:115
+#: c2cgeoportal/models.py:117
 msgid "Value"
 msgstr "Valeur"
 
-#: c2cgeoportal/models.py:150
+#: c2cgeoportal/models.py:152
 msgid "user"
 msgstr "Utilisateur"
 
-#: c2cgeoportal/models.py:151
+#: c2cgeoportal/models.py:153
 msgid "users"
 msgstr "Utilisateurs"
 
-#: c2cgeoportal/models.py:165 c2cgeoportal/templates/login.html:59
+#: c2cgeoportal/models.py:167 c2cgeoportal/templates/login.html:59
 msgid "Username"
 msgstr "Nom d'utilisateur"
 
-#: c2cgeoportal/models.py:168 c2cgeoportal/templates/login.html:62
+#: c2cgeoportal/models.py:170 c2cgeoportal/templates/login.html:62
 msgid "Password"
 msgstr "Mot de passe"
 
-#: c2cgeoportal/models.py:169
+#: c2cgeoportal/models.py:171
 msgid "E-mail"
 msgstr "E-mail"
 
-#: c2cgeoportal/models.py:224
+#: c2cgeoportal/models.py:172
+msgid "PasswordChanged"
+msgstr "Mot de passe modifié"
+
+#: c2cgeoportal/models.py:228
 msgid "role"
 msgstr "Rôle"
 
-#: c2cgeoportal/models.py:225
+#: c2cgeoportal/models.py:229
 msgid "roles"
 msgstr "Rôles"
 
-#: c2cgeoportal/models.py:233 c2cgeoportal/models.py:461
+#: c2cgeoportal/models.py:237 c2cgeoportal/models.py:468
 msgid "Description"
 msgstr "Description"
 
-#: c2cgeoportal/models.py:281
+#: c2cgeoportal/models.py:285
 msgid "Order"
 msgstr "Ordre"
 
-#: c2cgeoportal/models.py:282
+#: c2cgeoportal/models.py:286
 msgid "Metadata URL"
 msgstr "URL de métadonnée"
 
-#: c2cgeoportal/models.py:326
+#: c2cgeoportal/models.py:330
 msgid "layergroup"
 msgstr "Groupe de couches"
 
-#: c2cgeoportal/models.py:327
+#: c2cgeoportal/models.py:331
 msgid "layergroups"
 msgstr "Groupes de couches"
 
-#: c2cgeoportal/models.py:337
+#: c2cgeoportal/models.py:341
 msgid "Expanded"
 msgstr "Étendu"
 
-#: c2cgeoportal/models.py:338
+#: c2cgeoportal/models.py:342
 msgid "Internal WMS"
 msgstr "WMS interne"
 
-#: c2cgeoportal/models.py:340
+#: c2cgeoportal/models.py:344
 msgid "Group of base layers"
 msgstr "Groupe de couches de base"
 
-#: c2cgeoportal/models.py:352
+#: c2cgeoportal/models.py:356
 msgid "theme"
 msgstr "Thème"
 
-#: c2cgeoportal/models.py:353
+#: c2cgeoportal/models.py:357
 msgid "themes"
 msgstr "Thèmes"
 
-#: c2cgeoportal/models.py:363 c2cgeoportal/models.py:388
+#: c2cgeoportal/models.py:367 c2cgeoportal/models.py:392
 msgid "Icon"
 msgstr "Îcone"
 
-#: c2cgeoportal/models.py:364
+#: c2cgeoportal/models.py:368
 msgid "Display"
 msgstr "Afficher"
 
-#: c2cgeoportal/models.py:373
+#: c2cgeoportal/models.py:377
 msgid "layer"
 msgstr "Couche"
 
-#: c2cgeoportal/models.py:374
+#: c2cgeoportal/models.py:378
 msgid "layers"
 msgstr "Couches"
 
-#: c2cgeoportal/models.py:385
+#: c2cgeoportal/models.py:389
 msgid "Public"
 msgstr "Publique"
 
-#: c2cgeoportal/models.py:386
+#: c2cgeoportal/models.py:390
 msgid "Visible"
 msgstr "Visible"
 
-#: c2cgeoportal/models.py:387
+#: c2cgeoportal/models.py:391
 msgid "Checked"
 msgstr "Cochées"
 
-#: c2cgeoportal/models.py:394
+#: c2cgeoportal/models.py:398
 msgid "Type"
 msgstr "Type"
 
-#: c2cgeoportal/models.py:395
+#: c2cgeoportal/models.py:399
 msgid "Base URL"
 msgstr "URL de base"
 
-#: c2cgeoportal/models.py:398
+#: c2cgeoportal/models.py:403
 msgid "Image type"
 msgstr "Type d'image"
 
-#: c2cgeoportal/models.py:399
+#: c2cgeoportal/models.py:404
 msgid "Style"
 msgstr ""
 
-#: c2cgeoportal/models.py:400
+#: c2cgeoportal/models.py:405
 msgid "Dimensions"
 msgstr ""
 
-#: c2cgeoportal/models.py:401
+#: c2cgeoportal/models.py:406
 msgid "Matrix set"
 msgstr ""
 
-#: c2cgeoportal/models.py:402
+#: c2cgeoportal/models.py:407
 msgid "WMS server URL"
 msgstr "URL du serveur WMS"
 
-#: c2cgeoportal/models.py:403
+#: c2cgeoportal/models.py:408
 msgid "WMS layers"
 msgstr "Couches WMS"
 
-#: c2cgeoportal/models.py:404
+#: c2cgeoportal/models.py:409
 msgid "Query layers"
 msgstr "Couches à interroger"
 
-#: c2cgeoportal/models.py:405
+#: c2cgeoportal/models.py:410
 msgid "KML 3D"
 msgstr ""
 
-#: c2cgeoportal/models.py:406
+#: c2cgeoportal/models.py:411
 msgid "Single tile"
 msgstr "Tuile unique"
 
-#: c2cgeoportal/models.py:407
+#: c2cgeoportal/models.py:412
 msgid "Display legend"
 msgstr "Affiche la légende"
 
-#: c2cgeoportal/models.py:408
+#: c2cgeoportal/models.py:413
 msgid "Legend image"
 msgstr "Image de légende"
 
-#: c2cgeoportal/models.py:409
+#: c2cgeoportal/models.py:414
 msgid "Legend rule"
 msgstr ""
 
-#: c2cgeoportal/models.py:410
+#: c2cgeoportal/models.py:415
+msgid "Legend expanded"
+msgstr "Légende dépliée"
+
+#: c2cgeoportal/models.py:416
 msgid "Min resolution"
 msgstr "Résolution minimale"
 
-#: c2cgeoportal/models.py:411
+#: c2cgeoportal/models.py:417
 msgid "Max resolution"
 msgstr "Résolution maximale"
 
-#: c2cgeoportal/models.py:412
+#: c2cgeoportal/models.py:418
 msgid "Disclaimer"
 msgstr "Responsabilité"
 
-#: c2cgeoportal/models.py:413
+#: c2cgeoportal/models.py:420
 msgid "Identifier attribute field"
 msgstr "Nom du champ identifiant"
 
-#: c2cgeoportal/models.py:414
+#: c2cgeoportal/models.py:421
 msgid "Related Postgres table"
 msgstr "Table Postgres correspondante"
 
-#: c2cgeoportal/models.py:450
+#: c2cgeoportal/models.py:457
 msgid "restrictionarea"
 msgstr "Aire de restriction"
 
-#: c2cgeoportal/models.py:451
+#: c2cgeoportal/models.py:458
 msgid "restrictionareas"
 msgstr "Aires de restriction"
 
-#: c2cgeoportal/models.py:462
+#: c2cgeoportal/models.py:469
 msgid "Read-write mode"
 msgstr "Mode lecture écriture"
 
-#: c2cgeoportal/models.py:492
+#: c2cgeoportal/models.py:499
 msgid "parentrole"
 msgstr "Rôle parent"
 
-#: c2cgeoportal/models.py:493
+#: c2cgeoportal/models.py:500
 msgid "parentroles"
 msgstr "Rôles parent"
+
+#: c2cgeoportal/scaffolds/create/+package+/templates/edit.html_tmpl:60
+#: c2cgeoportal/scaffolds/create/+package+/templates/index.html_tmpl:71
+msgid "Loading message"
+msgstr "Chargement..."
+
+#: c2cgeoportal/scaffolds/create/+package+/templates/edit.html_tmpl:74
+#: c2cgeoportal/scaffolds/create/+package+/templates/index.html_tmpl:90
+msgid "search tip message"
+msgstr ""
 
 #: c2cgeoportal/templates/login.html:6
 msgid "Login to Geoportal Application"
@@ -260,11 +278,11 @@ msgstr "Connection"
 msgid "my translation test"
 msgstr "mon test de traduction"
 
-#: c2cgeoportal/views/entry.py:79
+#: c2cgeoportal/views/entry.py:81
 msgid "title i18n"
 msgstr "Test de l'i18n"
 
-#: c2cgeoportal/views/entry.py:119
+#: c2cgeoportal/views/entry.py:120
 msgid ""
 "WARNING! an error occured while trying to read the mapfile and recover "
 "the themes"

--- a/doc/integrator/internationalization.rst
+++ b/doc/integrator/internationalization.rst
@@ -65,7 +65,7 @@ Server
 
 #. Run buildout to compile all the .po files to .mo::
 
-    ./buildout/bin/buildout -c buildout_$USER.cfg
+    ./buildout/bin/buildout -c buildout_$USER.cfg install po2mo
 
 #. Finally don't forget to restart apache::
 

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,8 @@ setup(
     message_extractors={'c2cgeoportal': [
         ('static/**', 'ignore', None),
         ('**.py', 'python', None),
-        ('templates/**', 'mako', {'input_encoding': 'utf-8'})]},
+        ('templates/**', 'mako', {'input_encoding': 'utf-8'}),
+        ('scaffolds/create/+package+/templates/**', 'mako', {'input_encoding': 'utf-8'})]},
     zip_safe=False,
     install_requires=install_requires,
     setup_requires=setup_requires,


### PR DESCRIPTION
The message appearing when the application loads has no default translation. This PR fixes this.

By the way I have added by hand the msgid/msgstr in the .pot/.po files. Perhaps it would have been better to use xgettext and so on to regenerate the files but the doc is missing in the developper doc http://docs.camptocamp.net/c2cgeoportal/developer/index.html and I didn't wanted to spent to much time looking for the options to use (for instance how are we supposed to do to retrieve the strings to translate from the scaffold templates?).
