### PR TITLE
Fixes gzip compression for javascript

### DIFF
--- a/c2cgeoportal/scaffolds/create/apache/frontend.conf.in
+++ b/c2cgeoportal/scaffolds/create/apache/frontend.conf.in
@@ -1,6 +1,6 @@
 <LocationMatch /${vars:instanceid}/wsgi/>
     # Zip resources
-    AddOutputFilterByType DEFLATE text/html text/plain text/xml text/css application/x-javascript application/javascript application/json
+    AddOutputFilterByType DEFLATE text/html text/plain text/xml text/css application/x-javascript text/javascript application/javascript application/json
 </LocationMatch>
 
 <LocationMatch /${vars:instanceid}/wsgi/(proj|static)>

--- a/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -140,6 +140,9 @@ Version 1.5
 
 10. Do the following changes in the ``apache/frontend.conf.in`` file:
 
+  -AddOutputFilterByType DEFLATE text/html text/plain text/xml text/css application/x-javascript application/javascript application/json
+  +AddOutputFilterByType DEFLATE text/html text/plain text/xml text/css application/x-javascript text/javascript application/javascript application/json
+
   -<LocationMatch /${vars:instanceid}/wsgi/(app|build|lib)>
   -    # Remove etags to enable better client-side caching
   -    # (potential proxy problems)


### PR DESCRIPTION
`text/javascript` Content-type isn’t currently  compressed, so `app.js` isn’t either.
