### PR TITLE
separated defaultThemes in two (new parameter defaultThemes) to be able ...

### DIFF
--- a/c2cgeoportal/scaffolds/create/+package+/templates/viewer.js_tmpl
+++ b/c2cgeoportal/scaffolds/create/+package+/templates/viewer.js_tmpl
@@ -133,10 +133,9 @@ Ext.onReady(function() {
                 autoScroll: true,
                 themes: THEMES,
                 % if permalink_themes:
-                  defaultThemes: ${permalink_themes | n},
-                % else:
-                  defaultThemes: ["lieu_interet_thm"],
+                    permalinkThemes: ${permalink_themes | n},
                 % endif
+                defaultThemes: ["to_be_defined"],
                 wmsURL: "${request.route_url('mapserverproxy', path='')}"
             },
             outputTarget: "layerpanel"

--- a/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -504,6 +504,24 @@ localHostForward:
 
 19. In the `{{project}}/templates/*.js` files remove the `getMatrix` method from the `WMTS_OPTIONS`.
 
+20. The LayerTree defaultThemes parameter has been separated in two to allow to handle separately 
+    the default theme and the themes loaded from url.
+
+    replace:
+
+    % if permalink_themes:
+      defaultThemes: ${permalink_themes | n},
+    % else:
+      defaultThemes: ["lieu_interet_thm"],
+    % endif
+
+    by:
+
+    % if permalink_themes:
+        permalinkThemes: ${permalink_themes | n},
+    % endif
+    defaultThemes: ["to_be_defined"],
+
 
 Version 1.3.2
 =============


### PR DESCRIPTION
...to differenciate the action when loading themes/layers from an url generated by the permalink plugin

related to https://github.com/camptocamp/cgxp/issues/549 and https://github.com/camptocamp/cgxp/pull/591
