### PR TITLE
Remove trailing comma

### DIFF
--- a/c2cgeoportal/scaffolds/update/+package+/static/mobile/app/controller/Main.js
+++ b/c2cgeoportal/scaffolds/update/+package+/static/mobile/app/controller/Main.js
@@ -333,7 +333,7 @@ Ext.define('App.controller.Main', {
                         layers: t.layers,
                         transparent: true
                     },{
-                        singleTile: true,
+                        singleTile: true
                     }
                 );
                 App.map.addLayer(overlay);


### PR DESCRIPTION
Using version 1.5.0rc2 and running the Sencha cmd (build mobile app), one gets a warning from the Sencha cmd:

```
[WRN] C1000: Rhino Parse Warning (Trailing comma is not legal in an ECMA-262 object initializer =>                     }
) -- D:\Applications\Mapfish\sitn_internet\sitn\static\mobile\app\controller\Main.js:337:21
```

Removing the trailing comma resolves this.

Please review (and eventually merge if you agree...)
