### PR TITLE
Remove deprecated DUMP from mapfile

### DIFF
--- a/c2cgeoportal/scaffolds/create/mapserver/c2cgeoportal.map.in
+++ b/c2cgeoportal/scaffolds/create/mapserver/c2cgeoportal.map.in
@@ -114,7 +114,6 @@ MAP
 
             ${mapserver_layer_metadata} # For secured layers
         END
-        DUMP TRUE # For GetFeatureInfo
         STATUS ON
         PROJECTION
           "init=epsg:21781"


### PR DESCRIPTION
"Since 6.0, DUMP is not used anymore. LAYER METADATA is used instead."
http://mapserver.org/fr/mapfile/layer.html
