### PR TITLE
Fix typo in CONST_Makefile

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -29,7 +29,7 @@ DEFAULT_WEB_RULE += sencha-touch
 endif
 ifeq ($(NGEO), TRUE)
 DEFAULT_WEB_RULE += build-ngeo
-CLIENT_CHECH_RULE ?= lint-ngeo
+CLIENT_CHECK_RULE ?= lint-ngeo
 endif
 WEB_RULE ?= $(DEFAULT_WEB_RULE)
 


### PR DESCRIPTION
Because of this typo the js code is not linted on make checks.