### PR TITLE
Mapserverproxy layer filtering fix

### DIFF
--- a/c2cgeoportal/views/mapserverproxy.py
+++ b/c2cgeoportal/views/mapserverproxy.py
@@ -112,18 +112,7 @@ def proxy(request):
     # add protected layers enabling params
     if user and useSecurityMetadata:
         role_id = user.parent_role.id if external else user.role.id
-        layers = _get_protected_layers(role_id)
-        _params = dict(
-            (k.lower(), unicode(v).lower()) for k, v in params.iteritems()
-        )
-        if 'layers' in _params:
-            # limit the list to queried layers
-            l = []
-            for layer in _params['layers'].split(','):
-                if layer in layers:
-                    l.append(layer)
-            layers = l
-        for layer in layers:
+        for layer in _get_protected_layers(role_id):
             params['s_enable_' + str(layer)] = '*'
 
     # add functionalities params


### PR DESCRIPTION
As for now, when using the layer filtering tool (useful for instance to show only authorized layers in a GetCap), an intersection is done between the authorized layers list and the LAYERS param provided in the request (if provided).

In some cases (eg. with a mapserver GROUP: one might have defined the GROUP in the layer admin but the request might directly use the grouped layers => the intersection fails), this test is too restrictive and will incorrectly filter layers that should actually be available.

Solution: remove the intersection.
