### PR TITLE
Make sure the cached list of private layers is kept unchanged

### DIFF
--- a/c2cgeoportal/lib/filter_capabilities.py
+++ b/c2cgeoportal/lib/filter_capabilities.py
@@ -155,7 +155,7 @@ def filter_capabilities(content, role_id, wms, wms_url, headers, proxies):
         enable_proxies(proxies)
 
     wms_structure = _wms_structure(wms_url, headers.get('Host', None))
-    tmp_private_layers = _get_private_layers()
+    tmp_private_layers = list(_get_private_layers())
     for name in _get_protected_layers(role_id):
         tmp_private_layers.remove(name)
 


### PR DESCRIPTION
Function _get_private_layers() returns the list of non public layers. To avoid subsequent DB queries, its result is dogpile cached.

The list of layers is then manipulated (the layers that are actually accessible to the current user are removed). The problem is that the cached list is impacted by those changes. Which means that the next time the cached list is called, it is no longer in its initial status (layers may be missing).

To avoid this issue, the PR makes sure the cached list is not directly manipulated, only a copy.
