### PR TITLE
Make blank layer appear in mobile baselayer selector

### DIFF
--- a/c2cgeoportal/scaffolds/create/+package+/static/mobile/config.js_tmpl
+++ b/c2cgeoportal/scaffolds/create/+package+/static/mobile/config.js_tmpl
@@ -80,6 +80,7 @@ App.map = new OpenLayers.Map({
         }, WMTS_OPTIONS),
         new OpenLayers.Layer(
             OpenLayers.i18n('blank'),{
+                isBaseLayer: true,
                 ref: 'blank'
             }
         )


### PR DESCRIPTION
Without `isBaseLayer: true` the blank baselayer is not visible in the baselayers combo.
