### PR TITLE
Fix the slider thumb drag on IE10

### DIFF
--- a/c2cgeoportal/scaffolds/create/jsbuild/app.cfg_tmpl
+++ b/c2cgeoportal/scaffolds/create/jsbuild/app.cfg_tmpl
@@ -71,7 +71,6 @@ include =
     EPSG{{srid}}.js #proj4js
     util.js #GXP
     widgets/Viewer.js #GXP
-    DragTracker.js #ext.overrides
     CGXP/cgxp.js
     CGXP/plugins/ThemeSelector.js
     CGXP/plugins/LayerTree.js
@@ -138,6 +137,8 @@ root =
     {{package}}/static/lib/cgxp/ext.ux/GroupComboBox
     {{package}}/static/lib/cgxp/ext.ux/ColorPicker
     {{package}}/static/lib/cgxp/ext.ux/base64
+    {{package}}/static/lib/cgxp/ext.overrides
+    {{package}}/static/lib/cgxp/dygraphs
     {{package}}/static/js
 first =
     Ext/adapter/ext/ext-base-debug.js
@@ -192,6 +193,7 @@ root =
     {{package}}/static/lib/cgxp/openlayers.addins/GoogleEarthView/lib
     {{package}}/static/lib/cgxp/openlayers.addins/Spherical/lib
     {{package}}/static/lib/cgxp/openlayers.addins/URLCompressed/lib
+    {{package}}/static/lib/cgxp/openlayers.addins/DynamicMeasure/lib
     {{package}}/static/lib/cgxp/openlayers.addins/AddViaPoint/lib
     {{package}}/static/lib/cgxp/gxp/src/script
     {{package}}/static/lib/cgxp/proj4js
@@ -207,6 +209,8 @@ root =
     {{package}}/static/lib/cgxp/ext.ux/GroupComboBox
     {{package}}/static/lib/cgxp/ext.ux/ColorPicker
     {{package}}/static/lib/cgxp/ext.ux/base64
+    {{package}}/static/lib/cgxp/ext.overrides
+    {{package}}/static/lib/cgxp/dygraphs
     {{package}}/static/js
 first =
     Ext/adapter/ext/ext-base-debug.js
@@ -275,6 +279,8 @@ root =
     {{package}}/static/lib/cgxp/ext.ux/GroupComboBox
     {{package}}/static/lib/cgxp/ext.ux/ColorPicker
     {{package}}/static/lib/cgxp/ext.ux/base64
+    {{package}}/static/lib/cgxp/ext.overrides
+    {{package}}/static/lib/cgxp/dygraphs
     {{package}}/static/js
 first =
     OpenLayers/Lang/en.js
@@ -311,6 +317,8 @@ root =
     {{package}}/static/lib/cgxp/ext.ux/GroupComboBox
     {{package}}/static/lib/cgxp/ext.ux/ColorPicker
     {{package}}/static/lib/cgxp/ext.ux/base64
+    {{package}}/static/lib/cgxp/ext.overrides
+    {{package}}/static/lib/cgxp/dygraphs
     {{package}}/static/js
 first =
     OpenLayers/Lang/fr.js
@@ -352,6 +360,8 @@ root =
     {{package}}/static/lib/cgxp/ext.ux/GroupComboBox
     {{package}}/static/lib/cgxp/ext.ux/ColorPicker
     {{package}}/static/lib/cgxp/ext.ux/base64
+    {{package}}/static/lib/cgxp/ext.overrides
+    {{package}}/static/lib/cgxp/dygraphs
     {{package}}/static/js
 first =
     OpenLayers/Lang/de.js
@@ -390,8 +400,11 @@ root =
     {{package}}/static/lib/cgxp/sandbox
     {{package}}/static/lib/cgxp/styler/lib
     {{package}}/static/lib/cgxp/ext.ux/TwinTriggerComboBox
+    {{package}}/static/lib/cgxp/ext.ux/GroupComboBox
     {{package}}/static/lib/cgxp/ext.ux/ColorPicker
     {{package}}/static/lib/cgxp/ext.ux/base64
+    {{package}}/static/lib/cgxp/ext.overrides
+    {{package}}/static/lib/cgxp/dygraphs
     {{package}}/static/js
 first =
     OpenLayers/SingleFile.js
@@ -443,8 +456,11 @@ root =
     {{package}}/static/lib/cgxp/sandbox
     {{package}}/static/lib/cgxp/styler/lib
     {{package}}/static/lib/cgxp/ext.ux/TwinTriggerComboBox
+    {{package}}/static/lib/cgxp/ext.ux/GroupComboBox
     {{package}}/static/lib/cgxp/ext.ux/ColorPicker
     {{package}}/static/lib/cgxp/ext.ux/base64
+    {{package}}/static/lib/cgxp/ext.overrides
+    {{package}}/static/lib/cgxp/dygraphs
     {{package}}/static/js
 first =
     OpenLayers/Lang/en.js
@@ -475,8 +491,11 @@ root =
     {{package}}/static/lib/cgxp/sandbox
     {{package}}/static/lib/cgxp/styler/lib
     {{package}}/static/lib/cgxp/ext.ux/TwinTriggerComboBox
+    {{package}}/static/lib/cgxp/ext.ux/GroupComboBox
     {{package}}/static/lib/cgxp/ext.ux/ColorPicker
     {{package}}/static/lib/cgxp/ext.ux/base64
+    {{package}}/static/lib/cgxp/ext.overrides
+    {{package}}/static/lib/cgxp/dygraphs
     {{package}}/static/js
 first =
     OpenLayers/Lang/fr.js
@@ -507,8 +526,11 @@ root =
     {{package}}/static/lib/cgxp/sandbox
     {{package}}/static/lib/cgxp/styler/lib
     {{package}}/static/lib/cgxp/ext.ux/TwinTriggerComboBox
+    {{package}}/static/lib/cgxp/ext.ux/GroupComboBox
     {{package}}/static/lib/cgxp/ext.ux/ColorPicker
     {{package}}/static/lib/cgxp/ext.ux/base64
+    {{package}}/static/lib/cgxp/ext.overrides
+    {{package}}/static/lib/cgxp/dygraphs
     {{package}}/static/js
 first =
     OpenLayers/Lang/de.js
@@ -539,8 +561,11 @@ root =
     {{package}}/static/lib/cgxp/sandbox
     {{package}}/static/lib/cgxp/styler/lib
     {{package}}/static/lib/cgxp/ext.ux/TwinTriggerComboBox
+    {{package}}/static/lib/cgxp/ext.ux/GroupComboBox
     {{package}}/static/lib/cgxp/ext.ux/ColorPicker
     {{package}}/static/lib/cgxp/ext.ux/base64
+    {{package}}/static/lib/cgxp/ext.overrides
+    {{package}}/static/lib/cgxp/dygraphs
     {{package}}/static/js
 first =
     Ext/adapter/ext/ext-base-debug.js

--- a/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -505,7 +505,7 @@ localHostForward:
 
 19. In the `{{package}}/templates/*.js` files remove the `getMatrix` method from the `WMTS_OPTIONS`.
 
-20. The LayerTree defaultThemes parameter has been separated in two to allow to handle separately 
+20. The LayerTree defaultThemes parameter has been separated in two to allow to handle separately
     the default theme and the themes loaded from url.
 
     In ``viewer.js`` replace:
@@ -535,8 +535,8 @@ localHostForward:
 
 23. Adaptations for generic backend usage necessitate the following change.
 
-    In the ``jsbuild/app.cfg`` file, add ``CGXP/cgxp.js`` in ``[app.js]``, 
-    ``[edit.js]``, ``[routing.js]`` and ``[xapi.js]`` in the ``include =`` block, 
+    In the ``jsbuild/app.cfg`` file, add ``CGXP/cgxp.js`` in ``[app.js]``,
+    ``[edit.js]``, ``[routing.js]`` and ``[xapi.js]`` in the ``include =`` block,
     before any other CGXP/* entries.
 
     for example:
@@ -624,7 +624,41 @@ localHostForward:
     not currently taken into account due to a limitation in the OWSLib, see:
     https://github.com/geopython/OWSLib/pull/92
 
-30. If the FullTextSearch has a configuration in the ``config.yaml.in`` file,
+30. In the `jsbuild/app.cfg` file set all the `root` sections to:
+
+    {{package}}/static/lib/cgxp/core/src/script
+    {{package}}/static/lib/cgxp/ext
+    {{package}}/static/lib/cgxp/geoext/lib
+    {{package}}/static/lib/cgxp/openlayers/lib
+    {{package}}/static/lib/cgxp/openlayers.addins/GoogleEarthView/lib
+    {{package}}/static/lib/cgxp/openlayers.addins/Spherical/lib
+    {{package}}/static/lib/cgxp/openlayers.addins/URLCompressed/lib
+    {{package}}/static/lib/cgxp/openlayers.addins/DynamicMeasure/lib
+    {{package}}/static/lib/cgxp/openlayers.addins/AddViaPoint/lib
+    {{package}}/static/lib/cgxp/gxp/src/script
+    {{package}}/static/lib/cgxp/proj4js
+    {{package}}/static/lib/cgxp/geoext.ux/ux/Measure/lib
+    {{package}}/static/lib/cgxp/geoext.ux/ux/SimplePrint/lib
+    {{package}}/static/lib/cgxp/geoext.ux/ux/FeatureEditing/lib
+    {{package}}/static/lib/cgxp/geoext.ux/ux/FeatureSelectionModel/lib
+    {{package}}/static/lib/cgxp/geoext.ux/ux/WMSBrowser/lib
+    {{package}}/static/lib/cgxp/geoext.ux/ux/StreetViewPanel
+    {{package}}/static/lib/cgxp/sandbox
+    {{package}}/static/lib/cgxp/styler/lib
+    {{package}}/static/lib/cgxp/ext.ux/TwinTriggerComboBox
+    {{package}}/static/lib/cgxp/ext.ux/GroupComboBox
+    {{package}}/static/lib/cgxp/ext.ux/ColorPicker
+    {{package}}/static/lib/cgxp/ext.ux/base64
+    {{package}}/static/lib/cgxp/ext.overrides
+    {{package}}/static/lib/cgxp/dygraphs
+    {{package}}/static/js
+
+31. In the `jsbuild/app.cfg` file remove from the `include` section
+    of `[app.js]` the line:
+
+    DragTracker.js #ext.overrides
+
+32. If the FullTextSearch has a configuration in the ``config.yaml.in`` file,
     do the following changes::
 
     - fulltextsearch_maxlimit: 200


### PR DESCRIPTION
By removing DragTracker.js from ext.overrides that's a patch for IE9
needed in an older version id Ext JS.

By the way standardize all the root section in the jsbuild/app.cfg.
