### PR TITLE
Prevent checker loops

### DIFF
--- a/c2cgeoportal/views/check_collector.py
+++ b/c2cgeoportal/views/check_collector.py
@@ -34,6 +34,7 @@ from pyramid.view import view_config
 from pyramid.response import Response
 
 from httplib2 import Http
+from urlparse import urlparse
 
 
 class CheckerCollector(object):  # pragma: no cover
@@ -68,7 +69,12 @@ class CheckerCollector(object):  # pragma: no cover
 
     def _testurl(self, url):
         h = Http()
-        resp, content = h.request(url)
+
+        urlfragments = urlparse(url)
+        localurl = "%s://localhost%s" % (urlfragments.scheme, urlfragments.path)
+        headers = {'Host': urlfragments.netloc}
+
+        resp, content = h.request(localurl, headers=headers)
 
         if resp['status'] != '200':
             self.status_int = max(self.status_int, int(resp['status']))

--- a/c2cgeoportal/views/checker.py
+++ b/c2cgeoportal/views/checker.py
@@ -33,6 +33,9 @@ from pyramid.response import Response
 
 from httplib2 import Http
 import simplejson
+import logging
+
+log = logging.getLogger(__name__)
 
 
 class Checker(object):  # pragma: no cover
@@ -51,7 +54,13 @@ class Checker(object):  # pragma: no cover
 
     def testurl(self, url):
         h = Http()
-        resp, content = h.request(url)
+
+        log.info("Checker for url: %s" % url)
+
+        url = url.replace(self.request.environ.get('SERVER_NAME'), 'localhost')
+        headers = {'Host': self.request.environ.get('HTTP_HOST')}
+
+        resp, content = h.request(url, headers=headers)
 
         if resp['status'] != '200':
             self.update_status_int(resp['status'])
@@ -125,16 +134,24 @@ class Checker(object):  # pragma: no cover
         _url = self.request.route_url('printproxy_create') + \
             '?url=' + self.request.route_url('printproxy')
         h = Http()
-        headers = {'Content-type': 'application/json;charset=utf-8'}
+
+        log.info("Checker for printproxy request (create): %s" % _url)
+        _url = _url.replace(self.request.environ.get('SERVER_NAME'), "localhost:8080")
+        headers = {
+            'Content-Type': 'application/json;charset=utf-8',
+            'Host': self.request.environ.get('HTTP_HOST')
+        }
         resp, content = h.request(_url, 'POST', headers=headers, body=body)
 
         if resp['status'] != '200':
             self.update_status_int(resp['status'])
             return 'Failed creating PDF: ' + content
 
+        log.info("Checker for printproxy pdf (retrieve): %s" % _url)
         json = simplejson.loads(content)
-        _url = json['getURL']
-        resp, content = h.request(_url)
+        _url = json['getURL'].replace(self.request.environ.get('SERVER_NAME'), "localhost")
+        headers = {'Host': self.request.environ.get('HTTP_HOST')}
+        resp, content = h.request(_url, headers=headers)
 
         if resp['status'] != '200':
             self.update_status_int(resp['status'])
@@ -152,7 +169,12 @@ class Checker(object):  # pragma: no cover
             self.settings['fulltextsearch']
         )
         h = Http()
-        resp, content = h.request(_url)
+
+        log.info("Checker for fulltextsearch: %s" % _url)
+        _url = _url.replace(self.request.environ.get('SERVER_NAME'), "localhost")
+        headers = {'host': self.request.environ.get('HTTP_HOST')}
+
+        resp, content = h.request(_url, headers=headers)
 
         if resp['status'] != '200':
             self.update_status_int(resp['status'])

--- a/doc/integrator/checker.rst
+++ b/doc/integrator/checker.rst
@@ -18,6 +18,11 @@ The return code are::
   * 400-499 => Warning
   * 500-599 => Error
 
+.. Note::
+
+    Check collector can only check pages that are on the same server as it.
+
+
 Checker
 -------
 


### PR DESCRIPTION
These changes help me to prevent some loops between the serveur and the proxy. Requests must pass always by localhost, the headers parameters "host" indicates the "real" host to answer.
