### PR TITLE
Add main page title to gettext i18n

### DIFF
--- a/c2cgeoportal/locale/c2cgeoportal.pot
+++ b/c2cgeoportal/locale/c2cgeoportal.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: c2cgeoportal 1.5\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2014-01-29 13:25+0100\n"
+"POT-Creation-Date: 2014-07-03 15:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -29,11 +29,11 @@ msgstr ""
 msgid "Unlinked layers"
 msgstr ""
 
-#: c2cgeoportal/forms.py:413
+#: c2cgeoportal/forms.py:414
 msgid "Restriction area"
 msgstr ""
 
-#: c2cgeoportal/forms.py:437
+#: c2cgeoportal/forms.py:435
 msgid "Extent"
 msgstr ""
 
@@ -45,8 +45,8 @@ msgstr ""
 msgid "functionalitys"
 msgstr ""
 
-#: c2cgeoportal/models.py:124 c2cgeoportal/models.py:244 c2cgeoportal/models.py:292
-#: c2cgeoportal/models.py:484 c2cgeoportal/models.py:524
+#: c2cgeoportal/models.py:124 c2cgeoportal/models.py:255 c2cgeoportal/models.py:303
+#: c2cgeoportal/models.py:500 c2cgeoportal/models.py:540
 msgid "Name"
 msgstr ""
 
@@ -54,211 +54,211 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: c2cgeoportal/models.py:160
+#: c2cgeoportal/models.py:171
 msgid "user"
 msgstr ""
 
-#: c2cgeoportal/models.py:161
+#: c2cgeoportal/models.py:172
 msgid "users"
 msgstr ""
 
-#: c2cgeoportal/models.py:175 c2cgeoportal/templates/login.html:59
+#: c2cgeoportal/models.py:186 c2cgeoportal/templates/login.html:59
 msgid "Username"
 msgstr ""
 
-#: c2cgeoportal/models.py:178 c2cgeoportal/templates/login.html:62
+#: c2cgeoportal/models.py:189 c2cgeoportal/templates/login.html:62
 msgid "Password"
 msgstr ""
 
-#: c2cgeoportal/models.py:179
+#: c2cgeoportal/models.py:190
 msgid "E-mail"
 msgstr ""
 
-#: c2cgeoportal/models.py:180
+#: c2cgeoportal/models.py:191
 msgid "PasswordChanged"
 msgstr ""
 
-#: c2cgeoportal/models.py:236
+#: c2cgeoportal/models.py:247
 msgid "role"
 msgstr ""
 
-#: c2cgeoportal/models.py:237
+#: c2cgeoportal/models.py:248
 msgid "roles"
 msgstr ""
 
-#: c2cgeoportal/models.py:245 c2cgeoportal/models.py:485
+#: c2cgeoportal/models.py:256 c2cgeoportal/models.py:501
 msgid "Description"
 msgstr ""
 
-#: c2cgeoportal/models.py:293
+#: c2cgeoportal/models.py:304
 msgid "Order"
 msgstr ""
 
-#: c2cgeoportal/models.py:294
+#: c2cgeoportal/models.py:305
 msgid "Metadata URL"
 msgstr ""
 
-#: c2cgeoportal/models.py:338
+#: c2cgeoportal/models.py:349
 msgid "layergroup"
 msgstr ""
 
-#: c2cgeoportal/models.py:339
+#: c2cgeoportal/models.py:350
 msgid "layergroups"
 msgstr ""
 
-#: c2cgeoportal/models.py:349
+#: c2cgeoportal/models.py:360
 msgid "Expanded"
 msgstr ""
 
-#: c2cgeoportal/models.py:350
+#: c2cgeoportal/models.py:361
 msgid "Internal WMS"
 msgstr ""
 
-#: c2cgeoportal/models.py:352
+#: c2cgeoportal/models.py:363
 msgid "Group of base layers"
 msgstr ""
 
-#: c2cgeoportal/models.py:364
+#: c2cgeoportal/models.py:375
 msgid "theme"
 msgstr ""
 
-#: c2cgeoportal/models.py:365
+#: c2cgeoportal/models.py:376
 msgid "themes"
 msgstr ""
 
-#: c2cgeoportal/models.py:375 c2cgeoportal/models.py:402
+#: c2cgeoportal/models.py:386 c2cgeoportal/models.py:418
 msgid "Icon"
 msgstr ""
 
-#: c2cgeoportal/models.py:376 c2cgeoportal/models.py:399
+#: c2cgeoportal/models.py:387 c2cgeoportal/models.py:415
 msgid "Display in mobile"
 msgstr ""
 
-#: c2cgeoportal/models.py:377 c2cgeoportal/models.py:400
+#: c2cgeoportal/models.py:388 c2cgeoportal/models.py:416
 msgid "Display in desktop"
 msgstr ""
 
-#: c2cgeoportal/models.py:386
+#: c2cgeoportal/models.py:402
 msgid "layer"
 msgstr ""
 
-#: c2cgeoportal/models.py:387
+#: c2cgeoportal/models.py:403
 msgid "layers"
 msgstr ""
 
-#: c2cgeoportal/models.py:398
+#: c2cgeoportal/models.py:414
 msgid "Public"
 msgstr ""
 
-#: c2cgeoportal/models.py:401
+#: c2cgeoportal/models.py:417
 msgid "Checked"
 msgstr ""
 
-#: c2cgeoportal/models.py:408
+#: c2cgeoportal/models.py:424
 msgid "Type"
 msgstr ""
 
-#: c2cgeoportal/models.py:409
+#: c2cgeoportal/models.py:425
 msgid "Base URL"
 msgstr ""
 
-#: c2cgeoportal/models.py:413
+#: c2cgeoportal/models.py:429
 msgid "Image type"
 msgstr ""
 
-#: c2cgeoportal/models.py:414
+#: c2cgeoportal/models.py:430
 msgid "Style"
 msgstr ""
 
-#: c2cgeoportal/models.py:415
+#: c2cgeoportal/models.py:431
 msgid "Dimensions"
 msgstr ""
 
-#: c2cgeoportal/models.py:416
+#: c2cgeoportal/models.py:432
 msgid "Matrix set"
 msgstr ""
 
-#: c2cgeoportal/models.py:417
+#: c2cgeoportal/models.py:433
 msgid "WMS server URL"
 msgstr ""
 
-#: c2cgeoportal/models.py:418
+#: c2cgeoportal/models.py:434
 msgid "WMS layers"
 msgstr ""
 
-#: c2cgeoportal/models.py:419
+#: c2cgeoportal/models.py:435
 msgid "Query layers"
 msgstr ""
 
-#: c2cgeoportal/models.py:420
+#: c2cgeoportal/models.py:436
 msgid "KML 3D"
 msgstr ""
 
-#: c2cgeoportal/models.py:421
+#: c2cgeoportal/models.py:437
 msgid "Single tile"
 msgstr ""
 
-#: c2cgeoportal/models.py:422
+#: c2cgeoportal/models.py:438
 msgid "Display legend"
 msgstr ""
 
-#: c2cgeoportal/models.py:423
+#: c2cgeoportal/models.py:439
 msgid "Legend image"
 msgstr ""
 
-#: c2cgeoportal/models.py:424
+#: c2cgeoportal/models.py:440
 msgid "Legend rule"
 msgstr ""
 
-#: c2cgeoportal/models.py:425
+#: c2cgeoportal/models.py:441
 msgid "Legend expanded"
 msgstr ""
 
-#: c2cgeoportal/models.py:426
+#: c2cgeoportal/models.py:442
 msgid "Min resolution"
 msgstr ""
 
-#: c2cgeoportal/models.py:427
+#: c2cgeoportal/models.py:443
 msgid "Max resolution"
 msgstr ""
 
-#: c2cgeoportal/models.py:428
+#: c2cgeoportal/models.py:444
 msgid "Disclaimer"
 msgstr ""
 
-#: c2cgeoportal/models.py:430
+#: c2cgeoportal/models.py:446
 msgid "Identifier attribute field"
 msgstr ""
 
-#: c2cgeoportal/models.py:431
+#: c2cgeoportal/models.py:447
 msgid "Related Postgres table"
 msgstr ""
 
-#: c2cgeoportal/models.py:432
+#: c2cgeoportal/models.py:448
 msgid "Attributes to exclude"
 msgstr ""
 
-#: c2cgeoportal/models.py:438
+#: c2cgeoportal/models.py:454
 msgid "Time mode"
 msgstr ""
 
-#: c2cgeoportal/models.py:474
+#: c2cgeoportal/models.py:490
 msgid "restrictionarea"
 msgstr ""
 
-#: c2cgeoportal/models.py:475
+#: c2cgeoportal/models.py:491
 msgid "restrictionareas"
 msgstr ""
 
-#: c2cgeoportal/models.py:486
+#: c2cgeoportal/models.py:502
 msgid "Read-write mode"
 msgstr ""
 
-#: c2cgeoportal/models.py:516
+#: c2cgeoportal/models.py:532
 msgid "parentrole"
 msgstr ""
 
-#: c2cgeoportal/models.py:517
+#: c2cgeoportal/models.py:533
 msgid "parentroles"
 msgstr ""
 
@@ -274,6 +274,10 @@ msgstr ""
 msgid "search tip message"
 msgstr ""
 
+#: c2cgeoportal/scaffolds/create/+package+/templates/index.html_tmpl:16
+msgid "Application Title"
+msgstr ""
+
 #: c2cgeoportal/templates/login.html:6
 msgid "Login to Geoportal Application"
 msgstr ""
@@ -286,13 +290,13 @@ msgstr ""
 msgid "my translation test"
 msgstr ""
 
-#: c2cgeoportal/views/entry.py:76
+#: c2cgeoportal/views/entry.py:86
 msgid "title i18n"
 msgstr ""
 
-#: c2cgeoportal/views/entry.py:115
+#: c2cgeoportal/views/entry.py:139
 msgid ""
 "WARNING! an error occured while trying to read the mapfile and recover the "
-"themes"
+"themes."
 msgstr ""
 

--- a/c2cgeoportal/locale/de/LC_MESSAGES/c2cgeoportal.po
+++ b/c2cgeoportal/locale/de/LC_MESSAGES/c2cgeoportal.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: c2cgeoportal 0.8\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2014-01-29 13:25+0100\n"
+"POT-Creation-Date: 2014-07-03 15:21+0200\n"
 "PO-Revision-Date: 2012-07-13 12:06+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: de <LL@li.org>\n"
@@ -30,11 +30,11 @@ msgstr "Passworte stimmen nicht überein."
 msgid "Unlinked layers"
 msgstr "Unverknüpfte Layer"
 
-#: c2cgeoportal/forms.py:413
+#: c2cgeoportal/forms.py:414
 msgid "Restriction area"
 msgstr "geschützter Bereich"
 
-#: c2cgeoportal/forms.py:437
+#: c2cgeoportal/forms.py:435
 msgid "Extent"
 msgstr "Ausdehnung"
 
@@ -46,9 +46,9 @@ msgstr "Funktionalität"
 msgid "functionalitys"
 msgstr "Funktionalitäten"
 
-#: c2cgeoportal/models.py:124 c2cgeoportal/models.py:244
-#: c2cgeoportal/models.py:292 c2cgeoportal/models.py:484
-#: c2cgeoportal/models.py:524
+#: c2cgeoportal/models.py:124 c2cgeoportal/models.py:255
+#: c2cgeoportal/models.py:303 c2cgeoportal/models.py:500
+#: c2cgeoportal/models.py:540
 msgid "Name"
 msgstr "Name"
 
@@ -56,211 +56,211 @@ msgstr "Name"
 msgid "Value"
 msgstr "Wert"
 
-#: c2cgeoportal/models.py:160
+#: c2cgeoportal/models.py:171
 msgid "user"
 msgstr "Benutzer"
 
-#: c2cgeoportal/models.py:161
+#: c2cgeoportal/models.py:172
 msgid "users"
 msgstr "Benutzer"
 
-#: c2cgeoportal/models.py:175 c2cgeoportal/templates/login.html:59
+#: c2cgeoportal/models.py:186 c2cgeoportal/templates/login.html:59
 msgid "Username"
 msgstr "Benutzername"
 
-#: c2cgeoportal/models.py:178 c2cgeoportal/templates/login.html:62
+#: c2cgeoportal/models.py:189 c2cgeoportal/templates/login.html:62
 msgid "Password"
 msgstr "Passwort"
 
-#: c2cgeoportal/models.py:179
+#: c2cgeoportal/models.py:190
 msgid "E-mail"
 msgstr "E-Mail"
 
-#: c2cgeoportal/models.py:180
+#: c2cgeoportal/models.py:191
 msgid "PasswordChanged"
 msgstr "Passwort geändert"
 
-#: c2cgeoportal/models.py:236
+#: c2cgeoportal/models.py:247
 msgid "role"
 msgstr "Rolle"
 
-#: c2cgeoportal/models.py:237
+#: c2cgeoportal/models.py:248
 msgid "roles"
 msgstr "Rollen"
 
-#: c2cgeoportal/models.py:245 c2cgeoportal/models.py:485
+#: c2cgeoportal/models.py:256 c2cgeoportal/models.py:501
 msgid "Description"
 msgstr "Beschreibung"
 
-#: c2cgeoportal/models.py:293
+#: c2cgeoportal/models.py:304
 msgid "Order"
 msgstr "Reihenfolge"
 
-#: c2cgeoportal/models.py:294
+#: c2cgeoportal/models.py:305
 msgid "Metadata URL"
 msgstr "Metadaten-URL"
 
-#: c2cgeoportal/models.py:338
+#: c2cgeoportal/models.py:349
 msgid "layergroup"
 msgstr "Layer-Gruppe"
 
-#: c2cgeoportal/models.py:339
+#: c2cgeoportal/models.py:350
 msgid "layergroups"
 msgstr "Layer-Gruppen"
 
-#: c2cgeoportal/models.py:349
+#: c2cgeoportal/models.py:360
 msgid "Expanded"
 msgstr "Erweitert"
 
-#: c2cgeoportal/models.py:350
+#: c2cgeoportal/models.py:361
 msgid "Internal WMS"
 msgstr "Interner WMS"
 
-#: c2cgeoportal/models.py:352
+#: c2cgeoportal/models.py:363
 msgid "Group of base layers"
 msgstr "Gruppe von Basiskarten"
 
-#: c2cgeoportal/models.py:364
+#: c2cgeoportal/models.py:375
 msgid "theme"
 msgstr "Thema"
 
-#: c2cgeoportal/models.py:365
+#: c2cgeoportal/models.py:376
 msgid "themes"
 msgstr "Themen"
 
-#: c2cgeoportal/models.py:375 c2cgeoportal/models.py:402
+#: c2cgeoportal/models.py:386 c2cgeoportal/models.py:418
 msgid "Icon"
 msgstr "Symbol"
 
-#: c2cgeoportal/models.py:376 c2cgeoportal/models.py:399
+#: c2cgeoportal/models.py:387 c2cgeoportal/models.py:415
 msgid "Display in mobile"
 msgstr ""
 
-#: c2cgeoportal/models.py:377 c2cgeoportal/models.py:400
+#: c2cgeoportal/models.py:388 c2cgeoportal/models.py:416
 msgid "Display in desktop"
 msgstr ""
 
-#: c2cgeoportal/models.py:386
+#: c2cgeoportal/models.py:402
 msgid "layer"
 msgstr "Layer"
 
-#: c2cgeoportal/models.py:387
+#: c2cgeoportal/models.py:403
 msgid "layers"
 msgstr "Layer"
 
-#: c2cgeoportal/models.py:398
+#: c2cgeoportal/models.py:414
 msgid "Public"
 msgstr "Öffentlich"
 
-#: c2cgeoportal/models.py:401
+#: c2cgeoportal/models.py:417
 msgid "Checked"
 msgstr ""
 
-#: c2cgeoportal/models.py:408
+#: c2cgeoportal/models.py:424
 msgid "Type"
 msgstr "Typ"
 
-#: c2cgeoportal/models.py:409
+#: c2cgeoportal/models.py:425
 msgid "Base URL"
 msgstr "Basis-URL"
 
-#: c2cgeoportal/models.py:413
+#: c2cgeoportal/models.py:429
 msgid "Image type"
 msgstr "Bildtyp"
 
-#: c2cgeoportal/models.py:414
+#: c2cgeoportal/models.py:430
 msgid "Style"
 msgstr ""
 
-#: c2cgeoportal/models.py:415
+#: c2cgeoportal/models.py:431
 msgid "Dimensions"
 msgstr ""
 
-#: c2cgeoportal/models.py:416
+#: c2cgeoportal/models.py:432
 msgid "Matrix set"
 msgstr ""
 
-#: c2cgeoportal/models.py:417
+#: c2cgeoportal/models.py:433
 msgid "WMS server URL"
 msgstr ""
 
-#: c2cgeoportal/models.py:418
+#: c2cgeoportal/models.py:434
 msgid "WMS layers"
 msgstr "WMS Layer"
 
-#: c2cgeoportal/models.py:419
+#: c2cgeoportal/models.py:435
 msgid "Query layers"
 msgstr "Abfrage Layer"
 
-#: c2cgeoportal/models.py:420
+#: c2cgeoportal/models.py:436
 msgid "KML 3D"
 msgstr "KML 3D"
 
-#: c2cgeoportal/models.py:421
+#: c2cgeoportal/models.py:437
 msgid "Single tile"
 msgstr "Einzelkachel"
 
-#: c2cgeoportal/models.py:422
+#: c2cgeoportal/models.py:438
 msgid "Display legend"
 msgstr "Legende anzeigen"
 
-#: c2cgeoportal/models.py:423
+#: c2cgeoportal/models.py:439
 msgid "Legend image"
 msgstr "Legendenbild"
 
-#: c2cgeoportal/models.py:424
+#: c2cgeoportal/models.py:440
 msgid "Legend rule"
 msgstr "Legenden-Regel"
 
-#: c2cgeoportal/models.py:425
+#: c2cgeoportal/models.py:441
 msgid "Legend expanded"
 msgstr "Legende ausgeklappt"
 
-#: c2cgeoportal/models.py:426
+#: c2cgeoportal/models.py:442
 msgid "Min resolution"
 msgstr "Min. Auflösung"
 
-#: c2cgeoportal/models.py:427
+#: c2cgeoportal/models.py:443
 msgid "Max resolution"
 msgstr "Max. Auflösung"
 
-#: c2cgeoportal/models.py:428
+#: c2cgeoportal/models.py:444
 msgid "Disclaimer"
 msgstr ""
 
-#: c2cgeoportal/models.py:430
+#: c2cgeoportal/models.py:446
 msgid "Identifier attribute field"
 msgstr "Kennung Attributfeld (z.B. name)"
 
-#: c2cgeoportal/models.py:431
+#: c2cgeoportal/models.py:447
 msgid "Related Postgres table"
 msgstr ""
 
-#: c2cgeoportal/models.py:432
+#: c2cgeoportal/models.py:448
 msgid "Attributes to exclude"
 msgstr "Ausgeblendete Attribute"
 
-#: c2cgeoportal/models.py:438
+#: c2cgeoportal/models.py:454
 msgid "Time mode"
 msgstr ""
 
-#: c2cgeoportal/models.py:474
+#: c2cgeoportal/models.py:490
 msgid "restrictionarea"
 msgstr "Geschützter Bereich"
 
-#: c2cgeoportal/models.py:475
+#: c2cgeoportal/models.py:491
 msgid "restrictionareas"
 msgstr "Geschützte Bereiche"
 
-#: c2cgeoportal/models.py:486
+#: c2cgeoportal/models.py:502
 msgid "Read-write mode"
 msgstr ""
 
-#: c2cgeoportal/models.py:516
+#: c2cgeoportal/models.py:532
 msgid "parentrole"
 msgstr ""
 
-#: c2cgeoportal/models.py:517
+#: c2cgeoportal/models.py:533
 msgid "parentroles"
 msgstr ""
 
@@ -276,6 +276,10 @@ msgstr "Laden..."
 msgid "search tip message"
 msgstr ""
 
+#: c2cgeoportal/scaffolds/create/+package+/templates/index.html_tmpl:16
+msgid "Application Title"
+msgstr ""
+
 #: c2cgeoportal/templates/login.html:6
 msgid "Login to Geoportal Application"
 msgstr "Login Geoportal"
@@ -288,14 +292,14 @@ msgstr ""
 msgid "my translation test"
 msgstr "meine Übersetzung test"
 
-#: c2cgeoportal/views/entry.py:76
+#: c2cgeoportal/views/entry.py:86
 msgid "title i18n"
 msgstr "Testen des i18n"
 
-#: c2cgeoportal/views/entry.py:115
+#: c2cgeoportal/views/entry.py:139
 msgid ""
 "WARNING! an error occured while trying to read the mapfile and recover "
-"the themes"
+"the themes."
 msgstr ""
 
 #~ msgid "Display"
@@ -303,4 +307,7 @@ msgstr ""
 
 #~ msgid "Visible"
 #~ msgstr "Sichtbar"
+
+#~ msgid ""
+#~ msgstr ""
 

--- a/c2cgeoportal/locale/en/LC_MESSAGES/c2cgeoportal.po
+++ b/c2cgeoportal/locale/en/LC_MESSAGES/c2cgeoportal.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: c2cgeoportal 0.2\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2014-01-29 13:25+0100\n"
+"POT-Creation-Date: 2014-07-03 15:21+0200\n"
 "PO-Revision-Date: 2011-08-31 17:17+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -30,11 +30,11 @@ msgstr ""
 msgid "Unlinked layers"
 msgstr ""
 
-#: c2cgeoportal/forms.py:413
+#: c2cgeoportal/forms.py:414
 msgid "Restriction area"
 msgstr ""
 
-#: c2cgeoportal/forms.py:437
+#: c2cgeoportal/forms.py:435
 msgid "Extent"
 msgstr ""
 
@@ -46,9 +46,9 @@ msgstr "Functionality"
 msgid "functionalitys"
 msgstr "Functionalities"
 
-#: c2cgeoportal/models.py:124 c2cgeoportal/models.py:244
-#: c2cgeoportal/models.py:292 c2cgeoportal/models.py:484
-#: c2cgeoportal/models.py:524
+#: c2cgeoportal/models.py:124 c2cgeoportal/models.py:255
+#: c2cgeoportal/models.py:303 c2cgeoportal/models.py:500
+#: c2cgeoportal/models.py:540
 msgid "Name"
 msgstr ""
 
@@ -56,211 +56,211 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: c2cgeoportal/models.py:160
+#: c2cgeoportal/models.py:171
 msgid "user"
 msgstr "User"
 
-#: c2cgeoportal/models.py:161
+#: c2cgeoportal/models.py:172
 msgid "users"
 msgstr "Users"
 
-#: c2cgeoportal/models.py:175 c2cgeoportal/templates/login.html:59
+#: c2cgeoportal/models.py:186 c2cgeoportal/templates/login.html:59
 msgid "Username"
 msgstr "User name"
 
-#: c2cgeoportal/models.py:178 c2cgeoportal/templates/login.html:62
+#: c2cgeoportal/models.py:189 c2cgeoportal/templates/login.html:62
 msgid "Password"
 msgstr ""
 
-#: c2cgeoportal/models.py:179
+#: c2cgeoportal/models.py:190
 msgid "E-mail"
 msgstr ""
 
-#: c2cgeoportal/models.py:180
+#: c2cgeoportal/models.py:191
 msgid "PasswordChanged"
 msgstr ""
 
-#: c2cgeoportal/models.py:236
+#: c2cgeoportal/models.py:247
 msgid "role"
 msgstr "Role"
 
-#: c2cgeoportal/models.py:237
+#: c2cgeoportal/models.py:248
 msgid "roles"
 msgstr "Roles"
 
-#: c2cgeoportal/models.py:245 c2cgeoportal/models.py:485
+#: c2cgeoportal/models.py:256 c2cgeoportal/models.py:501
 msgid "Description"
 msgstr ""
 
-#: c2cgeoportal/models.py:293
+#: c2cgeoportal/models.py:304
 msgid "Order"
 msgstr ""
 
-#: c2cgeoportal/models.py:294
+#: c2cgeoportal/models.py:305
 msgid "Metadata URL"
 msgstr ""
 
-#: c2cgeoportal/models.py:338
+#: c2cgeoportal/models.py:349
 msgid "layergroup"
 msgstr "Layer Group"
 
-#: c2cgeoportal/models.py:339
+#: c2cgeoportal/models.py:350
 msgid "layergroups"
 msgstr "Layer Groups"
 
-#: c2cgeoportal/models.py:349
+#: c2cgeoportal/models.py:360
 msgid "Expanded"
 msgstr ""
 
-#: c2cgeoportal/models.py:350
+#: c2cgeoportal/models.py:361
 msgid "Internal WMS"
 msgstr ""
 
-#: c2cgeoportal/models.py:352
+#: c2cgeoportal/models.py:363
 msgid "Group of base layers"
 msgstr ""
 
-#: c2cgeoportal/models.py:364
+#: c2cgeoportal/models.py:375
 msgid "theme"
 msgstr "Theme"
 
-#: c2cgeoportal/models.py:365
+#: c2cgeoportal/models.py:376
 msgid "themes"
 msgstr "Themes"
 
-#: c2cgeoportal/models.py:375 c2cgeoportal/models.py:402
+#: c2cgeoportal/models.py:386 c2cgeoportal/models.py:418
 msgid "Icon"
 msgstr ""
 
-#: c2cgeoportal/models.py:376 c2cgeoportal/models.py:399
+#: c2cgeoportal/models.py:387 c2cgeoportal/models.py:415
 msgid "Display in mobile"
 msgstr ""
 
-#: c2cgeoportal/models.py:377 c2cgeoportal/models.py:400
+#: c2cgeoportal/models.py:388 c2cgeoportal/models.py:416
 msgid "Display in desktop"
 msgstr ""
 
-#: c2cgeoportal/models.py:386
+#: c2cgeoportal/models.py:402
 msgid "layer"
 msgstr "Layer"
 
-#: c2cgeoportal/models.py:387
+#: c2cgeoportal/models.py:403
 msgid "layers"
 msgstr "Layers"
 
-#: c2cgeoportal/models.py:398
+#: c2cgeoportal/models.py:414
 msgid "Public"
 msgstr ""
 
-#: c2cgeoportal/models.py:401
+#: c2cgeoportal/models.py:417
 msgid "Checked"
 msgstr ""
 
-#: c2cgeoportal/models.py:408
+#: c2cgeoportal/models.py:424
 msgid "Type"
 msgstr ""
 
-#: c2cgeoportal/models.py:409
+#: c2cgeoportal/models.py:425
 msgid "Base URL"
 msgstr ""
 
-#: c2cgeoportal/models.py:413
+#: c2cgeoportal/models.py:429
 msgid "Image type"
 msgstr ""
 
-#: c2cgeoportal/models.py:414
+#: c2cgeoportal/models.py:430
 msgid "Style"
 msgstr ""
 
-#: c2cgeoportal/models.py:415
+#: c2cgeoportal/models.py:431
 msgid "Dimensions"
 msgstr ""
 
-#: c2cgeoportal/models.py:416
+#: c2cgeoportal/models.py:432
 msgid "Matrix set"
 msgstr ""
 
-#: c2cgeoportal/models.py:417
+#: c2cgeoportal/models.py:433
 msgid "WMS server URL"
 msgstr ""
 
-#: c2cgeoportal/models.py:418
+#: c2cgeoportal/models.py:434
 msgid "WMS layers"
 msgstr ""
 
-#: c2cgeoportal/models.py:419
+#: c2cgeoportal/models.py:435
 msgid "Query layers"
 msgstr ""
 
-#: c2cgeoportal/models.py:420
+#: c2cgeoportal/models.py:436
 msgid "KML 3D"
 msgstr ""
 
-#: c2cgeoportal/models.py:421
+#: c2cgeoportal/models.py:437
 msgid "Single tile"
 msgstr ""
 
-#: c2cgeoportal/models.py:422
+#: c2cgeoportal/models.py:438
 msgid "Display legend"
 msgstr ""
 
-#: c2cgeoportal/models.py:423
+#: c2cgeoportal/models.py:439
 msgid "Legend image"
 msgstr ""
 
-#: c2cgeoportal/models.py:424
+#: c2cgeoportal/models.py:440
 msgid "Legend rule"
 msgstr ""
 
-#: c2cgeoportal/models.py:425
+#: c2cgeoportal/models.py:441
 msgid "Legend expanded"
 msgstr ""
 
-#: c2cgeoportal/models.py:426
+#: c2cgeoportal/models.py:442
 msgid "Min resolution"
 msgstr ""
 
-#: c2cgeoportal/models.py:427
+#: c2cgeoportal/models.py:443
 msgid "Max resolution"
 msgstr ""
 
-#: c2cgeoportal/models.py:428
+#: c2cgeoportal/models.py:444
 msgid "Disclaimer"
 msgstr ""
 
-#: c2cgeoportal/models.py:430
+#: c2cgeoportal/models.py:446
 msgid "Identifier attribute field"
 msgstr ""
 
-#: c2cgeoportal/models.py:431
+#: c2cgeoportal/models.py:447
 msgid "Related Postgres table"
 msgstr ""
 
-#: c2cgeoportal/models.py:432
+#: c2cgeoportal/models.py:448
 msgid "Attributes to exclude"
 msgstr ""
 
-#: c2cgeoportal/models.py:438
+#: c2cgeoportal/models.py:454
 msgid "Time mode"
 msgstr ""
 
-#: c2cgeoportal/models.py:474
+#: c2cgeoportal/models.py:490
 msgid "restrictionarea"
 msgstr "Restriction Area"
 
-#: c2cgeoportal/models.py:475
+#: c2cgeoportal/models.py:491
 msgid "restrictionareas"
 msgstr "Restriction Areas"
 
-#: c2cgeoportal/models.py:486
+#: c2cgeoportal/models.py:502
 msgid "Read-write mode"
 msgstr ""
 
-#: c2cgeoportal/models.py:516
+#: c2cgeoportal/models.py:532
 msgid "parentrole"
 msgstr "Parent Role"
 
-#: c2cgeoportal/models.py:517
+#: c2cgeoportal/models.py:533
 msgid "parentroles"
 msgstr "Parent Roles"
 
@@ -276,6 +276,10 @@ msgstr "Loading..."
 msgid "search tip message"
 msgstr ""
 
+#: c2cgeoportal/scaffolds/create/+package+/templates/index.html_tmpl:16
+msgid "Application Title"
+msgstr ""
+
 #: c2cgeoportal/templates/login.html:6
 msgid "Login to Geoportal Application"
 msgstr ""
@@ -288,19 +292,25 @@ msgstr ""
 msgid "my translation test"
 msgstr "my translation test"
 
-#: c2cgeoportal/views/entry.py:76
+#: c2cgeoportal/views/entry.py:86
 msgid "title i18n"
 msgstr "I18n test"
 
-#: c2cgeoportal/views/entry.py:115
+#: c2cgeoportal/views/entry.py:139
 msgid ""
 "WARNING! an error occured while trying to read the mapfile and recover "
-"the themes"
+"the themes."
 msgstr ""
 
 #~ msgid "Display"
 #~ msgstr ""
 
 #~ msgid "Visible"
+#~ msgstr ""
+
+#~ msgid ""
+#~ msgstr ""
+
+#~ msgid "Geoportal Application Title"
 #~ msgstr ""
 

--- a/c2cgeoportal/locale/fr/LC_MESSAGES/c2cgeoportal.po
+++ b/c2cgeoportal/locale/fr/LC_MESSAGES/c2cgeoportal.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: c2cgeoportal 0.2\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2014-01-29 13:25+0100\n"
+"POT-Creation-Date: 2014-07-03 15:21+0200\n"
 "PO-Revision-Date: 2011-08-31 17:17+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: fr <LL@li.org>\n"
@@ -30,11 +30,11 @@ msgstr "Les mots de passe ne correspondent pas."
 msgid "Unlinked layers"
 msgstr "Couches non liées"
 
-#: c2cgeoportal/forms.py:413
+#: c2cgeoportal/forms.py:414
 msgid "Restriction area"
 msgstr "Aire de restriction"
 
-#: c2cgeoportal/forms.py:437
+#: c2cgeoportal/forms.py:435
 msgid "Extent"
 msgstr "Emprise"
 
@@ -46,9 +46,9 @@ msgstr "Fonctionalité"
 msgid "functionalitys"
 msgstr "Fonctionalités"
 
-#: c2cgeoportal/models.py:124 c2cgeoportal/models.py:244
-#: c2cgeoportal/models.py:292 c2cgeoportal/models.py:484
-#: c2cgeoportal/models.py:524
+#: c2cgeoportal/models.py:124 c2cgeoportal/models.py:255
+#: c2cgeoportal/models.py:303 c2cgeoportal/models.py:500
+#: c2cgeoportal/models.py:540
 msgid "Name"
 msgstr "Nom"
 
@@ -56,211 +56,211 @@ msgstr "Nom"
 msgid "Value"
 msgstr "Valeur"
 
-#: c2cgeoportal/models.py:160
+#: c2cgeoportal/models.py:171
 msgid "user"
 msgstr "Utilisateur"
 
-#: c2cgeoportal/models.py:161
+#: c2cgeoportal/models.py:172
 msgid "users"
 msgstr "Utilisateurs"
 
-#: c2cgeoportal/models.py:175 c2cgeoportal/templates/login.html:59
+#: c2cgeoportal/models.py:186 c2cgeoportal/templates/login.html:59
 msgid "Username"
 msgstr "Nom d'utilisateur"
 
-#: c2cgeoportal/models.py:178 c2cgeoportal/templates/login.html:62
+#: c2cgeoportal/models.py:189 c2cgeoportal/templates/login.html:62
 msgid "Password"
 msgstr "Mot de passe"
 
-#: c2cgeoportal/models.py:179
+#: c2cgeoportal/models.py:190
 msgid "E-mail"
 msgstr "E-mail"
 
-#: c2cgeoportal/models.py:180
+#: c2cgeoportal/models.py:191
 msgid "PasswordChanged"
 msgstr "Mot de passe modifié"
 
-#: c2cgeoportal/models.py:236
+#: c2cgeoportal/models.py:247
 msgid "role"
 msgstr "Rôle"
 
-#: c2cgeoportal/models.py:237
+#: c2cgeoportal/models.py:248
 msgid "roles"
 msgstr "Rôles"
 
-#: c2cgeoportal/models.py:245 c2cgeoportal/models.py:485
+#: c2cgeoportal/models.py:256 c2cgeoportal/models.py:501
 msgid "Description"
 msgstr "Description"
 
-#: c2cgeoportal/models.py:293
+#: c2cgeoportal/models.py:304
 msgid "Order"
 msgstr "Ordre"
 
-#: c2cgeoportal/models.py:294
+#: c2cgeoportal/models.py:305
 msgid "Metadata URL"
 msgstr "URL de métadonnée"
 
-#: c2cgeoportal/models.py:338
+#: c2cgeoportal/models.py:349
 msgid "layergroup"
 msgstr "Groupe de couches"
 
-#: c2cgeoportal/models.py:339
+#: c2cgeoportal/models.py:350
 msgid "layergroups"
 msgstr "Groupes de couches"
 
-#: c2cgeoportal/models.py:349
+#: c2cgeoportal/models.py:360
 msgid "Expanded"
 msgstr "Étendu"
 
-#: c2cgeoportal/models.py:350
+#: c2cgeoportal/models.py:361
 msgid "Internal WMS"
 msgstr "WMS interne"
 
-#: c2cgeoportal/models.py:352
+#: c2cgeoportal/models.py:363
 msgid "Group of base layers"
 msgstr "Groupe de couches de base"
 
-#: c2cgeoportal/models.py:364
+#: c2cgeoportal/models.py:375
 msgid "theme"
 msgstr "Thème"
 
-#: c2cgeoportal/models.py:365
+#: c2cgeoportal/models.py:376
 msgid "themes"
 msgstr "Thèmes"
 
-#: c2cgeoportal/models.py:375 c2cgeoportal/models.py:402
+#: c2cgeoportal/models.py:386 c2cgeoportal/models.py:418
 msgid "Icon"
 msgstr "Îcone"
 
-#: c2cgeoportal/models.py:376 c2cgeoportal/models.py:399
+#: c2cgeoportal/models.py:387 c2cgeoportal/models.py:415
 msgid "Display in mobile"
 msgstr ""
 
-#: c2cgeoportal/models.py:377 c2cgeoportal/models.py:400
+#: c2cgeoportal/models.py:388 c2cgeoportal/models.py:416
 msgid "Display in desktop"
 msgstr ""
 
-#: c2cgeoportal/models.py:386
+#: c2cgeoportal/models.py:402
 msgid "layer"
 msgstr "Couche"
 
-#: c2cgeoportal/models.py:387
+#: c2cgeoportal/models.py:403
 msgid "layers"
 msgstr "Couches"
 
-#: c2cgeoportal/models.py:398
+#: c2cgeoportal/models.py:414
 msgid "Public"
 msgstr "Publique"
 
-#: c2cgeoportal/models.py:401
+#: c2cgeoportal/models.py:417
 msgid "Checked"
 msgstr "Cochées"
 
-#: c2cgeoportal/models.py:408
+#: c2cgeoportal/models.py:424
 msgid "Type"
 msgstr "Type"
 
-#: c2cgeoportal/models.py:409
+#: c2cgeoportal/models.py:425
 msgid "Base URL"
 msgstr "URL de base"
 
-#: c2cgeoportal/models.py:413
+#: c2cgeoportal/models.py:429
 msgid "Image type"
 msgstr "Type d'image"
 
-#: c2cgeoportal/models.py:414
+#: c2cgeoportal/models.py:430
 msgid "Style"
 msgstr ""
 
-#: c2cgeoportal/models.py:415
+#: c2cgeoportal/models.py:431
 msgid "Dimensions"
 msgstr ""
 
-#: c2cgeoportal/models.py:416
+#: c2cgeoportal/models.py:432
 msgid "Matrix set"
 msgstr ""
 
-#: c2cgeoportal/models.py:417
+#: c2cgeoportal/models.py:433
 msgid "WMS server URL"
 msgstr "URL du serveur WMS"
 
-#: c2cgeoportal/models.py:418
+#: c2cgeoportal/models.py:434
 msgid "WMS layers"
 msgstr "Couches WMS"
 
-#: c2cgeoportal/models.py:419
+#: c2cgeoportal/models.py:435
 msgid "Query layers"
 msgstr "Couches à interroger"
 
-#: c2cgeoportal/models.py:420
+#: c2cgeoportal/models.py:436
 msgid "KML 3D"
 msgstr ""
 
-#: c2cgeoportal/models.py:421
+#: c2cgeoportal/models.py:437
 msgid "Single tile"
 msgstr "Tuile unique"
 
-#: c2cgeoportal/models.py:422
+#: c2cgeoportal/models.py:438
 msgid "Display legend"
 msgstr "Affiche la légende"
 
-#: c2cgeoportal/models.py:423
+#: c2cgeoportal/models.py:439
 msgid "Legend image"
 msgstr "Image de légende"
 
-#: c2cgeoportal/models.py:424
+#: c2cgeoportal/models.py:440
 msgid "Legend rule"
 msgstr ""
 
-#: c2cgeoportal/models.py:425
+#: c2cgeoportal/models.py:441
 msgid "Legend expanded"
 msgstr "Légende dépliée"
 
-#: c2cgeoportal/models.py:426
+#: c2cgeoportal/models.py:442
 msgid "Min resolution"
 msgstr "Résolution minimale"
 
-#: c2cgeoportal/models.py:427
+#: c2cgeoportal/models.py:443
 msgid "Max resolution"
 msgstr "Résolution maximale"
 
-#: c2cgeoportal/models.py:428
+#: c2cgeoportal/models.py:444
 msgid "Disclaimer"
 msgstr ""
 
-#: c2cgeoportal/models.py:430
+#: c2cgeoportal/models.py:446
 msgid "Identifier attribute field"
 msgstr "Nom du champ identifiant"
 
-#: c2cgeoportal/models.py:431
+#: c2cgeoportal/models.py:447
 msgid "Related Postgres table"
 msgstr "Table Postgres correspondante"
 
-#: c2cgeoportal/models.py:432
+#: c2cgeoportal/models.py:448
 msgid "Attributes to exclude"
 msgstr "Attributs à exclure"
 
-#: c2cgeoportal/models.py:438
+#: c2cgeoportal/models.py:454
 msgid "Time mode"
 msgstr "Mode temps"
 
-#: c2cgeoportal/models.py:474
+#: c2cgeoportal/models.py:490
 msgid "restrictionarea"
 msgstr "Aire de restriction"
 
-#: c2cgeoportal/models.py:475
+#: c2cgeoportal/models.py:491
 msgid "restrictionareas"
 msgstr "Aires de restriction"
 
-#: c2cgeoportal/models.py:486
+#: c2cgeoportal/models.py:502
 msgid "Read-write mode"
 msgstr "Mode lecture écriture"
 
-#: c2cgeoportal/models.py:516
+#: c2cgeoportal/models.py:532
 msgid "parentrole"
 msgstr "Rôle parent"
 
-#: c2cgeoportal/models.py:517
+#: c2cgeoportal/models.py:533
 msgid "parentroles"
 msgstr "Rôles parent"
 
@@ -276,6 +276,10 @@ msgstr "Chargement..."
 msgid "search tip message"
 msgstr ""
 
+#: c2cgeoportal/scaffolds/create/+package+/templates/index.html_tmpl:16
+msgid "Application Title"
+msgstr ""
+
 #: c2cgeoportal/templates/login.html:6
 msgid "Login to Geoportal Application"
 msgstr "Connexion a l'application Geoportal"
@@ -288,14 +292,14 @@ msgstr "Connexion"
 msgid "my translation test"
 msgstr "mon test de traduction"
 
-#: c2cgeoportal/views/entry.py:76
+#: c2cgeoportal/views/entry.py:86
 msgid "title i18n"
 msgstr "Test de l'i18n"
 
-#: c2cgeoportal/views/entry.py:115
+#: c2cgeoportal/views/entry.py:139
 msgid ""
 "WARNING! an error occured while trying to read the mapfile and recover "
-"the themes"
+"the themes."
 msgstr ""
 
 #~ msgid "Display"
@@ -303,4 +307,7 @@ msgstr ""
 
 #~ msgid "Visible"
 #~ msgstr "Visible"
+
+#~ msgid ""
+#~ msgstr ""
 

--- a/c2cgeoportal/scaffolds/create/+package+/templates/index.html_tmpl
+++ b/c2cgeoportal/scaffolds/create/+package+/templates/index.html_tmpl
@@ -13,7 +13,7 @@
             }
         </script>
 % endif
-        <title>{{package}} Geoportal Application</title>
+        <title>${_('Application Title')}</title>
         <link rel="shortcut icon" type="image/x-icon" href="${request.static_url('{{package}}:static/images/favicon.ico')}">
 
         <style>


### PR DESCRIPTION
Fix #807

The main change is the use of _() for translation the "Application Title" (as the page title) in the index.html_tmpl template.

I have not added default POT/PO files for the project as suggested in #807 because it is not complicated to create them following the instructions in the doc: http://docs.camptocamp.net/c2cgeoportal/master/integrator/internationalization.html#server

On the other hand it could be handy for people not very familiar with Gettext to have the base files with a few custom translations that they will most likely customize, such as the "Application Title". Should I proceed?
