### PR TITLE
Add missing js include

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -147,6 +147,7 @@ Version 1.4
             CGXP/plugins/Routing.js
             CGXP/data/OSRM.js
             CGXP/widgets/MapPanel.js
+            CGXP/tools/tools.js
             OpenLayers/Control/Navigation.js
             OpenLayers/Control/KeyboardDefaults.js
             OpenLayers/Control/PanZoomBar.js


### PR DESCRIPTION
This PR adds `CGXP/tools/tools.js` to the routing build.

If `myproject/templates/routing.js` receives a `serverError` through mako, then js goes through the `if (serverError.length > 0)` condition and raises an Ext window by using `cgxp.tools.openWindow()`, but currently this function is not included in the `routing.js` build.
