### PR TITLE
Fixes login/logout may not work (viewer.js cache)

### DIFF
--- a/c2cgeoportal/views/entry.py
+++ b/c2cgeoportal/views/entry.py
@@ -744,6 +744,8 @@ class Entry(object):
         d['debug'] = self.debug
 
         self.request.response.content_type = 'application/javascript'
+        self.request.response.headers['cache-control'] = \
+            "private, max-age=0, no-cache"
         return d
 
     @view_config(route_name='edit', renderer='edit.html')


### PR DESCRIPTION
The `cache-control` headers set in [entry.py](https://github.com/tonio/c2cgeoportal/blob/66e60dac07bf7ac6008c93be11ad22a9f0ff4f15/c2cgeoportal/views/entry.py#L74) is imho too agressive for this route.
`viewer.js` shouldn’t  be cached.
