### PR TITLE
Add support for a cache version parameter in JS/CSS URLs

### DIFF
--- a/c2cgeoportal/scaffolds/create/+package+/templates/api/api.js_tmpl
+++ b/c2cgeoportal/scaffolds/create/+package+/templates/api/api.js_tmpl
@@ -17,11 +17,11 @@ document.write('<link rel="stylesheet" type="text/css" href="'
         + "${request.static_url('{{package}}:static/css/proj-map.css')}" + '" />');
 % else:
 document.write('<scr' + 'ipt type="text/javascript" src="'
-        + "${request.static_url('{{package}}:static/build/api.js')}" + '"></scr' + 'ipt>');
+        + "${request.static_url('{{package}}:static/build/api.js', _query=url_params)}" + '"></scr' + 'ipt>');
 document.write('<scr' + 'ipt type="text/javascript" src="'
-        + "${request.static_url('{{package}}:static/build/api-lang-%s.js' % lang)}" + '"></scr' + 'ipt>');
+        + "${request.static_url('{{package}}:static/build/api-lang-%s.js' % lang, _query=url_params)}" + '"></scr' + 'ipt>');
 document.write('<link rel="stylesheet" type="text/css" href="'
-        + "${request.static_url('{{package}}:static/build/api.css')}" + '" />');
+        + "${request.static_url('{{package}}:static/build/api.css', _query=url_params)}" + '" />');
 % endif
 
 

--- a/c2cgeoportal/scaffolds/create/+package+/templates/api/xapi.js_tmpl
+++ b/c2cgeoportal/scaffolds/create/+package+/templates/api/xapi.js_tmpl
@@ -134,11 +134,11 @@ document.write('<link rel="stylesheet" type="text/css" href="'
         + "${request.static_url('{{package}}:static/css/proj-widgets.css')}" + '" />');
 % else:
 document.write('<scr' + 'ipt type="text/javascript" src="'
-        + "${request.static_url('{{package}}:static/build/xapi.js')}" + '"></scr' + 'ipt>');
+        + "${request.static_url('{{package}}:static/build/xapi.js', _query=url_params)}" + '"></scr' + 'ipt>');
 document.write('<scr' + 'ipt type="text/javascript" src="'
-        + "${request.static_url('{{package}}:static/build/lang-%s.js' % lang)}" + '"></scr' + 'ipt>');
+        + "${request.static_url('{{package}}:static/build/lang-%s.js' % lang, _query=url_params)}" + '"></scr' + 'ipt>');
 document.write('<link rel="stylesheet" type="text/css" href="'
-        + "${request.static_url('{{package}}:static/build/xapi.css')}" + '" />');
+        + "${request.static_url('{{package}}:static/build/xapi.css', _query=url_params)}" + '" />');
 % endif
 
 {{package}} = {};

--- a/c2cgeoportal/scaffolds/create/+package+/templates/edit.html_tmpl
+++ b/c2cgeoportal/scaffolds/create/+package+/templates/edit.html_tmpl
@@ -50,7 +50,7 @@
         <link rel="stylesheet" type="text/css" href="${request.static_url('{{package}}:static/css/proj-map.css')}" />
         <link rel="stylesheet" type="text/css" href="${request.static_url('{{package}}:static/css/proj-widgets.css')}" />
 % else:
-        <link rel="stylesheet" type="text/css" href="${request.static_url('{{package}}:static/build/app.css')}" />
+        <link rel="stylesheet" type="text/css" href="${request.static_url('{{package}}:static/build/app.css', _query=url_params)}" />
 % endif
     </head>
 
@@ -87,9 +87,9 @@ jsbuild_root_dir = request.registry.settings.get('jsbuild_root_dir')
         <script type="text/javascript" src="${request.static_url(script.replace('/', ':', 1))}"></script>
 % endfor
 % else:
-        <script type="text/javascript" src="${request.static_url('{{package}}:static/build/edit.js')}"></script>
-        <script type="text/javascript" src="${request.static_url('{{package}}:static/build/lang-%s.js' % lang)}"></script>
+        <script type="text/javascript" src="${request.static_url('{{package}}:static/build/edit.js', _query=url_params)}"></script>
+        <script type="text/javascript" src="${request.static_url('{{package}}:static/build/lang-%s.js' % lang, _query=url_params)}"></script>
 % endif
-        <script type="text/javascript" src="${request.route_url('edit.js')}${extra_params}"></script>
+        <script type="text/javascript" src="${request.route_url('edit.js', _query=extra_params)}"></script>
     </body>
 </html>

--- a/c2cgeoportal/scaffolds/create/+package+/templates/index.html_tmpl
+++ b/c2cgeoportal/scaffolds/create/+package+/templates/index.html_tmpl
@@ -62,7 +62,7 @@
         <link rel="stylesheet" type="text/css" href="${request.static_url('{{package}}:static/css/proj-map.css')}" />
         <link rel="stylesheet" type="text/css" href="${request.static_url('{{package}}:static/css/proj-widgets.css')}" />
 % else:
-        <link rel="stylesheet" type="text/css" href="${request.static_url('{{package}}:static/build/app.css')}" />
+        <link rel="stylesheet" type="text/css" href="${request.static_url('{{package}}:static/build/app.css', _query=url_params)}" />
 % endif
     </head>
     <body class="${lang}">
@@ -103,9 +103,9 @@
         <script type="text/javascript" src="${request.static_url(script.replace('/', ':', 1))}"></script>
     % endfor
 % else:
-        <script type="text/javascript" src="${request.static_url('{{package}}:static/build/app.js')}"></script>
-        <script type="text/javascript" src="${request.static_url('{{package}}:static/build/lang-%s.js' % lang)}"></script>
+        <script type="text/javascript" src="${request.static_url('{{package}}:static/build/app.js', _query=url_params)}"></script>
+        <script type="text/javascript" src="${request.static_url('{{package}}:static/build/lang-%s.js' % lang, _query=url_params)}"></script>
 % endif
-        <script type="text/javascript" src="${request.route_url('viewer')}${extra_params}"></script>
+        <script type="text/javascript" src="${request.route_url('viewer', _query=extra_params)}"></script>
     </body>
 </html>

--- a/c2cgeoportal/scaffolds/create/+package+/templates/routing.html_tmpl
+++ b/c2cgeoportal/scaffolds/create/+package+/templates/routing.html_tmpl
@@ -50,7 +50,7 @@
         <link rel="stylesheet" type="text/css" href="${request.static_url('{{package}}:static/css/proj-map.css')}" />
         <link rel="stylesheet" type="text/css" href="${request.static_url('{{package}}:static/css/proj-widgets.css')}" />
 % else:
-        <link rel="stylesheet" type="text/css" href="${request.static_url('{{package}}:static/build/app.css')}" />
+        <link rel="stylesheet" type="text/css" href="${request.static_url('{{package}}:static/build/app.css', _query=url_params)}" />
 % endif
     </head>
 
@@ -87,9 +87,9 @@ jsbuild_root_dir = request.registry.settings.get('jsbuild_root_dir')
         <script type="text/javascript" src="${request.static_url(script.replace('/', ':', 1))}"></script>
 % endfor
 % else:
-        <script type="text/javascript" src="${request.static_url('{{package}}:static/build/routing.js')}"></script>
-        <script type="text/javascript" src="${request.static_url('{{package}}:static/build/lang-%s.js' % lang)}"></script>
+        <script type="text/javascript" src="${request.static_url('{{package}}:static/build/routing.js', _query=url_params)}"></script>
+        <script type="text/javascript" src="${request.static_url('{{package}}:static/build/lang-%s.js' % lang, _query=url_params)}"></script>
 % endif
-        <script type="text/javascript" src="${request.route_url('routing.js')}${extra_params}"></script>
+        <script type="text/javascript" src="${request.route_url('routing.js', _query=extra_params)}"></script>
     </body>
 </html>

--- a/c2cgeoportal/scaffolds/create/development.ini.in_tmpl
+++ b/c2cgeoportal/scaffolds/create/development.ini.in_tmpl
@@ -21,6 +21,7 @@ parentschema = ${vars:parent_schema}
 # For debug mode
 jsbuild_cfg = ${jsbuild:config}
 jsbuild_root_dir = ${buildout:directory}
+cache_version = ${cache_version}
 
 # Admin interface
 enable_admin_interface = ${vars:enable_admin_interface}

--- a/c2cgeoportal/scaffolds/create/production.ini.in_tmpl
+++ b/c2cgeoportal/scaffolds/create/production.ini.in_tmpl
@@ -21,6 +21,7 @@ parentschema = ${vars:parent_schema}
 # For debug mode
 jsbuild_cfg = ${jsbuild:config}
 jsbuild_root_dir = ${buildout:directory}
+cache_version = ${cache_version}
 
 # Admin interface
 enable_admin_interface = ${vars:enable_admin_interface}

--- a/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -21,6 +21,40 @@ Version 1.4.5
     -    config.add_static_view('mobile', '{{package}}:static/mobile/build/testing/App')
     +    config.add_static_view('mobile', '{{package}}:static/mobile/build/production/App')
 
+2. To add the cache version parameter to the JS/CSS URLs:
+
+   * Add to ``production.ini.in`` and ``development.ini.in`` in the ``[app:app]`` section:
+
+   cache_version = ${cache_version}
+
+   * In ``{{package}}/templates/index.html`` do the following changes:
+
+   - <link rel="stylesheet" type="text/css" href="${request.static_url('{{package}}:static/build/app.css')}" />
+   + <link rel="stylesheet" type="text/css" href="${request.static_url('{{package}}:static/build/app.css', _query=url_params)}" />
+
+   - <script type="text/javascript" src="${request.static_url('{{package}}:static/build/app.js')}"></script>
+   - <script type="text/javascript" src="${request.static_url('{{package}}:static/build/lang-%s.js' % lang)}"></script>
+   + <script type="text/javascript" src="${request.static_url('{{package}}:static/build/app.js', _query=url_params)}"></script>
+   + <script type="text/javascript" src="${request.static_url('{{package}}:static/build/lang-%s.js' % lang, _query=url_params)}"></script>
+
+   - <script type="text/javascript" src="${request.route_url('viewer')}${extra_params}"></script>
+   + <script type="text/javascript" src="${request.route_url('viewer', _query=extra_params)}"></script>
+
+   The same changes must be done in ``{{package}}/templates/edit.html`` and ``{{package}}/templates/routing.html``.
+
+   In ``{{package}}/templates/api/api.js`` do the following changes:
+
+     document.write('<scr' + 'ipt type="text/javascript" src="'
+   -     + "${request.static_url('{{package}}:static/build/api.js')}" + '"></scr' + 'ipt>');
+   +     + "${request.static_url('{{package}}:static/build/api.js', _query=url_params)}" + '"></scr' + 'ipt>');
+     document.write('<scr' + 'ipt type="text/javascript" src="'
+   -     + "${request.static_url('{{package}}:static/build/api-lang-%s.js' % lang)}" + '"></scr' + 'ipt>');
+   +     + "${request.static_url('{{package}}:static/build/api-lang-%s.js' % lang, _query=url_params)}" + '"></scr' + 'ipt>');
+     document.write('<link rel="stylesheet" type="text/css" href="'
+   -     + "${request.static_url('{{package}}:static/build/api.css')}" + '" />');
+   +     + "${request.static_url('{{package}}:static/build/api.css', _query=url_params)}" + '" />');
+
+   Similar changes are needed in ``{{package}}/templates/api/xapi.js`` as well.
 
 Version 1.4.3
 =============

--- a/c2cgeoportal/scaffolds/update/CONST_buildout.cfg_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_buildout.cfg_tmpl
@@ -46,6 +46,8 @@ modwsgi_user = www-data
 apache-entry-point = /${vars:instanceid}/wsgi/
 # cookie session secret
 authtkt_secret = __import__('uuid').uuid4().hex
+# UUID for inhibiting the browser cache after the application has been rebuilt:
+cache_version = __import__('uuid').uuid4().hex
 # database user
 dbuser = www-data
 # database password
@@ -168,6 +170,7 @@ recipe = z3c.recipe.filetemplate
 source-directory = .
 exclude-directories = buildout
 interpreted-options = authtkt_secret
+    cache_version
 extends = vars
     facts
 

--- a/c2cgeoportal/tests/functional/test_entry.py
+++ b/c2cgeoportal/tests/functional/test_entry.py
@@ -549,7 +549,7 @@ class TestEntryView(TestCase):
             set(result.keys()),
             set(
                 [
-                    'lang', 'debug', 'extra_params',
+                    'lang', 'debug', 'extra_params', 'url_params',
                     'mobile_url', 'no_redirect'
                 ]
             )
@@ -561,19 +561,31 @@ class TestEntryView(TestCase):
             '{"layer_test": {"label": "%s"}}' % mapserv
         )
         result = entry.edit()
-        self.assertEquals(set(result.keys()), set(['lang', 'debug', 'extra_params']))
+        self.assertEquals(
+            set(result.keys()),
+            set(['lang', 'debug', 'extra_params', 'url_params'])
+        )
         result = entry.editjs()
         self.assertEquals(set(result.keys()), all_params)
         result = entry.routing()
-        self.assertEquals(set(result.keys()), set(['lang', 'debug', 'extra_params']))
+        self.assertEquals(
+            set(result.keys()),
+            set(['lang', 'debug', 'extra_params', 'url_params'])
+        )
         result = entry.routingjs()
         self.assertEquals(set(result.keys()), all_params)
         result = entry.mobile()
         self.assertEquals(set(result.keys()), set(['lang']))
         result = entry.apijs()
-        self.assertEquals(set(result.keys()), set(['lang', 'debug', 'queryable_layers', 'tiles_url']))
+        self.assertEquals(
+            set(result.keys()),
+            set(['lang', 'debug', 'queryable_layers', 'tiles_url', 'url_params'])
+        )
         result = entry.xapijs()
-        self.assertEquals(set(result.keys()), set(['lang', 'debug', 'queryable_layers', 'tiles_url']))
+        self.assertEquals(
+            set(result.keys()),
+            set(['lang', 'debug', 'queryable_layers', 'tiles_url', 'url_params'])
+        )
         result = entry.apihelp()
         self.assertEquals(set(result.keys()), set(['lang', 'debug']))
         result = entry.xapihelp()
@@ -615,7 +627,7 @@ class TestEntryView(TestCase):
             set(result.keys()),
             set(
                 [
-                    'lang', 'debug', 'extra_params',
+                    'lang', 'debug', 'extra_params', 'url_params',
                     'mobile_url', 'no_redirect'
                 ]
             )
@@ -655,7 +667,7 @@ class TestEntryView(TestCase):
             set(result.keys()),
             set(
                 [
-                    'lang', 'debug', 'extra_params',
+                    'lang', 'debug', 'extra_params', 'url_params',
                     'mobile_url', 'no_redirect'
                 ]
             )
@@ -681,12 +693,12 @@ class TestEntryView(TestCase):
         self.assertEquals(
             result.keys(),
             [
-                'lang', 'mobile_url', 'permalink_themes',
+                'lang', 'url_params', 'mobile_url', 'permalink_themes',
                 'no_redirect', 'extra_params', 'debug'
             ]
         )
-        self.assertEquals(result['extra_params'], '?lang=en&permalink_themes=theme')
-        self.assertEquals(result['permalink_themes'], 'permalink_themes=theme')
+        self.assertEquals(result['extra_params'], {'lang': 'en', 'permalink_themes': 'theme'})
+        self.assertEquals(result['permalink_themes'], 'theme')
 
         request.matchdict = {
             'themes': ['theme1', 'theme2'],
@@ -695,12 +707,12 @@ class TestEntryView(TestCase):
         self.assertEquals(
             result.keys(),
             [
-                'lang', 'mobile_url', 'permalink_themes',
+                'lang', 'url_params', 'mobile_url', 'permalink_themes',
                 'no_redirect', 'extra_params', 'debug'
             ]
         )
-        self.assertEquals(result['extra_params'], '?lang=en&permalink_themes=theme1,theme2')
-        self.assertEquals(result['permalink_themes'], 'permalink_themes=theme1,theme2')
+        self.assertEquals(result['extra_params'], {'lang': 'en', 'permalink_themes': 'theme1,theme2'})
+        self.assertEquals(result['permalink_themes'], 'theme1,theme2')
 
     def test_layer(self):
         import httplib2

--- a/c2cgeoportal/views/entry.py
+++ b/c2cgeoportal/views/entry.py
@@ -734,10 +734,19 @@ class Entry(object):
 
     @view_config(route_name='home', renderer='index.html')
     def home(self, templates_params=None):
+        cache_version = self.settings.get('cache_version', None)
+        extra_params = {}
+        url_params = {}
+        if cache_version:
+            url_params['version'] = cache_version
+            extra_params['version'] = cache_version
+        if self.lang:
+            extra_params['lang'] = self.lang
         d = {
             'lang': self.lang,
             'debug': self.debug,
-            'extra_params': '?lang=%s&' % self.lang if self.lang else '?'
+            'url_params': url_params,
+            'extra_params': extra_params
         }
 
         # general templates_params handling
@@ -745,7 +754,7 @@ class Entry(object):
             d = dict(d.items() + templates_params.items())
         # specific permalink_themes handling
         if 'permalink_themes' in d:
-            d['extra_params'] = d['extra_params'] + d['permalink_themes']
+            d['extra_params']['permalink_themes'] = d['permalink_themes']
 
         # check if route to mobile app exists
         try:
@@ -768,10 +777,19 @@ class Entry(object):
 
     @view_config(route_name='edit', renderer='edit.html')
     def edit(self):
+        cache_version = self.settings.get('cache_version', None)
+        extra_params = {}
+        url_params = {}
+        if cache_version:
+            url_params['version'] = cache_version
+            extra_params['version'] = cache_version
+        if self.lang:
+            extra_params['lang'] = self.lang
         return {
             'lang': self.lang,
             'debug': self.debug,
-            'extra_params': '?lang=%s&' % self.lang if self.lang else '?'
+            'url_params': url_params,
+            'extra_params': extra_params
         }
 
     @view_config(route_name='edit.js', renderer='edit.js')
@@ -785,10 +803,19 @@ class Entry(object):
 
     @view_config(route_name='routing', renderer='routing.html')
     def routing(self):
+        cache_version = self.settings.get('cache_version', None)
+        extra_params = {}
+        url_params = {}
+        if cache_version:
+            url_params['version'] = cache_version
+            extra_params['version'] = cache_version
+        if self.lang:
+            extra_params['lang'] = self.lang
         return {
             'lang': self.lang,
             'debug': self.debug,
-            'extra_params': '?lang=%s&' % self.lang if self.lang else '?'
+            'url_params': url_params,
+            'extra_params': extra_params
         }
 
     @view_config(route_name='routing.js', renderer='routing.js')
@@ -919,10 +946,12 @@ class Entry(object):
         queryable_layers = [
             name for name in list(wms.contents)
             if wms[name].queryable == 1]
+        cache_version = self.settings.get('cache_version', None)
         d = {
             'lang': self.lang,
             'debug': self.debug,
             'queryable_layers': json.dumps(queryable_layers),
+            'url_params': {'version': cache_version} if cache_version else {},
             'tiles_url': json.dumps(self.settings.get("tiles_url")),
         }
         self.request.response.content_type = 'application/javascript'
@@ -938,10 +967,12 @@ class Entry(object):
         queryable_layers = [
             name for name in list(wms.contents)
             if wms[name].queryable == 1]
+        cache_version = self.settings.get('cache_version', None)
         d = {
             'lang': self.lang,
             'debug': self.debug,
             'queryable_layers': json.dumps(queryable_layers),
+            'url_params': {'version': cache_version} if cache_version else {},
             'tiles_url': json.dumps(self.settings.get("tiles_url")),
         }
         self.request.response.content_type = 'application/javascript'
@@ -1086,6 +1117,6 @@ class Entry(object):
         # recover themes from url route
         themes = self.request.matchdict['themes']
         d = {}
-        d['permalink_themes'] = 'permalink_themes=' + ','.join(themes)
+        d['permalink_themes'] = ','.join(themes)
         # call home with extra params
         return self.home(d)


### PR DESCRIPTION
This PR adds the possibility to add a kind of "uuid" GET parameter (actually named "version") to the JS or CSS (or whatever) files loaded by the application, thus enabling to force the browser to load new files after running the buildout command.
