### PR TITLE
make the layer filtering in wms getcapabilty configurable

### DIFF
--- a/c2cgeoportal/scaffolds/create/config.yaml.in_tmpl
+++ b/c2cgeoportal/scaffolds/create/config.yaml.in_tmpl
@@ -91,6 +91,13 @@ mapserv_url: http://localhost/${vars:instanceid}/mapserv
 # Define whether the MapServer proxy should hide the OGC capabilities.
 hide_capabilities: false
 
+# Enable or disable the filtering of the layers using Mapserver runtime 
+# substitution variables in METADATA to hide protected layers from the 
+# GetCapabilities. 
+# Be careful as too many protected layers will cause an error because Apache has a 
+# 8190 characters hard limit for GET query length.
+use_security_metadata: false
+
 # For print proxy
 print_url: http://localhost:8080/print-c2cgeoportal-${vars:instanceid}/pdf/
 

--- a/c2cgeoportal/scaffolds/create/config_child.yaml.in_tmpl
+++ b/c2cgeoportal/scaffolds/create/config_child.yaml.in_tmpl
@@ -92,6 +92,14 @@ mapserv_url: http://${vars:host}/${vars:instanceid}/mapserv
 # Define whether the MapServer proxy should hide the OGC capabilities.
 hide_capabilities: false
 
+
+# Enable or disable the filtering of the layers using Mapserver runtime 
+# substitution variables in METADATA to hide protected layers from the 
+# GetCapabilities. 
+# Be careful as too many protected layers will cause an error because Apache has a 
+# 8190 characters hard limit for GET query length.
+use_security_metadata: false
+
 # For print proxy
 # This value mean that we use the parent print server
 print_url: http://${vars:host}:8080/print-c2cgeoportal-${vars:parent_instanceid}/pdf/

--- a/c2cgeoportal/views/mapserverproxy.py
+++ b/c2cgeoportal/views/mapserverproxy.py
@@ -76,6 +76,7 @@ def proxy(request):
 
     user = request.user
     external = bool(request.params.get("EXTERNAL", None))
+    useSecurityMetadata = bool(request.registry.settings.get('use_security_metadata', False))
 
     # params hold the parameters we're going to send to MapServer
     params = dict(request.params)
@@ -109,7 +110,7 @@ def proxy(request):
             del params[k]
 
     # add protected layers enabling params
-    if user:
+    if user and useSecurityMetadata:
         role_id = user.parent_role.id if external else user.role.id
         layers = _get_protected_layers(role_id)
         _params = dict(

--- a/doc/integrator/features.rst
+++ b/doc/integrator/features.rst
@@ -33,3 +33,4 @@ Features that require additional steps (most of the time):
    password_replication
    shortener
    intranet
+   security

--- a/doc/integrator/security.rst
+++ b/doc/integrator/security.rst
@@ -1,0 +1,22 @@
+.. _integrator_security:
+
+Security
+========
+
+Enable / Disable WMS GetCapability
+----------------------------------
+
+Set ``hide_capabilities`` to ``true`` in your ``<package>/config.yaml.in`` to disable 
+the WMS GetCapability when accessing the Mapserver proxy (mapserverproxy).
+
+default: ``false``
+
+Enable / Disable layer(s) in the WMS GetCapability
+--------------------------------------------------
+
+To hide protected layers from the WMS GetCapabilities, set ``use_security_metadata`` to ``true`` in your ``<package>/config.yaml.in``.
+
+Be careful as too many protected layers will cause an error because Apache has a 
+8190 characters hard limit for GET query length.
+
+default: ``false``


### PR DESCRIPTION
because if there are too many layer, the GET query will be longer than Apache limit
