### PR TITLE
Add layer-enabling substitution params

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_script:
 
 script: 
 - ./travis/doc.sh
-- find c2cgeoportal/*.py c2cgeoportal/lib c2cgeoportal/scripts c2cgeoportal/views -name \*.py | xargs ./buildout/bin/flake8 --ignore=E712 --max-complexity=30 --max-line-length=100
+- find c2cgeoportal/*.py c2cgeoportal/lib c2cgeoportal/scripts c2cgeoportal/views -name \*.py | xargs ./buildout/bin/flake8 --ignore=E712 --max-complexity=35 --max-line-length=100
 - find c2cgeoportal/*.py c2cgeoportal/tests -name \*.py | xargs ./buildout/bin/flake8 --ignore=E501
 - buildout/bin/pcreate -s c2cgeoportal_create /tmp/test package=test srid=21781
 - buildout/bin/pcreate -s c2cgeoportal_update /tmp/test package=test

--- a/c2cgeoportal/lib/__init__.py
+++ b/c2cgeoportal/lib/__init__.py
@@ -48,6 +48,21 @@ def get_setting(settings, path, default=None):
     return value if value else default
 
 
+def get_protected_layers_query(role_id, what=None):
+    from c2cgeoportal.models import DBSession, Layer, \
+        RestrictionArea, Role, layer_ra, role_ra
+
+    q = DBSession.query(what if what is not None else Layer)
+    q = q.join(
+        (layer_ra, Layer.id == layer_ra.c.layer_id),
+        (RestrictionArea,
+            RestrictionArea.id == layer_ra.c.restrictionarea_id),
+        (role_ra, role_ra.c.restrictionarea_id == RestrictionArea.id),
+        (Role, Role.id == role_ra.c.role_id))
+    q = q.filter(Role.id == role_id)
+    return q.filter(Layer.public != True)  # NOQA
+
+
 @implementer(IRoutePregenerator)
 class MultiDomainPregenerator:  # pragma: no cover
     def __call__(self, request, elements, kw):


### PR DESCRIPTION
This PR uses the recent possibility (with C2C-built mapserver) to use runtime substitution variables in METADATA. As a result it is for instance possible to hide a protected layer from the GetCapabilities response by adding the following configuration in the LAYER definition (mapfile):

```
NAME "somelayername"
METADATA
    "ows_enable_request" "%s_enable_somelayername%"
END
VALIDATION
    "s_enable_somelayername" "^[a-zA-Z\!\*, ]*$"
    "default_s_enable_somelayername" "!*"
END
```

=> by default the layer "somelayername" cannot be requested (GetCapabilities, GetMap, GetFeature, etc.).

When a user is authenticated, the mapserver proxy will retrieve the list of layernames available to the user (using joins between roles/restricted areas/layers) and automatically adds matching runtime substitution variables with value "*\* to the query string. In the example above: `s_enable_somelayername=*`

The join query is inspired by the code in entry view:
https://github.com/camptocamp/c2cgeoportal/blob/1.4/c2cgeoportal/views/entry.py#L129-L137

The retrieved list of layers may contain mapserver groups instead of layers.

For requests that have a LAYERS param, an intersection is made with the list of layers available to the current role, in order to avoid adding useless parameters in the requests.
Note that if a large number of protected layers are available to the user, the resulting URL may grow too big and hit URL size limit...

Changes have also be done in the "entry" view because it sometimes perform getcapabilities, for instance for building the themes list. Then we need to provide the available protected layers list as well. A "role_id" parameter has been added to the concerned function so that different versions of the getcapabilities are cached depending on the user's role.
