### PR TITLE
Missing to load app/model/Theme.js

### DIFF
--- a/c2cgeoportal/scaffolds/update/+package+/static/mobile/app.js
+++ b/c2cgeoportal/scaffolds/update/+package+/static/mobile/app.js
@@ -18,7 +18,7 @@ Ext.application({
     ],
 
     views: ['Main', 'Layers', 'Themes', 'Search', 'Query', 'Settings', 'LoginForm'],
-    models: ['Layer', 'Search', 'Query'],
+    models: ['Layer', 'Search', 'Query', 'Theme'],
     controllers: ['Main', 'Search', 'Query'],
 
     icon: {


### PR DESCRIPTION
I just try to update the demo application and the 'app/model/Theme.js' file exists but he isn't load:
http://mapfish-geoportal.demo-camptocamp.com/sbrunner-demo/wsgi/mobile_dev/#home

Then I have the error : 
`Uncaught Error: [ERROR][Ext.data.Store#setModel] Model with name "App.model.Theme" does not exist.`
