### PR TITLE
Mobile: use map extent center if map center has not been set

### DIFF
--- a/c2cgeoportal/scaffolds/update/+package+/static/mobile/app/plugin/StatefulMap.js
+++ b/c2cgeoportal/scaffolds/update/+package+/static/mobile/app/plugin/StatefulMap.js
@@ -83,7 +83,7 @@ Ext.define('App.plugin.StatefulMap', {
     },
 
     update: function() {
-        var center = this.getMap().getCenter();
+        var center = this.getMap().getCenter() || new OpenLayers.Bounds(this.getMap().extent).getCenterLonLat();
         var main = App.app.getController('Main');
         var layers = main.getOverlay() && main.getOverlay().params.LAYERS || [];
         this.setState({


### PR DESCRIPTION
StatefulMap tries to use a map attribute that is not set by default in the mobile scaffold:
https://github.com/camptocamp/c2cgeoportal/blob/1.4/c2cgeoportal/scaffolds/create/%2Bpackage%2B/static/mobile/config.js_tmpl#L53-L58
therefore triggering an "undefined" JS error.
