### PR TITLE
Add project translations files last

### DIFF
--- a/c2cgeoportal/scaffolds/create/jsbuild/app.cfg_tmpl
+++ b/c2cgeoportal/scaffolds/create/jsbuild/app.cfg_tmpl
@@ -290,11 +290,12 @@ root =
     {{package}}/static/js
 first =
     OpenLayers/Lang/en.js
+last =
+    Proj/Lang/en.js
 include =
     Ext/src/locale/ext-lang-en.js
     Styler/lang/en.js
     locale/en.js #GXP
-    Proj/Lang/en.js
 exclude =
     OpenLayers/Lang.js
 
@@ -328,6 +329,9 @@ root =
     {{package}}/static/js
 first =
     OpenLayers/Lang/fr.js
+last =
+    Proj/Lang/fr.js
+    Proj/Lang/GeoExt-fr.js
 include =
     Ext/src/locale/ext-lang-fr.js
     GeoExt/locale/GeoExt-fr.js
@@ -337,8 +341,6 @@ include =
     ux/locale/StreetViewPanel-fr.js
     locale/fr.js #GXP
     CGXP/locale/fr.js
-    Proj/Lang/fr.js
-    Proj/Lang/GeoExt-fr.js
 exclude =
     OpenLayers/Lang.js
 
@@ -372,6 +374,9 @@ root =
     {{package}}/static/js
 first =
     OpenLayers/Lang/de.js
+last =
+    Proj/Lang/de.js
+    Proj/Lang/GeoExt-de.js
 include =
     Ext/src/locale/ext-lang-de.js
 #    GeoExt/locale/GeoExt-de.js
@@ -381,8 +386,6 @@ include =
     ux/locale/StreetViewPanel-de.js
     locale/de.js #GXP
     CGXP/locale/de.js
-    Proj/Lang/de.js
-    Proj/Lang/GeoExt-de.js
 exclude =
     OpenLayers/Lang.js
 

--- a/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -6,11 +6,22 @@ Version 1.5
 
 1. Update the `jsbuild/app.cfg` file.
 
-    * In the language sections [lang-fr.js], [lang-de.js] Add the following
+    * In the language sections [lang-fr.js], [lang-de.js] add the following
       localisation files (in `include`) respectively:
 
         ux/locale/StreetViewPanel-fr.js
         ux/locale/StreetViewPanel-de.js
+
+    * To make sure that custom translations always have priority, also
+      do the following changes in [lang-fr.js], [lang-de.js]:
+
+        + last =
+        +     Proj/Lang/<lang>.js
+        +     Proj/Lang/GeoExt-<lang>.js
+          include =
+              ...
+        -     Proj/Lang/<lang>.js
+        -     Proj/Lang/GeoExt-<lang>.js
 
 2. Update the `production.ini.in` and `development.ini.in` files:
 


### PR DESCRIPTION
In a project (SZ), we have noticed that the project-specific language files `Proj/Lang/de.js` and `Proj/Lang/GeoExt-de.js` were sometimes loaded before the standard translations that have them priority.

To avoid the problem, this PR suggests that those files are explicitely loaded last.
