### PR TITLE
Fix big print capabilities

### DIFF
--- a/c2cgeoportal/views/printproxy.py
+++ b/c2cgeoportal/views/printproxy.py
@@ -89,7 +89,10 @@ class Printproxy(object):  # pragma: no cover
             layout['name'] in templates)
 
         headers = dict(resp)
-        del headers['content-length']
+        if 'content-length' in headers:
+            del headers['content-length']
+        if 'transfer-encoding' in headers:
+            del headers['transfer-encoding']
         headers["Expires"] = "-1"
         headers["Pragma"] = "no-cache"
         headers["CacheControl"] = "no-cache"
@@ -151,6 +154,6 @@ class Printproxy(object):  # pragma: no cover
         headers['content-disposition'] = resp['content-disposition']
         # remove Pragma and Cache-Control headers because of ie bug:
         # http://support.microsoft.com/default.aspx?scid=KB;EN-US;q316431
-        #del response.headers['Pragma']
-        #del response.headers['Cache-Control']
+        # del response.headers['Pragma']
+        # del response.headers['Cache-Control']
         return Response(content, status=resp.status, headers=headers)


### PR DESCRIPTION
When we have a big JSON returned for the print capabilities, we don's
have an 'Content-Length' header, but we have an unwanted
'Transfer-Encoding' header...
