### PR TITLE
Mobile crosshair

### DIFF
--- a/c2cgeoportal/scaffolds/create/+package+/static/mobile/config.js_tmpl
+++ b/c2cgeoportal/scaffolds/create/+package+/static/mobile/config.js_tmpl
@@ -8,6 +8,7 @@
  */
 
 OpenLayers.Lang.setCode("${lang}");
+OpenLayers.ImgPath = "${request.static_url('{{package}}:static/lib/cgxp/core/src/theme/img/ol/')}";
 
 var dummy = "<% from json import dumps %>";
 jsonFormat = new OpenLayers.Format.JSON();

--- a/c2cgeoportal/scaffolds/update/+package+/static/mobile/app/controller/Main.js
+++ b/c2cgeoportal/scaffolds/update/+package+/static/mobile/app/controller/Main.js
@@ -345,5 +345,39 @@ Ext.define('App.controller.Main', {
                 return false;
             }
         }, this);
+    },
+
+    setCenterCrosshair: function(lonlat, zoom) {
+
+        var map = this.getMainView().getMap();
+
+        var path =  App.crosshair_options && App.crosshair_options.path
+            || OpenLayers.ImgPath + 'crosshair.png';
+        var width =  App.crosshair_options && App.crosshair_options.size
+            && App.marker_options.size[0] || 16;
+        var height =  App.crosshair_options && App.crosshair_options.size
+            && App.crosshair_options.size[1] || 16;
+
+        var style = OpenLayers.Util.applyDefaults({
+            externalGraphic: path,
+            graphicWidth: width,
+            graphicHeight: height,
+            graphicXOffset: -width/2,
+            graphicYOffset: -height/2,
+            graphicOpacity: 1
+        }, OpenLayers.Feature.Vector.style['default']);
+
+        var layer = new OpenLayers.Layer.Vector('Crosshair');
+
+        layer.addFeatures([
+            new OpenLayers.Feature.Vector(
+                new OpenLayers.Geometry.Point(lonlat[0], lonlat[1]),
+                null,
+                style
+            )
+        ]);
+        map.setCenter(lonlat, zoom);
+        map.addLayer(layer);
     }
+
 });

--- a/c2cgeoportal/scaffolds/update/+package+/static/mobile/app/plugin/StatefulMap.js
+++ b/c2cgeoportal/scaffolds/update/+package+/static/mobile/app/plugin/StatefulMap.js
@@ -70,7 +70,11 @@ Ext.define('App.plugin.StatefulMap', {
                     }, 1);
                 }
                 if (state.lonlat) {
-                    map.setCenter(state.lonlat, state.zoom);
+                    if (state.crosshair === 1) {
+                        main.setCenterCrosshair(state.lonlat, state.zoom);
+                    } else {
+                        map.setCenter(state.lonlat, state.zoom);
+                    }
                 }
                 map.events.on({
                     moveend: this.update,
@@ -117,6 +121,9 @@ Ext.define('App.plugin.StatefulMap', {
         if (q.map_x && q.map_y) {
             state.lonlat = [ q.map_x, q.map_y ];
             state.zoom = q.map_zoom;
+            if (q.map_crosshair) {
+                state.crosshair = 1;
+            }
         }
         return state;
     },

--- a/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -106,6 +106,9 @@ Version 1.6
     +% if bounds:
     +    var INITIAL_EXTENT = ${dumps(bounds)};
 
+12. In the `{{package}}/static/mobile/config.js` add the following line at the top of the file:
+
+    +OpenLayers.ImgPath = "${request.static_url('{{package}}:static/lib/cgxp/core/src/theme/img/ol/')}";
 
 Version 1.5.2
 =============

--- a/doc/integrator/mobile.rst
+++ b/doc/integrator/mobile.rst
@@ -178,6 +178,33 @@ to be adapted to the data retrieved from the server:
 In the example above ``mns`` and ``mnt`` are the keys used in the server
 config for the ``raster web services``.
 
+Permalink crosshair
+-------------------
+
+A crosshair can be shown on the map when requesting the mobile application. To
+do so, the following parameters have to be defined in the called URL:
+
+* ``map_zoom``: map some level
+* ``map_x``: x coordinate on which the marker will be placed
+* ``map_y``: y coordinate on which the marker will be placed
+* ``map_crosshair``: set to a value (e.g. ``map_crosshair=1``)
+
+By default, the OpenLayers default marker will be used.
+
+To use a custom marker, do the following changes in the ``static/mobile/config.js``
+file:
+
+* Set ``OpenLayers.ImgPath`` to the path where you custom marker is.
+* Define the following new variable::
+
+      App.crosshair_options = {
+          'path': OpenLayers.ImgPath+'custom_marker.png',
+          'size': [image_width, image_height]
+      };
+
+Where ``image_width`` and ``image_height`` are respectively the width and the
+height of the crosshair image.
+
 Settings view
 -------------
 


### PR DESCRIPTION
This PR adds the possibility to display a crosshair (`map_crosshair`) when calling the mobile app.

Currently it only implements the `map_crosshair` URL variable for the mobile app.

Please review