### PR TITLE
Add missing runtime substitution params in initial GetCapabilities

### DIFF
--- a/c2cgeoportal/lib/functionality.py
+++ b/c2cgeoportal/lib/functionality.py
@@ -28,7 +28,10 @@
 # either expressed or implied, of the FreeBSD Project.
 
 
+import logging
 from c2cgeoportal.lib import get_setting
+
+log = logging.getLogger(__name__)
 
 
 def _get_config_functionality(name, registered, config):
@@ -69,3 +72,23 @@ def get_functionality(name, config, request):
     if len(result) == 0:
         result = _get_config_functionality(name, request.user is not None, config)
     return result
+
+
+def get_mapserver_substitution_params(request):
+    params = {}
+    mss = get_functionality('mapserver_substitution',
+                            request.registry.settings, request)
+    if mss:
+        for s in mss:
+            index = s.find('=')
+            if index > 0:
+                attribute = 's_' + s[:index]
+                value = s[index + 1:]
+                if attribute in params:
+                    params[attribute] += "," + value
+                else:
+                    params[attribute] = value
+            else:
+                log.warning("Mapserver Substitution '%s' does not "
+                            "respect pattern: <attribute>=<value>" % s)
+    return params

--- a/c2cgeoportal/views/entry.py
+++ b/c2cgeoportal/views/entry.py
@@ -29,6 +29,7 @@
 
 
 import httplib2
+import urllib
 import logging
 import json
 import sys
@@ -49,7 +50,8 @@ from xml.dom.minidom import parseString
 from math import sqrt
 
 from c2cgeoportal.lib import get_setting, caching, get_protected_layers_query
-from c2cgeoportal.lib.functionality import get_functionality
+from c2cgeoportal.lib.functionality import get_functionality, \
+    get_mapserver_substitution_params
 from c2cgeoportal.models import DBSession, Layer, LayerGroup, \
     Theme, RestrictionArea, Role, User
 from c2cgeoportal.lib.wmstparsing import parse_extent, TimeInformation
@@ -96,6 +98,11 @@ class Entry(object):
             q = get_protected_layers_query(role_id)
             for layer in q.all():
                 url += '&s_enable_' + str(layer.name) + '=*'
+
+        # add functionalities params
+        sparams = get_mapserver_substitution_params(self.request)
+        if sparams:  # pragma: no cover
+            url += '&' + urllib.urlencode(sparams)
 
         log.info("WMS GetCapabilities for base url: %s" % url)
 

--- a/c2cgeoportal/views/mapserverproxy.py
+++ b/c2cgeoportal/views/mapserverproxy.py
@@ -42,7 +42,7 @@ from pyramid.view import view_config
 
 from c2cgeoportal.lib import caching, get_protected_layers_query
 from c2cgeoportal.lib.wfsparsing import is_get_feature, limit_featurecollection
-from c2cgeoportal.lib.functionality import get_functionality
+from c2cgeoportal.lib.functionality import get_mapserver_substitution_params
 from c2cgeoportal.models import Layer
 
 log = logging.getLogger(__name__)
@@ -116,21 +116,7 @@ def proxy(request):
             params['s_enable_' + str(layer)] = '*'
 
     # add functionalities params
-    mss = get_functionality('mapserver_substitution',
-                            request.registry.settings, request)
-    if mss:
-        for s in mss:
-            index = s.find('=')
-            if index > 0:
-                attribute = 's_' + s[:index]
-                value = s[index + 1:]
-                if attribute in params:
-                    params[attribute] += "," + value
-                else:
-                    params[attribute] = value
-            else:
-                log.warning("Mapserver Substitution '%s' does not "
-                            "respect pattern: <attribute>=<value>" % s)
+    params.update(get_mapserver_substitution_params(request))
 
     # get method
     method = request.method


### PR DESCRIPTION
As for now, the initial getcapabilities request done for instance when generating the viewer.js does not take into account the runtime substitution parameters from the functionalities.
