### PR TITLE
Check first that user exists

### DIFF
--- a/c2cgeoportal/__init__.py
+++ b/c2cgeoportal/__init__.py
@@ -95,6 +95,15 @@ def get_user_from_request(request):
     from sqlalchemy.orm import joinedload
     username = unauthenticated_userid(request)
     if username is not None:
+
+        # all users using the geoportal are not
+        # defined in the database
+        user_exists = DBSession.query(User) \
+            .filter_by(username=username) \
+            .first()
+        if user_exists is None:
+            return None
+
         # we know we'll need to role object for the
         # user so we use earger loading
         return DBSession.query(User) \


### PR DESCRIPTION
At SITN, we will soon be using the "remote user" policy (see <a href="http://docs.camptocamp.net/c2cgeoportal/integrator/authentication.html#example-with-a-remote-user-policy" target=_blank>`c2cgeoportal` doc</a>)

The problem with the current implemented solution is that all users have to exist in the `c2cgeoportal` database, otherwise the application throws an error 500, because of line https://github.com/camptocamp/c2cgeoportal/blob/master/c2cgeoportal/__init__.py#L103.

In SQLAlchemy:
- `one()`: Return exactly one result or raise an exception.

So  I would like to propose something to first check if a user exists in the DB, if yes continue to get his role, if no return `None` (thus unconnected user)

Moreover: is there a specific purpose to use `one()` and raise an error ? Or could we use `first()` (and return `None` instead of raising an error...)

The solution proposed in this PR actually checks first if the user exists, and then uses the already implemented join which uses `one`.

@elemoine, could I have your opinion on this ?
