### PR TITLE
Avoid calls to non existing files in the administration interface

### DIFF
--- a/c2cgeoportal/forms.py
+++ b/c2cgeoportal/forms.py
@@ -415,10 +415,7 @@ RestrictionArea.area.set(label=_(u'Restriction area'), options=[
     ('base_layer', 'new OpenLayers.Layer.OSM("OSM")'),
     ('zoom', formalchemy_default_zoom),
     ('default_lon', formalchemy_default_x),
-    ('default_lat', formalchemy_default_y),
-    # if we specify None or '' GeoFolmAlchemy will add a script from openlayers.org
-    # and we want to use our own build script.
-    ('openlayers_lib', 'none')
+    ('default_lat', formalchemy_default_y)
 ])
 fieldOrder = [RestrictionArea.name,
               RestrictionArea.description,
@@ -439,10 +436,7 @@ Role.extent.set(label=_(u'Extent'), options=[
     ('base_layer', 'new OpenLayers.Layer.OSM("OSM")'),
     ('zoom', formalchemy_default_zoom),
     ('default_lon', formalchemy_default_x),
-    ('default_lat', formalchemy_default_y),
-    # if we specify None or '' GeoFolmAlchemy will add a script from openlayers.org
-    # and we want to use our own build script.
-    ('openlayers_lib', 'none')
+    ('default_lat', formalchemy_default_y)
 ])
 fieldOrder = [Role.name,
               Role.description,

--- a/c2cgeoportal/templates/admin/map.mako
+++ b/c2cgeoportal/templates/admin/map.mako
@@ -9,7 +9,6 @@ options = {}
 options['zoom'] = 4
 options['map_width'] = 700
 options['map_height'] = 400
-options['openlayers_lib'] = 'http://openlayers.org/dev/OpenLayers.js'
 from pyramid.threadlocal import get_current_request
 options['image_select_feature_on'] = get_current_request().static_url('c2cgeoportal:static/adminapp/images/select_feature_on.png')
 options['image_select_feature_off'] = get_current_request().static_url('c2cgeoportal:static/adminapp/images/select_feature_off.png')
@@ -18,8 +17,6 @@ options['image_remove_feature_off'] = get_current_request().static_url('c2cgeopo
 %>
 
 % if insert_libs:
-<script src="${openlayers_lib or options['openlayers_lib']}"></script>
-
 <style>
 .formmap {
     border: 1px solid #ccc;

--- a/c2cgeoportal/templates/admin/map_js.mako
+++ b/c2cgeoportal/templates/admin/map_js.mako
@@ -258,7 +258,7 @@ geoformalchemy.init_map = function (
         panelControls.push(controlDragFeature);
     }
     
-    map = new OpenLayers.Map('map_' + field_name);
+    map = new OpenLayers.Map('map_' + field_name, {theme: null});
 
     $('#map_' + field_name).resizable({
         stop: function(event, ui) {


### PR DESCRIPTION
Setting `openlayers_lib` to "none" actually make GeoFormAlchemy to load a "none" file.
This PR suggests to drop this parameter since OL is loaded using a JS built file anyway. 

Ditto for the missing `theme: null` in the map object (made OL tries to load a "theme" file).
