### PR TITLE
Repo gone public

### DIFF
--- a/doc/integrator/create_application.rst
+++ b/doc/integrator/create_application.rst
@@ -65,7 +65,7 @@ do not have the required permissions. Please contact Camptocamp in that case.
 To install ``c2cgeoportal`` you first need to clone the c2cgeoportal repository
 from GitHub::
 
-    git clone git@github.com:camptocamp/c2cgeoportal.git
+    git clone https://github.com/camptocamp/c2cgeoportal.git
     cd c2cgeoportal
 
 Then you should checkout the branch or tag of the version you want to install::


### PR DESCRIPTION
As `c2cgeoportal` is now a public GitHub repo, we should use direct cloning instead of secured GitHub cloning (thus use `https://github.com/myrepo` instead of `github@github.com/myrepo`).

This PR aims to correct that in docs.
