### PR TITLE
Fixes geolocation and measure tools

### DIFF
--- a/c2cgeoportal/scaffolds/update/+package+/static/mobile/resources/sass/app.scss
+++ b/c2cgeoportal/scaffolds/update/+package+/static/mobile/resources/sass/app.scss
@@ -115,7 +115,7 @@ div.olMap {
     z-index: 0;
 }
 // Avoid tiles flickering on webkit
-.olMapViewport * {
+.olBackBuffer, .olBackBuffer *, .olLayerGrid, .olLayerGrid * {
     -webkit-transform: translate3d(0,0,0);
     transform: translate3d(0,0,0);
 }


### PR DESCRIPTION
Using a more accurate selector for the `translate3d` rule, just targeting tiles & backbuffers, not vector.

Hope this is the good fix…
