### PR TITLE
Add example of iconOffset in API

### DIFF
--- a/c2cgeoportal/scaffolds/create/+package+/static/apihelp/MonFichier.txt
+++ b/c2cgeoportal/scaffolds/create/+package+/static/apihelp/MonFichier.txt
@@ -1,6 +1,0 @@
-point	title	description	icon	iconSize
-216300,553000	Information	Office de l'information<br />Tél: 032 000 00 00<br>Email: <a href="mailto:info@example.com">info@example.com</a><br />Internet: <a href="http://fr.wikipedia.org/wiki/La_Chaux-de-Fonds" target=new>Cliquer ici</a>	http://openlayers.org/dev/img/marker.png	21,25
-215600,554250	Ma première station	Diesel pas cher	http://openlayers.org/dev/img/marker-blue.png	21,25
-215864,552556	Mon parking	C'est celui-là le meilleur.	http://openlayers.org/dev/img/marker-gold.png	21,25
-217126,554489	Mon parking	Ce parking est<br/>le meillleur.	http://openlayers.org/dev/img/marker-gold.png	21,25
-217326,554089	Ma deuxième station	Sans-plomb pas cher.	http://openlayers.org/dev/img/marker-blue.png	21,25

--- a/c2cgeoportal/scaffolds/create/+package+/static/apihelp/data.txt
+++ b/c2cgeoportal/scaffolds/create/+package+/static/apihelp/data.txt
@@ -1,0 +1,6 @@
+point	title	description	icon	iconSize	iconOffset
+216300,553000	Information	Office de l'information<br />Tél: 032 000 00 00<br>Email: <a href="mailto:info@example.com">info@example.com</a><br />Internet: <a href="http://fr.wikipedia.org/wiki/La_Chaux-de-Fonds" target=new>Cliquer ici</a>	http://openlayers.org/dev/img/marker.png	21,25	-10.5,-12.5
+215600,554250	Ma première station	Diesel pas cher	http://openlayers.org/dev/img/marker-blue.png	21,25	-10.5,-12.5
+215864,552556	Mon parking	C'est celui-là le meilleur.	http://openlayers.org/dev/img/marker-gold.png	21,25	-10.5,-12.5
+217126,554489	Mon parking	Ce parking est<br/>le meillleur.	http://openlayers.org/dev/img/marker-gold.png	21,25	-10.5,-12.5
+217326,554089	Ma deuxième station	Sans-plomb pas cher.	http://openlayers.org/dev/img/marker-blue.png	21,25	-10.5,-12.5

--- a/c2cgeoportal/scaffolds/create/+package+/templates/api/apihelp.html_tmpl
+++ b/c2cgeoportal/scaffolds/create/+package+/templates/api/apihelp.html_tmpl
@@ -193,13 +193,13 @@ map.addCustomLayer('gpx', 'My GPX layer', '${request.static_path('{{package}}:st
 
 <div class="api">
     <h2>Load data from a text file</h2>
-    See <a href="${request.static_path('{{package}}:static/apihelp/MonFichier.txt')}" target="_blank">MonFichier.txt</a>.
+    See <a href="${request.static_path('{{package}}:static/apihelp/data.txt')}" target="_blank">data.txt</a>.
     <br />
     <div id='map9' class="map"></div>
     <pre data-language="javascript">var map = new {{package}}.Map({
     div: 'map9'
 });
-map.addCustomLayer('text', 'My custom txt layer', '${request.static_path('{{package}}:static/apihelp/MonFichier.txt')}');
+map.addCustomLayer('text', 'My custom txt layer', '${request.static_path('{{package}}:static/apihelp/data.txt')}');
 </pre>
 </div>
 


### PR DESCRIPTION
This PR:
- renames MonFIchier.txt to data.txt in order to be consistent with the project using english as main language.
- adds example of iconOffset in this example txt data file.

Actually the added offset are the default ones anyway:
https://github.com/openlayers/openlayers/blob/master/lib/OpenLayers/Format/Text.js#L59-L60
but at least it makes the example more explict on what to do when using icons with another size.
