### PR TITLE
Return back to the old OWSLib version

### DIFF
--- a/c2cgeoportal/scaffolds/create/versions.cfg
+++ b/c2cgeoportal/scaffolds/create/versions.cfg
@@ -32,7 +32,7 @@ Markdown = 2.3.1
 markdown = 2.3.1
 MarkupSafe = 0.18
 markupsafe = 0.18
-OWSLib = 0.8.3
+OWSLib = 0.7.2
 Paste = 1.7.5.1
 PasteDeploy = 1.5.0
 PasteScript = 1.7.5
@@ -97,12 +97,3 @@ zope.deprecation = 4.0.2
 zope.event = 4.0.2
 zope.interface = 4.0.5
 zope.sqlalchemy = 0.7.2
-
-# for OWSlib
-PIL = 1.1.7
-cov-core = 1.7
-pytest-cov = 1.6
-python-dateutil = 2.1
-coverage = 3.7
-py = 1.4.19
-pytest = 2.5.1

--- a/doc/integrator/install_application.rst
+++ b/doc/integrator/install_application.rst
@@ -31,7 +31,7 @@ on your system:
 
 * Git (or whatever revision control (for example Subversion)
     is used for the application)
-* Python 2.7 (2.5 or 3.x are not supported, 2.6 can be supported but with limited functionalities)
+* Python 2.6, 2.7 (2.5 or 3.x are not supportedi)
 * Oracle Java SE Development Kit 6 or 7
 * Tomcat
 * Apache
@@ -267,14 +267,6 @@ Also, by default, the path to Tomcat's ``webapps`` directory is
 
     [print-war]
     output = /var/lib/tomcat6/webapps/print-c2cgeoportal-${vars:instanceid}.war
-
-By default we use ``OWSLib`` ``0.8.3`` which is not compatible with Python 2.6.
-``OWSLib`` ``0.7.2`` actually supports Python 2.6 but then it is not possible
-to get the WMS-time default value. To do so, add the following lines in the
-``buildout.cfg`` file::
-
-    [versions]
-    OWSLib = 0.7.2
 
 apache/mapserver.conf.in
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/integrator/wmstime.rst
+++ b/doc/integrator/wmstime.rst
@@ -102,3 +102,22 @@ Some of those limitations apply to the mapfile:
 There is also a limitation that applies to the admin interface: all the WMS Time
 layers of a group should be configured to use the same time mode (``single``,
 ``range`` or ``disabled``).
+
+Default values
+--------------
+
+If you need to get the default WMS-time values, you must make sure to use
+``OWSLib`` ``0.8.3`` and Python 2.7.
+
+To use the ``OWSLib`` ``0.8.3``, add the following lines in the
+``buildout.cfg`` file::
+
+    [versions]
+    OWSLib = 0.8.3
+    PIL = 1.1.7
+    cov-core = 1.7
+    pytest-cov = 1.6
+    python-dateutil = 2.1
+    coverage = 3.7
+    py = 1.4.19
+    pytest = 2.5.1


### PR DESCRIPTION
because we have too many issues with python 2.6
