### PR TITLE
remove limite of 1000 characters in url stored in shorturl table

### DIFF
--- a/c2cgeoportal/models.py
+++ b/c2cgeoportal/models.py
@@ -551,7 +551,7 @@ class Shorturl(Base):
     __table_args__ = {'schema': _schema + "_static"}
     __acl__ = [DENY_ALL]
     id = Column(types.Integer, primary_key=True)
-    url = Column(types.Unicode(1000))
+    url = Column(types.Unicode)
     ref = Column(types.String(20), index=True, unique=True, nullable=False)
     creator_email = Column(types.Unicode(200))
     creation = Column(types.DateTime)

--- a/c2cgeoportal/scaffolds/update/+package+/CONST_migration/versions/019_Alter_column_url_to_remove_limitation.py
+++ b/c2cgeoportal/scaffolds/update/+package+/CONST_migration/versions/019_Alter_column_url_to_remove_limitation.py
@@ -1,0 +1,11 @@
+from sqlalchemy import MetaData, Table, types
+
+from c2cgeoportal import schema
+
+def upgrade(migrate_engine):
+    meta = MetaData(bind=migrate_engine)
+    table = Table('shorturl', meta, schema='%s_static' % schema, autoload=True)
+    table.c.url.alter(type=types.Unicode)
+
+def downgrade(migrate_engine):
+    pass


### PR DESCRIPTION
browsers, even IE, support more than that (>2000),
after discussion with Stephane, we decided to remove completely the limitation
