### PR TITLE
Add pdfreport webservice

### DIFF
--- a/c2cgeoportal/__init__.py
+++ b/c2cgeoportal/__init__.py
@@ -290,6 +290,9 @@ def includeme(config):
     config.add_route('shortener_create', '/short/create')
     config.add_route('shortener_get', '/short/{ref}')
 
+    # PDF report tool
+    config.add_route('pdfreport', '/pdfreport/{layername}/{id:\d+}')
+
     # add routes for the "layers" web service
     config.add_route(
         'layers_count', '/layers/{layer_id:\\d+}/count',

--- a/c2cgeoportal/lib/filter_capabilities.py
+++ b/c2cgeoportal/lib/filter_capabilities.py
@@ -53,13 +53,13 @@ log = logging.getLogger(__name__)
 
 
 @cache_region.cache_on_arguments()
-def _get_protected_layers(role_id):
+def get_protected_layers(role_id):
     q = get_protected_layers_query(role_id, distinct(Layer.name))
     return [r for r, in q.all()]
 
 
 @cache_region.cache_on_arguments()
-def _get_private_layers():
+def get_private_layers():
     q = DBSession.query(Layer.name).filter(Layer.public.is_(False))
     return [r for r, in q.all()]
 
@@ -155,8 +155,8 @@ def filter_capabilities(content, role_id, wms, wms_url, headers, proxies):
         enable_proxies(proxies)
 
     wms_structure = _wms_structure(wms_url, headers.get('Host', None))
-    tmp_private_layers = list(_get_private_layers())
-    for name in _get_protected_layers(role_id):
+    tmp_private_layers = list(get_private_layers())
+    for name in get_protected_layers(role_id):
         tmp_private_layers.remove(name)
 
     private_layers = set()

--- a/c2cgeoportal/views/pdfreport.py
+++ b/c2cgeoportal/views/pdfreport.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2011-2015, Camptocamp SA
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# The views and conclusions contained in the software and documentation are those
+# of the authors and should not be interpreted as representing official policies,
+# either expressed or implied, of the FreeBSD Project.
+
+from pyramid.view import view_config
+from pyramid.response import Response
+from pyramid.httpexceptions import HTTPBadGateway, HTTPForbidden, \
+    HTTPInternalServerError
+
+import httplib2
+from urlparse import urlparse
+from json import dumps, loads
+
+from c2cgeoportal.lib.filter_capabilities import get_protected_layers, \
+    get_private_layers
+
+import logging
+log = logging.getLogger(__name__)
+
+
+class PdfReport:  # pragma: no cover
+
+    def __init__(self, request):
+        self.request = request
+        self.config = self.request.registry.settings.get('pdfreport', {})
+
+    def do_print(self, spec):
+        """ Get created PDF. """
+        url = self.config['print_url'] + "/print/buildreport.pdf"
+        http = httplib2.Http()
+        h = dict(self.request.headers)
+        h["Content-Type"] = "application/json"
+        if urlparse(url).hostname != 'localhost':
+            h.pop('Host')
+        try:
+            resp, content = http.request(
+                url, method='POST', headers=h, body=dumps(spec)
+            )
+        except:
+            return HTTPBadGateway()
+
+        headers = {}
+        if 'content-type' in resp:
+            headers['content-type'] = resp['content-type']
+        if 'content-disposition' in resp:
+            headers['content-disposition'] = resp['content-disposition']
+        return Response(
+            content, status=resp.status, headers=headers
+        )
+
+    @view_config(route_name='pdfreport', renderer="json")
+    def getreport(self):
+        id = int(self.request.matchdict['id'])
+        layername = self.request.matchdict['layername']
+        featureid = layername + "." + str(id)
+
+        # check user credentials
+        role_id = None if self.request.user is None else \
+            self.request.user.role.id
+
+        # FIXME: support of mapserver groups
+        if layername in get_private_layers() and \
+                layername not in get_protected_layers(role_id):
+            raise HTTPForbidden
+
+        srs = self.config.get('srs')
+        if srs is None:
+            raise HTTPInternalServerError(
+                'Missing "srs" in service configuration'
+            )
+        params = {
+            'service': 'WFS',
+            'version': '1.0.0',
+            'request': 'GetFeature',
+            'typeName': layername,
+            'featureid': featureid,
+            'srsName': srs
+        }
+
+        mapserv_url = self.request.route_url('mapserverproxy')
+        vector_request_url = mapserv_url + "?" \
+            + "&".join(["%s=%s" % i for i in params.items()])
+
+        backgroundlayers = self.config.get("layers", {}). \
+            get(layername, {}).get('backgroundlayers')
+        if backgroundlayers is None:
+            backgroundlayers = self.config.get('default_backgroundlayers', '""')
+
+        imageformat = self.config.get("layers", {}). \
+            get(layername, {}).get('imageformat')
+        if imageformat is None:
+            imageformat = self.config.get('default_imageformat', 'image/png')
+
+        spec_template = self.config.get("spec_template")
+        if spec_template is None:
+            spec_template = {
+                "layout": "%(layername)s",
+                "outputFormat": "pdf",
+                "attributes": {
+                    "paramID": "%(id)d",
+                    "map": {
+                        "projection": "%(srs)s",
+                        "dpi": 254,
+                        "rotation": 0,
+                        "bbox": [0, 0, 1000000, 1000000],
+                        "zoomToFeatures": {
+                            "zoomType": "center",
+                            "layer": "vector",
+                            "minScale": 25000
+                        },
+                        "layers": [{
+                            "type": "gml",
+                            "name": "vector",
+                            "style": {
+                                "version": "2",
+                                "[1 > 0]": {
+                                    "fillColor": "red",
+                                    "fillOpacity": 0.2,
+                                    "symbolizers": [{
+                                        "strokeColor": "red",
+                                        "strokeWidth": 1,
+                                        "type": "point",
+                                        "pointRadius": 10
+                                    }]
+                                }
+                            },
+                            "opacity": 1,
+                            "url": "%(vector_request_url)s"
+                        }, {
+                            "baseURL": "%(mapserv_url)s",
+                            "opacity": 1,
+                            "type": "WMS",
+                            "serverType": "mapserver",
+                            "layers": ["%(backgroundlayers)s"],
+                            "imageFormat": "%(imageformat)s"
+                        }]
+                    }
+                }
+            }
+        spec = dumps(spec_template) % {
+            'layername': layername, 'id': id, 'srs': srs,
+            'mapserv_url': mapserv_url,
+            'vector_request_url': vector_request_url,
+            'imageformat': imageformat,
+            'backgroundlayers': backgroundlayers
+        }
+
+        return self.do_print(loads(spec))

--- a/doc/integrator/features.rst
+++ b/doc/integrator/features.rst
@@ -34,3 +34,4 @@ Features that require additional steps (most of the time):
    shortener
    intranet
    security
+   pdfreport

--- a/doc/integrator/pdfreport.rst
+++ b/doc/integrator/pdfreport.rst
@@ -1,0 +1,107 @@
+.. _integrator_pdfreport:
+
+PDF Reporting
+=============
+
+c2cgeoportal offers a *pdfreport* webservice that can be used to generate
+advanced PDF reports about a given feature.
+
+It is based upon `MapfishPrint version 3 <http://mapfish.github.io/mapfish-print-doc/>`_
+and `Jasper Reports <http://community.jaspersoft.com/project/jasperreports-library>`_.
+
+The webservice is called using the following URL schema:
+``http://<host>/<instanceid>/wsgi/pdfreport/<layername>/<featureid>``.
+
+Configuration
+-------------
+
+The service is configured in the main ``config.yaml.in`` file of the project
+as in the following example:
+
+.. code-block:: yaml
+
+    pdfreport:
+        print_url: http://localhost:8080/print-c2cgeoportal-${vars:instanceid} 
+        default_backgroundlayers: "grp_ly_tilegenerierung_landeskarte"
+        default_imageformat: "image/png"
+        srs: "EPSG:21781"
+        layers: 
+            ly_a020_belastete_standorte_point: 
+                backgroundlayers: "grp_ly_tilegenerierung_landeskarte,ly_a020_belastete_standorte_point"
+                imageformat: "image/jpeg"
+        spec_template: <optional spec template>
+
+
+with the following parameters:
+
+* ``print_url`` is the local URL of the MapFish Print version 3 instance.
+* ``default_backgroundlayers`` and ``default_imageformat`` are default values used when the corresponding parameters are not provided for a given layer.
+* ``srs`` is the code of the used projection
+* ``layers`` is an optional per-layer list of settings specific to the listed layers. The entries of the list are the layernames provided as argument of the webservice. If a layer is not listed, the default parameters above are used.
+* ``backgroundlayers`` is a string containing a comma-separated list of WMS layers that should be displayed on the map. If the curent layer must also be displayed, it should be added to the list. Please note that layernames must be embedded in double-quotes (").
+* ``spec_template`` is an optional JSON template used to build the ``spec`` argument sent to the MapFish Print webapp.
+
+If no ``spec_template`` is specified, the following template is used:
+
+.. code-block:: json
+
+    {
+        "layout": "%(layername)s",
+        "outputFormat": "pdf",
+        "attributes": {
+            "paramID": "%(id)d",
+            "map": {
+                "projection": "%(srs)s",
+                "dpi": 254,
+                "rotation": 0,
+                "bbox": [0, 0, 1000000, 1000000],
+                "zoomToFeatures": {
+                    "zoomType": "center",
+                    "layer": "vector",
+                    "minScale": 25000
+                },  
+                "layers": [{
+                    "type": "gml",
+                    "name": "vector",
+                    "style": {
+                        "version": "2",
+                        "[1 > 0]": {
+                            "fillColor": "red",
+                            "fillOpacity": 0.2,
+                            "symbolizers": [{
+                                "strokeColor": "red",
+                                "strokeWidth": 1,
+                                "type": "point",
+                                "pointRadius": 10
+                            }]  
+                        }   
+                    },  
+                    "opacity": 1,
+                    "url": "%(vector_request_url)s"
+                }, {
+                    "baseURL": "%(mapserv_url)s",
+                    "opacity": 1,
+                    "type": "WMS",
+                    "serverType": "mapserver",
+                    "layers": ["%(backgroundlayers)s"],
+                    "imageFormat": "%(imageformat)s"
+                }]  
+            }   
+        }   
+    }
+
+Variables may be inserted using the ``%(<variable name>)s`` syntax. The following
+variables values are passed to the template:
+
+* ``layername``: name of the layer
+* ``id``: feature id
+* ``srs``: projection code as passed using the ``srs`` parameter in ``config.yaml.in``
+* ``mapserv_url``: URL of the MapServer proxy
+* ``vector_request_url``: URL of the WFS GetFeature request retrieving the feature geometry in GML
+* ``imageformat``: format of the WMS layer
+* ``backgroundlayers``: WMS layers to display on the map (including the current layer)
+
+Configuration of the reports
+----------------------------
+
+See the `Mapfish Print documentation <http://mapfish.github.io/mapfish-print-doc/>`_.


### PR DESCRIPTION
This webservice allows the users to get a full PDF report concerning a given feature (layername+id), using  MapFish Print 3 and some jasper reports.

WIP, still TODO:
* handling mapserver groups