### PR TITLE
Add the ability to exclude properties to be shown in editing

### DIFF
--- a/c2cgeoportal/lib/dbreflection.py
+++ b/c2cgeoportal/lib/dbreflection.py
@@ -160,7 +160,7 @@ def get_table(tablename, schema=None, DBSession=None):
     return table
 
 
-def get_class(tablename, DBSession=None):
+def get_class(tablename, DBSession=None, exclude_properties=None):
     """
     Get the SQLAlchemy mapped class for "tablename". If no class exists
     for "tablename" one is created, and added to the cache. "tablename"
@@ -176,7 +176,7 @@ def get_class(tablename, DBSession=None):
     table = get_table(tablename, schema, DBSession)
 
     # create the mapped class
-    cls = _create_class(table)
+    cls = _create_class(table, exclude_properties)
 
     # add class to cache
     _class_cache[(schema, tablename)] = cls
@@ -184,12 +184,18 @@ def get_class(tablename, DBSession=None):
     return cls
 
 
-def _create_class(table):
+def _create_class(table, exclude_properties=None):
+
+    if isinstance(exclude_properties, basestring):
+        exclude_properties = [p.strip() for p in exclude_properties.split(',')]
 
     cls = type(
         str(table.name.capitalize()),
         (GeoInterface, Base),
-        dict(__table__=table)
+        dict(
+            __table__=table,
+            __mapper_args__={'exclude_properties': exclude_properties}
+        ),
     )
 
     for col in table.columns:

--- a/c2cgeoportal/locale/c2cgeoportal.pot
+++ b/c2cgeoportal/locale/c2cgeoportal.pot
@@ -1,14 +1,14 @@
 # Translations template for c2cgeoportal.
-# Copyright (C) 2013 ORGANIZATION
+# Copyright (C) 2014 ORGANIZATION
 # This file is distributed under the same license as the c2cgeoportal project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2013.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2014.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: c2cgeoportal 1.4\n"
+"Project-Id-Version: c2cgeoportal 1.5\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2013-11-15 15:18+0100\n"
+"POT-Creation-Date: 2014-01-29 13:25+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -46,7 +46,7 @@ msgid "functionalitys"
 msgstr ""
 
 #: c2cgeoportal/models.py:124 c2cgeoportal/models.py:244 c2cgeoportal/models.py:292
-#: c2cgeoportal/models.py:483 c2cgeoportal/models.py:523
+#: c2cgeoportal/models.py:484 c2cgeoportal/models.py:524
 msgid "Name"
 msgstr ""
 
@@ -86,7 +86,7 @@ msgstr ""
 msgid "roles"
 msgstr ""
 
-#: c2cgeoportal/models.py:245 c2cgeoportal/models.py:484
+#: c2cgeoportal/models.py:245 c2cgeoportal/models.py:485
 msgid "Description"
 msgstr ""
 
@@ -234,27 +234,31 @@ msgstr ""
 msgid "Related Postgres table"
 msgstr ""
 
-#: c2cgeoportal/models.py:437
+#: c2cgeoportal/models.py:432
+msgid "Attributes to exclude"
+msgstr ""
+
+#: c2cgeoportal/models.py:438
 msgid "Time mode"
 msgstr ""
 
-#: c2cgeoportal/models.py:473
+#: c2cgeoportal/models.py:474
 msgid "restrictionarea"
 msgstr ""
 
-#: c2cgeoportal/models.py:474
+#: c2cgeoportal/models.py:475
 msgid "restrictionareas"
 msgstr ""
 
-#: c2cgeoportal/models.py:485
+#: c2cgeoportal/models.py:486
 msgid "Read-write mode"
 msgstr ""
 
-#: c2cgeoportal/models.py:515
+#: c2cgeoportal/models.py:516
 msgid "parentrole"
 msgstr ""
 
-#: c2cgeoportal/models.py:516
+#: c2cgeoportal/models.py:517
 msgid "parentroles"
 msgstr ""
 
@@ -282,11 +286,11 @@ msgstr ""
 msgid "my translation test"
 msgstr ""
 
-#: c2cgeoportal/views/entry.py:83
+#: c2cgeoportal/views/entry.py:76
 msgid "title i18n"
 msgstr ""
 
-#: c2cgeoportal/views/entry.py:122
+#: c2cgeoportal/views/entry.py:115
 msgid ""
 "WARNING! an error occured while trying to read the mapfile and recover the "
 "themes"

--- a/c2cgeoportal/locale/de/LC_MESSAGES/c2cgeoportal.po
+++ b/c2cgeoportal/locale/de/LC_MESSAGES/c2cgeoportal.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: c2cgeoportal 0.8\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2013-11-15 15:18+0100\n"
+"POT-Creation-Date: 2014-01-29 13:25+0100\n"
 "PO-Revision-Date: 2012-07-13 12:06+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: de <LL@li.org>\n"
@@ -47,8 +47,8 @@ msgid "functionalitys"
 msgstr "Funktionalitäten"
 
 #: c2cgeoportal/models.py:124 c2cgeoportal/models.py:244
-#: c2cgeoportal/models.py:292 c2cgeoportal/models.py:483
-#: c2cgeoportal/models.py:523
+#: c2cgeoportal/models.py:292 c2cgeoportal/models.py:484
+#: c2cgeoportal/models.py:524
 msgid "Name"
 msgstr "Name"
 
@@ -88,7 +88,7 @@ msgstr "Rolle"
 msgid "roles"
 msgstr "Rollen"
 
-#: c2cgeoportal/models.py:245 c2cgeoportal/models.py:484
+#: c2cgeoportal/models.py:245 c2cgeoportal/models.py:485
 msgid "Description"
 msgstr "Beschreibung"
 
@@ -236,27 +236,31 @@ msgstr "Kennung Attributfeld (z.B. name)"
 msgid "Related Postgres table"
 msgstr ""
 
-#: c2cgeoportal/models.py:437
+#: c2cgeoportal/models.py:432
+msgid "Attributes to exclude"
+msgstr "Ausgeblendete Attribute"
+
+#: c2cgeoportal/models.py:438
 msgid "Time mode"
 msgstr ""
 
-#: c2cgeoportal/models.py:473
+#: c2cgeoportal/models.py:474
 msgid "restrictionarea"
 msgstr "Geschützter Bereich"
 
-#: c2cgeoportal/models.py:474
+#: c2cgeoportal/models.py:475
 msgid "restrictionareas"
 msgstr "Geschützte Bereiche"
 
-#: c2cgeoportal/models.py:485
+#: c2cgeoportal/models.py:486
 msgid "Read-write mode"
 msgstr ""
 
-#: c2cgeoportal/models.py:515
+#: c2cgeoportal/models.py:516
 msgid "parentrole"
 msgstr ""
 
-#: c2cgeoportal/models.py:516
+#: c2cgeoportal/models.py:517
 msgid "parentroles"
 msgstr ""
 
@@ -284,11 +288,11 @@ msgstr ""
 msgid "my translation test"
 msgstr "meine Übersetzung test"
 
-#: c2cgeoportal/views/entry.py:83
+#: c2cgeoportal/views/entry.py:76
 msgid "title i18n"
 msgstr "Testen des i18n"
 
-#: c2cgeoportal/views/entry.py:122
+#: c2cgeoportal/views/entry.py:115
 msgid ""
 "WARNING! an error occured while trying to read the mapfile and recover "
 "the themes"

--- a/c2cgeoportal/locale/en/LC_MESSAGES/c2cgeoportal.po
+++ b/c2cgeoportal/locale/en/LC_MESSAGES/c2cgeoportal.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: c2cgeoportal 0.2\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2013-11-15 15:18+0100\n"
+"POT-Creation-Date: 2014-01-29 13:25+0100\n"
 "PO-Revision-Date: 2011-08-31 17:17+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -47,8 +47,8 @@ msgid "functionalitys"
 msgstr "Functionalities"
 
 #: c2cgeoportal/models.py:124 c2cgeoportal/models.py:244
-#: c2cgeoportal/models.py:292 c2cgeoportal/models.py:483
-#: c2cgeoportal/models.py:523
+#: c2cgeoportal/models.py:292 c2cgeoportal/models.py:484
+#: c2cgeoportal/models.py:524
 msgid "Name"
 msgstr ""
 
@@ -88,7 +88,7 @@ msgstr "Role"
 msgid "roles"
 msgstr "Roles"
 
-#: c2cgeoportal/models.py:245 c2cgeoportal/models.py:484
+#: c2cgeoportal/models.py:245 c2cgeoportal/models.py:485
 msgid "Description"
 msgstr ""
 
@@ -236,27 +236,31 @@ msgstr ""
 msgid "Related Postgres table"
 msgstr ""
 
-#: c2cgeoportal/models.py:437
+#: c2cgeoportal/models.py:432
+msgid "Attributes to exclude"
+msgstr ""
+
+#: c2cgeoportal/models.py:438
 msgid "Time mode"
 msgstr ""
 
-#: c2cgeoportal/models.py:473
+#: c2cgeoportal/models.py:474
 msgid "restrictionarea"
 msgstr "Restriction Area"
 
-#: c2cgeoportal/models.py:474
+#: c2cgeoportal/models.py:475
 msgid "restrictionareas"
 msgstr "Restriction Areas"
 
-#: c2cgeoportal/models.py:485
+#: c2cgeoportal/models.py:486
 msgid "Read-write mode"
 msgstr ""
 
-#: c2cgeoportal/models.py:515
+#: c2cgeoportal/models.py:516
 msgid "parentrole"
 msgstr "Parent Role"
 
-#: c2cgeoportal/models.py:516
+#: c2cgeoportal/models.py:517
 msgid "parentroles"
 msgstr "Parent Roles"
 
@@ -284,11 +288,11 @@ msgstr ""
 msgid "my translation test"
 msgstr "my translation test"
 
-#: c2cgeoportal/views/entry.py:83
+#: c2cgeoportal/views/entry.py:76
 msgid "title i18n"
 msgstr "I18n test"
 
-#: c2cgeoportal/views/entry.py:122
+#: c2cgeoportal/views/entry.py:115
 msgid ""
 "WARNING! an error occured while trying to read the mapfile and recover "
 "the themes"

--- a/c2cgeoportal/locale/fr/LC_MESSAGES/c2cgeoportal.po
+++ b/c2cgeoportal/locale/fr/LC_MESSAGES/c2cgeoportal.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: c2cgeoportal 0.2\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2013-11-15 15:18+0100\n"
+"POT-Creation-Date: 2014-01-29 13:25+0100\n"
 "PO-Revision-Date: 2011-08-31 17:17+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: fr <LL@li.org>\n"
@@ -47,8 +47,8 @@ msgid "functionalitys"
 msgstr "Fonctionalités"
 
 #: c2cgeoportal/models.py:124 c2cgeoportal/models.py:244
-#: c2cgeoportal/models.py:292 c2cgeoportal/models.py:483
-#: c2cgeoportal/models.py:523
+#: c2cgeoportal/models.py:292 c2cgeoportal/models.py:484
+#: c2cgeoportal/models.py:524
 msgid "Name"
 msgstr "Nom"
 
@@ -88,7 +88,7 @@ msgstr "Rôle"
 msgid "roles"
 msgstr "Rôles"
 
-#: c2cgeoportal/models.py:245 c2cgeoportal/models.py:484
+#: c2cgeoportal/models.py:245 c2cgeoportal/models.py:485
 msgid "Description"
 msgstr "Description"
 
@@ -236,27 +236,31 @@ msgstr "Nom du champ identifiant"
 msgid "Related Postgres table"
 msgstr "Table Postgres correspondante"
 
-#: c2cgeoportal/models.py:437
+#: c2cgeoportal/models.py:432
+msgid "Attributes to exclude"
+msgstr "Attributs à exclure"
+
+#: c2cgeoportal/models.py:438
 msgid "Time mode"
 msgstr "Mode temps"
 
-#: c2cgeoportal/models.py:473
+#: c2cgeoportal/models.py:474
 msgid "restrictionarea"
 msgstr "Aire de restriction"
 
-#: c2cgeoportal/models.py:474
+#: c2cgeoportal/models.py:475
 msgid "restrictionareas"
 msgstr "Aires de restriction"
 
-#: c2cgeoportal/models.py:485
+#: c2cgeoportal/models.py:486
 msgid "Read-write mode"
 msgstr "Mode lecture écriture"
 
-#: c2cgeoportal/models.py:515
+#: c2cgeoportal/models.py:516
 msgid "parentrole"
 msgstr "Rôle parent"
 
-#: c2cgeoportal/models.py:516
+#: c2cgeoportal/models.py:517
 msgid "parentroles"
 msgstr "Rôles parent"
 
@@ -284,11 +288,11 @@ msgstr "Connexion"
 msgid "my translation test"
 msgstr "mon test de traduction"
 
-#: c2cgeoportal/views/entry.py:83
+#: c2cgeoportal/views/entry.py:76
 msgid "title i18n"
 msgstr "Test de l'i18n"
 
-#: c2cgeoportal/views/entry.py:122
+#: c2cgeoportal/views/entry.py:115
 msgid ""
 "WARNING! an error occured while trying to read the mapfile and recover "
 "the themes"
@@ -299,3 +303,4 @@ msgstr ""
 
 #~ msgid "Visible"
 #~ msgstr "Visible"
+

--- a/c2cgeoportal/models.py
+++ b/c2cgeoportal/models.py
@@ -429,6 +429,7 @@ class Layer(TreeItem):
     # data attribute field in which application can find a human identifiable name or number
     identifierAttributeField = Column(types.Unicode, label=_(u'Identifier attribute field'))
     geoTable = Column(types.Unicode, label=_(u'Related Postgres table'))
+    excludeProperties = Column(types.Unicode, label=_(u'Attributes to exclude'))
     timeMode = Column(types.Enum(
         "disabled",
         "single",

--- a/c2cgeoportal/scaffolds/update/+package+/CONST_migration/versions/017_Add_column_to_layers_table_to_manage_exclude_properties.py
+++ b/c2cgeoportal/scaffolds/update/+package+/CONST_migration/versions/017_Add_column_to_layers_table_to_manage_exclude_properties.py
@@ -1,0 +1,14 @@
+from sqlalchemy import MetaData, Table, Column, types
+
+from c2cgeoportal import schema
+
+
+def upgrade(migrate_engine):
+    meta = MetaData(bind=migrate_engine)
+    layer = Table('layer', meta, schema=schema, autoload=True)
+    Column('excludeProperties', types.Unicode).create(layer)
+
+def downgrade(migrate_engine):
+    meta = MetaData(bind=migrate_engine)
+    layer = Table('layer', meta, schema=schema, autoload=True)
+    layer.c.excludeProperties.drop()

--- a/c2cgeoportal/tests/functional/test_layers.py
+++ b/c2cgeoportal/tests/functional/test_layers.py
@@ -94,7 +94,8 @@ class TestLayers(TestCase):
 
         transaction.commit()
 
-    def _create_layer(self, public=False, none_area=False, attr_list=False):
+    def _create_layer(self, public=False, none_area=False, attr_list=False,
+                      exclude_properties=False):
         """ This function is central for this test class. It creates
         a layer with two features, and associates a restriction area
         to it. """
@@ -165,6 +166,10 @@ class TestLayers(TestCase):
         layer.id = id
         layer.geoTable = tablename
         layer.public = public
+
+        if exclude_properties:
+            layer.excludeProperties = 'name'
+
         DBSession.add(layer)
 
         if not public:
@@ -455,6 +460,15 @@ class TestLayers(TestCase):
         self.assertEquals(cls.__table__.name, 'table_%d' % layer_id)
         self.assertTrue(hasattr(cls, 'name'))
         self.assertTrue('child' in cls.__dict__)
+
+    def test_metadata_exclude_properties(self):
+        from c2cgeoportal.views.layers import metadata
+
+        layer_id = self._create_layer(exclude_properties=True)
+        request = self._get_request(layer_id, username=u'__test_user')
+
+        cls = metadata(request)
+        self.assertFalse(hasattr(cls, 'name'))
 
     ### With None area ###
     def test_read_public_none_area(self):

--- a/c2cgeoportal/views/layers.py
+++ b/c2cgeoportal/views/layers.py
@@ -312,7 +312,11 @@ def metadata(request):
     layer = _get_layer_for_request(request)
     if not layer.public and request.user is None:
         raise HTTPForbidden()
-    return get_class(str(layer.geoTable))
+    cls = get_class(
+        str(layer.geoTable),
+        exclude_properties=layer.excludeProperties
+    )
+    return cls
 
 
 @view_config(route_name='layers_enumerate_attribute_values', renderer='json')

--- a/doc/administrator/administrate.rst
+++ b/doc/administrator/administrate.rst
@@ -37,6 +37,9 @@ The layers in the admin interface has the following attributes:
     `FeaturesWindow <http://docs.camptocamp.net/cgxp/lib/plugins/FeaturesWindow.html>`_.
  *  ``Related Postgres table``: the related postgres table,
     used by the :ref:`administrator_editing`.
+ *  ``Attributes to exclude``: the list of attributes that shouldn't appear in
+    the :ref:`administrator_editing` so that they cannot be modified by end
+    user.
  *  ``Restrictions area``: the areas throw witch the user can see the layer.
  *  ``Parents``: the groups and theme in witch the layer is.
 


### PR DESCRIPTION
This can be used to prevent users from editing values from fields that are computed using triggers for example.
