### PR TITLE
Edit.js - add permalink and themefinder

### DIFF
--- a/c2cgeoportal/scaffolds/create/+package+/templates/edit.js_tmpl
+++ b/c2cgeoportal/scaffolds/create/+package+/templates/edit.js_tmpl
@@ -62,7 +62,11 @@ Ext.onReady(function() {
             {
                 id: 'left-panel',
                 region: 'west',
-                width: 300
+                width: 300,
+                layout: "vbox",
+                layoutConfig: {
+                    align: "stretch"
+                }
             }]
         },
 
@@ -77,10 +81,20 @@ Ext.onReady(function() {
             outputTarget: 'left-panel',
             outputConfig: {
                 layout: 'fit',
-                style: 'padding: 3px;'
+                style: 'padding: 3px 0 3px 3px;'
             },
             layerTreeId: 'layertree',
             themes: THEMES
+        },
+        {
+            ptype: "cgxp_themefinder",
+            outputTarget: "left-panel",
+            layerTreeId: "layertree",
+            themes: THEMES,
+            outputConfig: {
+                layout: "fit",
+                style: "padding: 3px;"
+            }
         },
         {
             ptype: "cgxp_layertree",
@@ -94,6 +108,12 @@ Ext.onReady(function() {
                 wmsURL: '${request.route_url('mapserverproxy')}'
             },
             outputTarget: 'left-panel'
+        },
+        {
+            ptype: "cgxp_permalink",
+            id: "permalink",
+            actionTarget: "map.tbar",
+            shortenerCreateURL: "${request.route_url('shortener_create', path='')}"
         },
         {
             ptype: "cgxp_menushortcut",
@@ -110,7 +130,8 @@ Ext.onReady(function() {
         },
         {
             ptype: "cgxp_mapopacityslider",
-            defaultBaseLayerRef: "${functionality['default_basemap'][0] | n}"
+            defaultBaseLayerRef: "${functionality['default_basemap'][0] | n}",
+            permalinkId: "permalink"
         }],
 
         // layer sources

--- a/c2cgeoportal/scaffolds/create/jsbuild/app.cfg_tmpl
+++ b/c2cgeoportal/scaffolds/create/jsbuild/app.cfg_tmpl
@@ -168,9 +168,11 @@ include =
     CGXP/plugins/Editing.js
     CGXP/plugins/Login.js
     CGXP/plugins/ThemeSelector.js
+    CGXP/plugins/ThemeFinder.js
     CGXP/plugins/LayerTree.js
     CGXP/plugins/MenuShortcut.js
     CGXP/plugins/MapOpacitySlider.js
+    CGXP/plugins/Permalink.js
     CGXP/widgets/MapPanel.js
     CGXP/tools/tools.js
     OpenLayers/Control/Navigation.js


### PR DESCRIPTION
Two things here :
First : I added the useful cgxp_themefinder in default edit.js file (and a panel to obtain a correct positioning).
Second : I added the permalink plugin (in edit.js file too) because the login plugin needs explicitely a "permalinkId" and so, a permalink plugin. Thus, the error message "permalinkId not found, your permalink plugin "id" config is either missing or wrong" will not appear anymore.

This dependency between login and permalink looks like a bug to me. Should I open an issue for that ? 
