### PR TITLE
Add proxy for TinyOWS

### DIFF
--- a/c2cgeoportal/__init__.py
+++ b/c2cgeoportal/__init__.py
@@ -457,6 +457,11 @@ def includeme(config):
         custom_predicates=(mapserverproxy_route_predicate,),
         pregenerator=MultiDomainPregenerator())
 
+    # add route to the tinyows proxy
+    config.add_route(
+        'tinyowsproxy', '/tinyows_proxy',
+        pregenerator=MultiDomainPregenerator())
+
     # add routes to csv view
     config.add_route("csvecho", "/csv")
 

--- a/c2cgeoportal/__init__.py
+++ b/c2cgeoportal/__init__.py
@@ -459,7 +459,7 @@ def includeme(config):
 
     # add route to the tinyows proxy
     config.add_route(
-        'tinyowsproxy', '/tinyows_proxy',
+        "tinyowsproxy", "/tinyows_proxy",
         pregenerator=MultiDomainPregenerator())
 
     # add routes to csv view

--- a/c2cgeoportal/lib/__init__.py
+++ b/c2cgeoportal/lib/__init__.py
@@ -77,7 +77,7 @@ def get_setting(settings, path, default=None):
     return value if value else default
 
 
-def get_protected_layers_query(role_id, what=None, version=1):
+def _get_layers_query(role_id, what=None, version=1):
     from c2cgeoportal.models import DBSession, LayerV1, \
         Layer, RestrictionArea, Role, layer_ra, role_ra, \
         LayerInternalWMS, LayerExternalWMS, LayerWMTS
@@ -95,7 +95,20 @@ def get_protected_layers_query(role_id, what=None, version=1):
         (role_ra, role_ra.c.restrictionarea_id == RestrictionArea.id),
         (Role, Role.id == role_ra.c.role_id))
     q = q.filter(Role.id == role_id)
+
+    return q
+
+
+def get_protected_layers_query(role_id, what=None, version=1):
+    from c2cgeoportal.models import Layer
+    q = _get_layers_query(role_id, what, version)
     return q.filter(Layer.public.is_(False))
+
+
+def get_writable_layers_query(role_id, what=None, version=1):
+    from c2cgeoportal.models import RestrictionArea
+    q = _get_layers_query(role_id, what, version)
+    return q.filter(RestrictionArea.readwrite.is_(True))
 
 
 @implementer(IRoutePregenerator)

--- a/c2cgeoportal/lib/filter_capabilities.py
+++ b/c2cgeoportal/lib/filter_capabilities.py
@@ -184,7 +184,7 @@ def filter_capabilities(content, role_id, wms, wms_url, headers, proxies):
     return unicode(result.getvalue(), "utf-8")
 
 
-def filter_wfst_capabilities(content, role_id, wfs_url, headers, proxies):
+def filter_wfst_capabilities(content, role_id, wfs_url, proxies):
 
     if proxies:  # pragma: no cover
         enable_proxies(proxies)

--- a/c2cgeoportal/lib/filter_capabilities.py
+++ b/c2cgeoportal/lib/filter_capabilities.py
@@ -193,14 +193,14 @@ def filter_wfst_capabilities(content, role_id, wfs_url, proxies):
 
     parser = sax.make_parser()
     result = StringIO()
-    downstream_handler = XMLGenerator(result, 'utf-8')
+    downstream_handler = XMLGenerator(result, "utf-8")
     filter_handler = _CapabilitiesFilter(
         parser, downstream_handler,
-        u'FeatureType',
+        u"FeatureType",
         layers_whitelist=writable_layers
     )
     filter_handler.parse(StringIO(content))
-    filtered_content = unicode(result.getvalue(), 'utf-8')
+    filtered_content = unicode(result.getvalue(), "utf-8")
     return filtered_content
 
 
@@ -228,11 +228,11 @@ class _CapabilitiesFilter(XMLFilterBase):
         self._accumulator = []
 
         assert layers_blacklist is not None or layers_whitelist is not None, \
-            'either layers_blacklist OR layers_whitelist must be set'
+            "either layers_blacklist OR layers_whitelist must be set"
         assert not (
             layers_blacklist is not None and
             layers_whitelist is not None), \
-            'only either layers_blacklist OR layers_whitelist can be set'
+            "only either layers_blacklist OR layers_whitelist can be set"
         self.layers_blacklist = layers_blacklist
         self.layers_whitelist = layers_whitelist
 
@@ -335,8 +335,8 @@ def normalize_tag(tag):
     """
     normalized = tag
     if len(tag) >= 3:
-        if tag[0] == '{':
-            normalized = tag[1:].split('}')[1]
+        if tag[0] == "{":
+            normalized = tag[1:].split("}")[1]
     return normalized.lower()
 
 
@@ -346,6 +346,6 @@ def normalize_typename(typename):
     e.g. 'tows:parks' -> 'parks'
     """
     normalized = typename
-    if ':' in typename:
-        normalized = typename.split(':')[1]
+    if ":" in typename:
+        normalized = typename.split(":")[1]
     return normalized.lower()

--- a/c2cgeoportal/scaffolds/create/+dot+gitignore_tmpl
+++ b/c2cgeoportal/scaffolds/create/+dot+gitignore_tmpl
@@ -9,6 +9,7 @@
 /apache/frontend.conf
 /apache/mapserver.conf
 /apache/wsgi.conf
+/apache/tinyows.conf
 /apache/application.wsgi
 /deploy/deploy.cfg
 /alembic.ini
@@ -20,6 +21,7 @@
 /print/WEB-INF/lib/*.jar
 /print/WEB-INF/classes/logback.xml
 /mapserver/c2cgeoportal.map
+/mapserver/tinyows.xml
 /deploy/hooks/post-restore-database
 /{{package}}/static/build/
 /{{package}}/locale/*/LC_MESSAGES/*.mo

--- a/c2cgeoportal/scaffolds/create/apache/tinyows.conf.mako
+++ b/c2cgeoportal/scaffolds/create/apache/tinyows.conf.mako
@@ -1,0 +1,12 @@
+# to enable TinyOWS uncomment the following lines
+
+# ScriptAlias /${instanceid}/tinyows /usr/lib/cgi-bin/tinyows
+# <Location /${instanceid}/tinyows>
+#   SetEnv TINYOWS_CONFIG_FILE ${directory}/mapserver/tinyows.xml
+#
+#   # restrict access to localhost so that all requests go through the proxy
+#   Options All
+#   Order deny,allow
+#   Deny from all
+#   Allow from 127.0.0.1 ::1
+# </Location>

--- a/c2cgeoportal/scaffolds/create/mapserver/tinyows.xml.mako
+++ b/c2cgeoportal/scaffolds/create/mapserver/tinyows.xml.mako
@@ -1,0 +1,36 @@
+<tinyows
+    online_resource="http://${host}/${instanceid}/wsgi/tinyows_proxy"
+    schema_dir="/usr/share/tinyows/schema/"
+    log="tinyows.log"
+    log_level="1"
+    check_schema="0">
+
+  <contact
+      name="GeoMapFish"
+      site="http://www.geomapfish.org/"
+      email="geomapfish@googlegroups.com" />
+
+  <metadata
+      name="GeoMapFish TinyOWS Server"
+      title="GeoMapFish TinyOWS Server" />
+
+  <pg
+      host="${dbhost}"
+      user="${dbuser}"
+      password="${dbpassword}"
+      port="${dbport}"
+      dbname="${db}" />
+
+<!--
+  <layer
+      retrievable="1"
+      writable="1"
+      ns_prefix="tows"
+      ns_uri="http://www.tinyows.org/"
+      name="point"
+      schema="edit"
+      table="point"
+      title="Points"
+      pkey="id" />
+-->
+</tinyows>

--- a/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -251,7 +251,7 @@ CONFIG_VARS += sqlalchemy.url schema parentschema enable_admin_interface pyramid
 	node_modules_path closure_library_path default_locale_name servers layers \
 	available_locale_names cache admin_interface functionalities external_themes_url \
 	raster shortener hide_capabilities use_security_metadata mapserverproxy \
-	print_url tiles_url checker check_collector default_max_age jsbuild package srid
+	tinyowsproxy print_url tiles_url checker check_collector default_max_age jsbuild package srid
 ENVIRONMENT_VARS += INSTANCE_ID=${INSTANCE_ID} \
 	APACHE_ENTRY_POINT=$(APACHE_ENTRY_POINT) \
 	DEVELOPMENT=${DEVELOPMENT} \

--- a/c2cgeoportal/scaffolds/update/CONST_vars.yaml_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_vars.yaml_tmpl
@@ -172,6 +172,21 @@ vars:
         # external_mapserv_wfs_url parameter
         #external_mapserv_wfs_url:
 
+    tinyowsproxy:
+        # URL to internal TinyOWS instance
+        tinyows_url: http://localhost/{instanceid}/tinyows
+
+        # If the `online_resource` url in the TinyOWS configuration is not set
+        # to the TinyOWS proxy url (e.g. when the service is also used without
+        # the proxy), the proxy can replace the original `online_resource`
+        # url with the proxy url.
+        # proxy_online_resource: http://{host}/{instanceid}/tinyows_proxy
+        # online_resource: http://localhost/{instanceid}/tinyows
+
+        # When running a c2cgeoportal appl. in debug mode (with `make serve`)
+        # the host has to be set explicitly in a vhost environment.
+        # tinyows_host: {host}
+
     servers:
 
     # The "raster web services" configuration. See the "raster"

--- a/c2cgeoportal/tests/__init__.py
+++ b/c2cgeoportal/tests/__init__.py
@@ -43,3 +43,8 @@ def create_dummy_request(additional_settings={}, *args, **kargs):
     }
     request.registry.settings.update(additional_settings)
     return request
+
+
+def load_file(file_name):
+    with open(file_name) as file:
+        return file.read()

--- a/c2cgeoportal/tests/data/tinyows_describefeaturetype_request.xml
+++ b/c2cgeoportal/tests/data/tinyows_describefeaturetype_request.xml
@@ -1,0 +1,10 @@
+<DescribeFeatureType
+  service="WFS"
+  version="1.1.0"
+  xmlns="http://www.opengis.net/wfs"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:tows="http://www.tinyows.org/"
+  xsi:schemaLocation="http://www.opengis.net/wfs
+  http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
+    <TypeName>tows:layer_1</TypeName>
+</DescribeFeatureType>

--- a/c2cgeoportal/tests/data/tinyows_describefeaturetype_request_multiple.xml
+++ b/c2cgeoportal/tests/data/tinyows_describefeaturetype_request_multiple.xml
@@ -1,0 +1,11 @@
+<DescribeFeatureType
+  service="WFS"
+  version="1.1.0"
+  xmlns="http://www.opengis.net/wfs"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:tows="http://www.tinyows.org/"
+  xsi:schemaLocation="http://www.opengis.net/wfs
+  http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
+    <TypeName>tows:layer_1</TypeName>
+    <TypeName>tows:layer_2</TypeName>
+</DescribeFeatureType>

--- a/c2cgeoportal/tests/data/tinyows_getcapabilities.xml
+++ b/c2cgeoportal/tests/data/tinyows_getcapabilities.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WFS_Capabilities xmlns="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" version="1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" updateSequence="0" xsi:schemaLocation="http://www.opengis.net/wfs  http://schemas.opengis.net/wfs/1.0.0/WFS-capabilities.xsd">
+ <Service>
+  <Name>TinyOWS Server</Name>
+  <Title>TinyOWS Server - Test</Title>
+  <OnlineResource>http://server.com/tinyows</OnlineResource>
+ </Service>
+ <Capability>
+  <Request>
+   <GetCapabilities>
+    <DCPType>
+     <HTTP>
+      <Get onlineResource="http://server.com/tinyows?"></Get>
+     </HTTP>
+    </DCPType>
+    <DCPType>
+     <HTTP>
+      <Post onlineResource="http://server.com/tinyows"></Post>
+     </HTTP>
+    </DCPType>
+   </GetCapabilities>
+   <DescribeFeatureType>
+     <SchemaDescriptionLanguage>
+        <XMLSCHEMA></XMLSCHEMA>
+     </SchemaDescriptionLanguage>
+    <DCPType>
+     <HTTP>
+      <Get onlineResource="http://server.com/tinyows?"></Get>
+     </HTTP>
+    </DCPType>
+    <DCPType>
+     <HTTP>
+      <Post onlineResource="http://server.com/tinyows"></Post>
+     </HTTP>
+    </DCPType>
+   </DescribeFeatureType>
+   <GetFeature>
+<ResultFormat>
+<GML2></GML2>
+</ResultFormat>
+    <DCPType>
+     <HTTP>
+      <Get onlineResource="http://server.com/tinyows?"></Get>
+     </HTTP>
+    </DCPType>
+    <DCPType>
+     <HTTP>
+      <Post onlineResource="http://server.com/tinyows"></Post>
+     </HTTP>
+    </DCPType>
+   </GetFeature>
+   <Transaction>
+    <DCPType>
+     <HTTP>
+      <Get onlineResource="http://server.com/tinyows?"></Get>
+     </HTTP>
+    </DCPType>
+    <DCPType>
+     <HTTP>
+      <Post onlineResource="http://server.com/tinyows"></Post>
+     </HTTP>
+    </DCPType>
+   </Transaction>
+  </Request>
+ </Capability>
+ <FeatureTypeList>
+  <Operations>
+   <Query></Query>
+   <Insert></Insert>
+   <Update></Update>
+   <Delete></Delete>
+  </Operations>
+<FeatureType xmlns:tows="http://www.tinyows.org/">
+  <Name>tows:parks</Name>
+  <Title>Parks</Title>
+ <SRS>EPSG:4326</SRS>
+  <LatLongBoundingBox minx="-32.665395" miny="18.315848" maxx="6.591136" maxy="46.527381"></LatLongBoundingBox>
+</FeatureType>
+ </FeatureTypeList>
+<ogc:Filter_Capabilities>
+ <ogc:Spatial_Capabilities>
+  <ogc:Spatial_Operators>
+   <ogc:Disjoint></ogc:Disjoint>
+   <ogc:Equals></ogc:Equals>
+   <ogc:DWithin></ogc:DWithin>
+   <ogc:Beyond></ogc:Beyond>
+   <ogc:Intersect></ogc:Intersect>
+   <ogc:Touches></ogc:Touches>
+   <ogc:Crosses></ogc:Crosses>
+   <ogc:Within></ogc:Within>
+   <ogc:Contains></ogc:Contains>
+   <ogc:Overlaps></ogc:Overlaps>
+   <ogc:BBOX></ogc:BBOX>
+  </ogc:Spatial_Operators>
+ </ogc:Spatial_Capabilities>
+ <ogc:Scalar_Capabilities>
+  <ogc:Logical_Operators></ogc:Logical_Operators>
+  <ogc:Comparison_Operators>
+   <ogc:Simple_Comparisons></ogc:Simple_Comparisons>
+   <ogc:Between></ogc:Between>
+   <ogc:Like></ogc:Like>
+   <ogc:NullCheck></ogc:NullCheck>
+  </ogc:Comparison_Operators>
+  <ogc:Arithmetic_Operators>
+   <ogc:Simple_Arithmetic></ogc:Simple_Arithmetic>
+   <ogc:Functions>
+    <ogc:Function_Names>
+     <ogc:Function_Name nArgs="1">abs</ogc:Function_Name>
+     <ogc:Function_Name nArgs="1">acos</ogc:Function_Name>
+     <ogc:Function_Name nArgs="1">asin</ogc:Function_Name>
+     <ogc:Function_Name nArgs="1">atan</ogc:Function_Name>
+     <ogc:Function_Name nArgs="1">avg</ogc:Function_Name>
+     <ogc:Function_Name nArgs="1">cbrt</ogc:Function_Name>
+     <ogc:Function_Name nArgs="1">ceil</ogc:Function_Name>
+     <ogc:Function_Name nArgs="1">ceiling</ogc:Function_Name>
+     <ogc:Function_Name nArgs="1">cos</ogc:Function_Name>
+     <ogc:Function_Name nArgs="1">cot</ogc:Function_Name>
+     <ogc:Function_Name nArgs="1">count</ogc:Function_Name>
+     <ogc:Function_Name nArgs="1">degrees</ogc:Function_Name>
+     <ogc:Function_Name nArgs="1">exp</ogc:Function_Name>
+     <ogc:Function_Name nArgs="1">floor</ogc:Function_Name>
+     <ogc:Function_Name nArgs="1">length</ogc:Function_Name>
+     <ogc:Function_Name nArgs="1">ln</ogc:Function_Name>
+     <ogc:Function_Name nArgs="1">log</ogc:Function_Name>
+     <ogc:Function_Name nArgs="1">min</ogc:Function_Name>
+     <ogc:Function_Name nArgs="1">max</ogc:Function_Name>
+     <ogc:Function_Name nArgs="1">radians</ogc:Function_Name>
+     <ogc:Function_Name nArgs="1">round</ogc:Function_Name>
+     <ogc:Function_Name nArgs="1">sin</ogc:Function_Name>
+     <ogc:Function_Name nArgs="1">sqrt</ogc:Function_Name>
+     <ogc:Function_Name nArgs="1">tan</ogc:Function_Name>
+     <ogc:Function_Name nArgs="1">trunc</ogc:Function_Name>
+    </ogc:Function_Names>
+   </ogc:Functions>
+  </ogc:Arithmetic_Operators>
+ </ogc:Scalar_Capabilities>
+</ogc:Filter_Capabilities>
+</WFS_Capabilities>

--- a/c2cgeoportal/tests/data/tinyows_getcapabilities_layer.xml
+++ b/c2cgeoportal/tests/data/tinyows_getcapabilities_layer.xml
@@ -1,0 +1,263 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WFS_Capabilities xmlns="http://www.opengis.net/wfs" xmlns:ows="http://www.opengis.net/ows" xmlns:ogc="http://www.opengis.net/ogc" version="1.1.0" xmlns:gml="http://www.opengis.net/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" updateSequence="0" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.opengis.net/wfs   http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
+ <ows:ServiceIdentification>
+  <ows:Title>TinyOWS Server - Test</ows:Title>
+  <ows:ServiceType>WFS</ows:ServiceType>
+  <ows:ServiceTypeVersion>1.0.0,1.1.0</ows:ServiceTypeVersion>
+ </ows:ServiceIdentification>
+ <ows:ServiceProvider>
+  <ows:ProviderName>TinyOWS Server</ows:ProviderName>
+  <ows:ProviderSite xlink:href="http://www.tinyows.org/"></ows:ProviderSite>
+  <ows:ServiceContact>
+   <ows:ContactInfo>
+    <ows:Address>
+    <ows:ElectronicMailAddress>tinyows-users@lists.maptools.org</ows:ElectronicMailAddress>
+    </ows:Address>
+   </ows:ContactInfo>
+  </ows:ServiceContact>
+ </ows:ServiceProvider>
+ <ows:OperationsMetadata>
+  <ows:Operation name="GetCapabilities">
+    <ows:DCP>
+     <ows:HTTP>
+      <ows:Get xlink:href="http://server.com/tinyows_proxy?"></ows:Get>
+     </ows:HTTP>
+    </ows:DCP>
+    <ows:DCP>
+     <ows:HTTP>
+      <ows:Post xlink:href="http://server.com/tinyows_proxy"></ows:Post>
+     </ows:HTTP>
+    </ows:DCP>
+  <ows:Parameter name="AcceptVersions">
+  <ows:Value>1.1.0</ows:Value>
+  <ows:Value>1.0.0</ows:Value>
+  </ows:Parameter>
+  <ows:Parameter name="AcceptFormats">
+  <ows:Value>text/xml</ows:Value>
+  </ows:Parameter>
+  <ows:Parameter name="Sections">
+  <ows:Value>ServiceIdentification</ows:Value>
+  <ows:Value>ServiceProvider</ows:Value>
+  <ows:Value>OperationsMetadata</ows:Value>
+  <ows:Value>FeatureTypeList</ows:Value>
+  <ows:Value>ServesGMLObjectTypeList</ows:Value>
+  <ows:Value>SupportsGMLObjectTypeList</ows:Value>
+  </ows:Parameter>
+   </ows:Operation>
+   <ows:Operation name="DescribeFeatureType">
+    <ows:DCP>
+     <ows:HTTP>
+      <ows:Get xlink:href="http://server.com/tinyows_proxy?"></ows:Get>
+     </ows:HTTP>
+    </ows:DCP>
+    <ows:DCP>
+     <ows:HTTP>
+      <ows:Post xlink:href="http://server.com/tinyows_proxy"></ows:Post>
+     </ows:HTTP>
+    </ows:DCP>
+  <ows:Parameter name="outputFormat">
+  <ows:Value>text/xml; subtype=gml/3.1.1</ows:Value>
+  <ows:Value>text/xml; subtype=gml/2.1.2</ows:Value>
+  </ows:Parameter>
+   </ows:Operation>
+   <ows:Operation name="GetFeature">
+    <ows:DCP>
+     <ows:HTTP>
+      <ows:Get xlink:href="http://server.com/tinyows_proxy?"></ows:Get>
+     </ows:HTTP>
+    </ows:DCP>
+    <ows:DCP>
+     <ows:HTTP>
+      <ows:Post xlink:href="http://server.com/tinyows_proxy"></ows:Post>
+     </ows:HTTP>
+    </ows:DCP>
+  <ows:Parameter name="resultType">
+  <ows:Value>results</ows:Value>
+  <ows:Value>hits</ows:Value>
+  </ows:Parameter>
+  <ows:Parameter name="outputFormat">
+  <ows:Value>text/xml; subtype=gml/3.1.1</ows:Value>
+  <ows:Value>text/xml; subtype=gml/2.1.2</ows:Value>
+  <ows:Value>application/json</ows:Value>
+  </ows:Parameter>
+   </ows:Operation>
+   <ows:Operation name="Transaction">
+    <ows:DCP>
+     <ows:HTTP>
+      <ows:Get xlink:href="http://server.com/tinyows_proxy?"></ows:Get>
+     </ows:HTTP>
+    </ows:DCP>
+    <ows:DCP>
+     <ows:HTTP>
+      <ows:Post xlink:href="http://server.com/tinyows_proxy"></ows:Post>
+     </ows:HTTP>
+    </ows:DCP>
+    <ows:Parameter name="inputFormat">
+     <ows:Value>text/xml; subtype=gml/3.1.1</ows:Value>
+    </ows:Parameter>
+    <ows:Parameter name="idgen">
+     <ows:Value>GenerateNew</ows:Value>
+     <ows:Value>UseExisting</ows:Value>
+    </ows:Parameter>
+   </ows:Operation>
+   <ows:Constraint name="LocalTraverseXLinkScope">
+    <ows:Value>0</ows:Value>
+   </ows:Constraint>
+   <ows:Constraint name="RemoteTraverseXLinkScope">
+    <ows:Value>0</ows:Value>
+   </ows:Constraint>
+ </ows:OperationsMetadata>
+ <FeatureTypeList>
+  <Operations>
+   <Operation>Query</Operation>
+   <Operation>Insert</Operation>
+   <Operation>Update</Operation>
+   <Operation>Delete</Operation>
+  </Operations>
+  <FeatureType xmlns:tows="http://www.tinyows.org/">
+    <Name>tows:layer_1</Name>
+    <Title>Layer 1</Title>
+   <DefaultSRS>urn:ogc:def:crs:EPSG::4326</DefaultSRS>
+    <ows:WGS84BoundingBox> <ows:LowerCorner>-48.888249 17.815912</ows:LowerCorner> <ows:UpperCorner>6.591136 46.527381</ows:UpperCorner> </ows:WGS84BoundingBox>
+  </FeatureType>
+  <FeatureType xmlns:tows="http://www.tinyows.org/">
+    <Name>tows:layer_2</Name>
+    <Title>Layer 2</Title>
+   <DefaultSRS>urn:ogc:def:crs:EPSG::4326</DefaultSRS>
+    <ows:WGS84BoundingBox> <ows:LowerCorner>-48.888249 17.815912</ows:LowerCorner> <ows:UpperCorner>6.591136 46.527381</ows:UpperCorner> </ows:WGS84BoundingBox>
+  </FeatureType>
+  <FeatureType xmlns:tows="http://www.tinyows.org/">
+    <Name>tows:layer_3</Name>
+    <Title>Layer 3</Title>
+   <DefaultSRS>urn:ogc:def:crs:EPSG::4326</DefaultSRS>
+    <ows:WGS84BoundingBox> <ows:LowerCorner>-48.888249 17.815912</ows:LowerCorner> <ows:UpperCorner>6.591136 46.527381</ows:UpperCorner> </ows:WGS84BoundingBox>
+  </FeatureType>
+ </FeatureTypeList>
+ <SupportsGMLObjectTypeList>
+  <GMLObjectType>
+   <Name>gml:AbstractGMLFeatureType</Name>
+   <OutputFormats>
+    <Format>text/xml; subtype=gml/2.1.2</Format>
+    <Format>text/xml; subtype=gml/3.1.1</Format>
+   </OutputFormats>
+  </GMLObjectType>
+  <GMLObjectType>
+   <Name>gml:PointType</Name>
+   <OutputFormats>
+    <Format>text/xml; subtype=gml/2.1.2</Format>
+    <Format>text/xml; subtype=gml/3.1.1</Format>
+   </OutputFormats>
+  </GMLObjectType>
+  <GMLObjectType>
+   <Name>gml:LineStringType</Name>
+   <OutputFormats>
+    <Format>text/xml; subtype=gml/2.1.2</Format>
+    <Format>text/xml; subtype=gml/3.1.1</Format>
+   </OutputFormats>
+  </GMLObjectType>
+  <GMLObjectType>
+   <Name>gml:PolygonType</Name>
+   <OutputFormats>
+    <Format>text/xml; subtype=gml/2.1.2</Format>
+    <Format>text/xml; subtype=gml/3.1.1</Format>
+   </OutputFormats>
+  </GMLObjectType>
+  <GMLObjectType>
+   <Name>gml:MultiPointType</Name>
+   <OutputFormats>
+    <Format>text/xml; subtype=gml/2.1.2</Format>
+    <Format>text/xml; subtype=gml/3.1.1</Format>
+   </OutputFormats>
+  </GMLObjectType>
+  <GMLObjectType>
+   <Name>gml:MultiLineStringType</Name>
+   <OutputFormats>
+    <Format>text/xml; subtype=gml/2.1.2</Format>
+    <Format>text/xml; subtype=gml/3.1.1</Format>
+   </OutputFormats>
+  </GMLObjectType>
+  <GMLObjectType>
+   <Name>gml:MultiPolygonType</Name>
+   <OutputFormats>
+    <Format>text/xml; subtype=gml/2.1.2</Format>
+    <Format>text/xml; subtype=gml/3.1.1</Format>
+   </OutputFormats>
+  </GMLObjectType>
+ </SupportsGMLObjectTypeList>
+<ogc:Filter_Capabilities>
+ <ogc:Spatial_Capabilities>
+  <ogc:GeometryOperands>
+   <ogc:GeometryOperand>gml:Envelope</ogc:GeometryOperand>
+   <ogc:GeometryOperand>gml:Point</ogc:GeometryOperand>
+   <ogc:GeometryOperand>gml:LineString</ogc:GeometryOperand>
+   <ogc:GeometryOperand>gml:Polygon</ogc:GeometryOperand>
+   <ogc:GeometryOperand>gml:Triangle</ogc:GeometryOperand>
+   <ogc:GeometryOperand>gml:PolyhedralSurface</ogc:GeometryOperand>
+   <ogc:GeometryOperand>gml:Tin</ogc:GeometryOperand>
+  </ogc:GeometryOperands>
+  <ogc:SpatialOperators>
+  <ogc:SpatialOperator name="Disjoint"></ogc:SpatialOperator>
+  <ogc:SpatialOperator name="Equals"></ogc:SpatialOperator>
+  <ogc:SpatialOperator name="DWithin"></ogc:SpatialOperator>
+  <ogc:SpatialOperator name="Beyond"></ogc:SpatialOperator>
+  <ogc:SpatialOperator name="Intersects"></ogc:SpatialOperator>
+  <ogc:SpatialOperator name="Touches"></ogc:SpatialOperator>
+  <ogc:SpatialOperator name="Crosses"></ogc:SpatialOperator>
+  <ogc:SpatialOperator name="Within"></ogc:SpatialOperator>
+  <ogc:SpatialOperator name="Contains"></ogc:SpatialOperator>
+  <ogc:SpatialOperator name="Overlaps"></ogc:SpatialOperator>
+  <ogc:SpatialOperator name="BBOX"></ogc:SpatialOperator>
+ </ogc:SpatialOperators>
+ </ogc:Spatial_Capabilities>
+ <ogc:Scalar_Capabilities>
+  <ogc:LogicalOperators></ogc:LogicalOperators>
+  <ogc:ComparisonOperators>
+   <ogc:ComparisonOperator>EqualTo</ogc:ComparisonOperator>
+   <ogc:ComparisonOperator>NotEqualTo</ogc:ComparisonOperator>
+   <ogc:ComparisonOperator>LessThan</ogc:ComparisonOperator>
+   <ogc:ComparisonOperator>GreaterThan</ogc:ComparisonOperator>
+   <ogc:ComparisonOperator>LessThanEqualTo</ogc:ComparisonOperator>
+   <ogc:ComparisonOperator>GreaterThanEqualTo</ogc:ComparisonOperator>
+   <ogc:ComparisonOperator>Between</ogc:ComparisonOperator>
+   <ogc:ComparisonOperator>Like</ogc:ComparisonOperator>
+   <ogc:ComparisonOperator>NullCheck</ogc:ComparisonOperator>
+  </ogc:ComparisonOperators>
+  <ogc:ArithmeticOperators>
+   <ogc:SimpleArithmetic></ogc:SimpleArithmetic>
+   <ogc:Functions>
+    <ogc:FunctionNames>
+     <ogc:FunctionName nArgs="1">abs</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">acos</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">asin</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">atan</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">avg</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">cbrt</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">ceil</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">ceiling</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">cos</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">cot</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">count</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">degrees</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">exp</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">floor</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">length</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">ln</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">log</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">min</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">max</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">radians</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">round</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">sin</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">sqrt</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">tan</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">trunc</ogc:FunctionName>
+    </ogc:FunctionNames>
+   </ogc:Functions>
+  </ogc:ArithmeticOperators>
+ </ogc:Scalar_Capabilities>
+ <ogc:Id_Capabilities>
+  <ogc:EID></ogc:EID>
+  <ogc:FID></ogc:FID>
+ </ogc:Id_Capabilities>
+</ogc:Filter_Capabilities>
+</WFS_Capabilities>

--- a/c2cgeoportal/tests/data/tinyows_getcapabilities_layer_filtered_user1.xml
+++ b/c2cgeoportal/tests/data/tinyows_getcapabilities_layer_filtered_user1.xml
@@ -126,7 +126,6 @@
    <DefaultSRS>urn:ogc:def:crs:EPSG::4326</DefaultSRS>
     <ows:WGS84BoundingBox> <ows:LowerCorner>-48.888249 17.815912</ows:LowerCorner> <ows:UpperCorner>6.591136 46.527381</ows:UpperCorner> </ows:WGS84BoundingBox>
   </FeatureType>
-  
  </FeatureTypeList>
  <SupportsGMLObjectTypeList>
   <GMLObjectType>

--- a/c2cgeoportal/tests/data/tinyows_getcapabilities_layer_filtered_user1.xml
+++ b/c2cgeoportal/tests/data/tinyows_getcapabilities_layer_filtered_user1.xml
@@ -1,0 +1,258 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WFS_Capabilities xmlns="http://www.opengis.net/wfs" xmlns:ows="http://www.opengis.net/ows" xmlns:ogc="http://www.opengis.net/ogc" version="1.1.0" xmlns:gml="http://www.opengis.net/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" updateSequence="0" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.opengis.net/wfs   http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
+ <ows:ServiceIdentification>
+  <ows:Title>TinyOWS Server - Test</ows:Title>
+  <ows:ServiceType>WFS</ows:ServiceType>
+  <ows:ServiceTypeVersion>1.0.0,1.1.0</ows:ServiceTypeVersion>
+ </ows:ServiceIdentification>
+ <ows:ServiceProvider>
+  <ows:ProviderName>TinyOWS Server</ows:ProviderName>
+  <ows:ProviderSite xlink:href="http://www.tinyows.org/"></ows:ProviderSite>
+  <ows:ServiceContact>
+   <ows:ContactInfo>
+    <ows:Address>
+    <ows:ElectronicMailAddress>tinyows-users@lists.maptools.org</ows:ElectronicMailAddress>
+    </ows:Address>
+   </ows:ContactInfo>
+  </ows:ServiceContact>
+ </ows:ServiceProvider>
+ <ows:OperationsMetadata>
+  <ows:Operation name="GetCapabilities">
+    <ows:DCP>
+     <ows:HTTP>
+      <ows:Get xlink:href="http://server.com/tinyows_proxy?"></ows:Get>
+     </ows:HTTP>
+    </ows:DCP>
+    <ows:DCP>
+     <ows:HTTP>
+      <ows:Post xlink:href="http://server.com/tinyows_proxy"></ows:Post>
+     </ows:HTTP>
+    </ows:DCP>
+  <ows:Parameter name="AcceptVersions">
+  <ows:Value>1.1.0</ows:Value>
+  <ows:Value>1.0.0</ows:Value>
+  </ows:Parameter>
+  <ows:Parameter name="AcceptFormats">
+  <ows:Value>text/xml</ows:Value>
+  </ows:Parameter>
+  <ows:Parameter name="Sections">
+  <ows:Value>ServiceIdentification</ows:Value>
+  <ows:Value>ServiceProvider</ows:Value>
+  <ows:Value>OperationsMetadata</ows:Value>
+  <ows:Value>FeatureTypeList</ows:Value>
+  <ows:Value>ServesGMLObjectTypeList</ows:Value>
+  <ows:Value>SupportsGMLObjectTypeList</ows:Value>
+  </ows:Parameter>
+   </ows:Operation>
+   <ows:Operation name="DescribeFeatureType">
+    <ows:DCP>
+     <ows:HTTP>
+      <ows:Get xlink:href="http://server.com/tinyows_proxy?"></ows:Get>
+     </ows:HTTP>
+    </ows:DCP>
+    <ows:DCP>
+     <ows:HTTP>
+      <ows:Post xlink:href="http://server.com/tinyows_proxy"></ows:Post>
+     </ows:HTTP>
+    </ows:DCP>
+  <ows:Parameter name="outputFormat">
+  <ows:Value>text/xml; subtype=gml/3.1.1</ows:Value>
+  <ows:Value>text/xml; subtype=gml/2.1.2</ows:Value>
+  </ows:Parameter>
+   </ows:Operation>
+   <ows:Operation name="GetFeature">
+    <ows:DCP>
+     <ows:HTTP>
+      <ows:Get xlink:href="http://server.com/tinyows_proxy?"></ows:Get>
+     </ows:HTTP>
+    </ows:DCP>
+    <ows:DCP>
+     <ows:HTTP>
+      <ows:Post xlink:href="http://server.com/tinyows_proxy"></ows:Post>
+     </ows:HTTP>
+    </ows:DCP>
+  <ows:Parameter name="resultType">
+  <ows:Value>results</ows:Value>
+  <ows:Value>hits</ows:Value>
+  </ows:Parameter>
+  <ows:Parameter name="outputFormat">
+  <ows:Value>text/xml; subtype=gml/3.1.1</ows:Value>
+  <ows:Value>text/xml; subtype=gml/2.1.2</ows:Value>
+  <ows:Value>application/json</ows:Value>
+  </ows:Parameter>
+   </ows:Operation>
+   <ows:Operation name="Transaction">
+    <ows:DCP>
+     <ows:HTTP>
+      <ows:Get xlink:href="http://server.com/tinyows_proxy?"></ows:Get>
+     </ows:HTTP>
+    </ows:DCP>
+    <ows:DCP>
+     <ows:HTTP>
+      <ows:Post xlink:href="http://server.com/tinyows_proxy"></ows:Post>
+     </ows:HTTP>
+    </ows:DCP>
+    <ows:Parameter name="inputFormat">
+     <ows:Value>text/xml; subtype=gml/3.1.1</ows:Value>
+    </ows:Parameter>
+    <ows:Parameter name="idgen">
+     <ows:Value>GenerateNew</ows:Value>
+     <ows:Value>UseExisting</ows:Value>
+    </ows:Parameter>
+   </ows:Operation>
+   <ows:Constraint name="LocalTraverseXLinkScope">
+    <ows:Value>0</ows:Value>
+   </ows:Constraint>
+   <ows:Constraint name="RemoteTraverseXLinkScope">
+    <ows:Value>0</ows:Value>
+   </ows:Constraint>
+ </ows:OperationsMetadata>
+ <FeatureTypeList>
+  <Operations>
+   <Operation>Query</Operation>
+   <Operation>Insert</Operation>
+   <Operation>Update</Operation>
+   <Operation>Delete</Operation>
+  </Operations>
+  <FeatureType xmlns:tows="http://www.tinyows.org/">
+    <Name>tows:layer_1</Name>
+    <Title>Layer 1</Title>
+   <DefaultSRS>urn:ogc:def:crs:EPSG::4326</DefaultSRS>
+    <ows:WGS84BoundingBox> <ows:LowerCorner>-48.888249 17.815912</ows:LowerCorner> <ows:UpperCorner>6.591136 46.527381</ows:UpperCorner> </ows:WGS84BoundingBox>
+  </FeatureType>
+  <FeatureType xmlns:tows="http://www.tinyows.org/">
+    <Name>tows:layer_2</Name>
+    <Title>Layer 2</Title>
+   <DefaultSRS>urn:ogc:def:crs:EPSG::4326</DefaultSRS>
+    <ows:WGS84BoundingBox> <ows:LowerCorner>-48.888249 17.815912</ows:LowerCorner> <ows:UpperCorner>6.591136 46.527381</ows:UpperCorner> </ows:WGS84BoundingBox>
+  </FeatureType>
+  
+ </FeatureTypeList>
+ <SupportsGMLObjectTypeList>
+  <GMLObjectType>
+   <Name>gml:AbstractGMLFeatureType</Name>
+   <OutputFormats>
+    <Format>text/xml; subtype=gml/2.1.2</Format>
+    <Format>text/xml; subtype=gml/3.1.1</Format>
+   </OutputFormats>
+  </GMLObjectType>
+  <GMLObjectType>
+   <Name>gml:PointType</Name>
+   <OutputFormats>
+    <Format>text/xml; subtype=gml/2.1.2</Format>
+    <Format>text/xml; subtype=gml/3.1.1</Format>
+   </OutputFormats>
+  </GMLObjectType>
+  <GMLObjectType>
+   <Name>gml:LineStringType</Name>
+   <OutputFormats>
+    <Format>text/xml; subtype=gml/2.1.2</Format>
+    <Format>text/xml; subtype=gml/3.1.1</Format>
+   </OutputFormats>
+  </GMLObjectType>
+  <GMLObjectType>
+   <Name>gml:PolygonType</Name>
+   <OutputFormats>
+    <Format>text/xml; subtype=gml/2.1.2</Format>
+    <Format>text/xml; subtype=gml/3.1.1</Format>
+   </OutputFormats>
+  </GMLObjectType>
+  <GMLObjectType>
+   <Name>gml:MultiPointType</Name>
+   <OutputFormats>
+    <Format>text/xml; subtype=gml/2.1.2</Format>
+    <Format>text/xml; subtype=gml/3.1.1</Format>
+   </OutputFormats>
+  </GMLObjectType>
+  <GMLObjectType>
+   <Name>gml:MultiLineStringType</Name>
+   <OutputFormats>
+    <Format>text/xml; subtype=gml/2.1.2</Format>
+    <Format>text/xml; subtype=gml/3.1.1</Format>
+   </OutputFormats>
+  </GMLObjectType>
+  <GMLObjectType>
+   <Name>gml:MultiPolygonType</Name>
+   <OutputFormats>
+    <Format>text/xml; subtype=gml/2.1.2</Format>
+    <Format>text/xml; subtype=gml/3.1.1</Format>
+   </OutputFormats>
+  </GMLObjectType>
+ </SupportsGMLObjectTypeList>
+<ogc:Filter_Capabilities>
+ <ogc:Spatial_Capabilities>
+  <ogc:GeometryOperands>
+   <ogc:GeometryOperand>gml:Envelope</ogc:GeometryOperand>
+   <ogc:GeometryOperand>gml:Point</ogc:GeometryOperand>
+   <ogc:GeometryOperand>gml:LineString</ogc:GeometryOperand>
+   <ogc:GeometryOperand>gml:Polygon</ogc:GeometryOperand>
+   <ogc:GeometryOperand>gml:Triangle</ogc:GeometryOperand>
+   <ogc:GeometryOperand>gml:PolyhedralSurface</ogc:GeometryOperand>
+   <ogc:GeometryOperand>gml:Tin</ogc:GeometryOperand>
+  </ogc:GeometryOperands>
+  <ogc:SpatialOperators>
+  <ogc:SpatialOperator name="Disjoint"></ogc:SpatialOperator>
+  <ogc:SpatialOperator name="Equals"></ogc:SpatialOperator>
+  <ogc:SpatialOperator name="DWithin"></ogc:SpatialOperator>
+  <ogc:SpatialOperator name="Beyond"></ogc:SpatialOperator>
+  <ogc:SpatialOperator name="Intersects"></ogc:SpatialOperator>
+  <ogc:SpatialOperator name="Touches"></ogc:SpatialOperator>
+  <ogc:SpatialOperator name="Crosses"></ogc:SpatialOperator>
+  <ogc:SpatialOperator name="Within"></ogc:SpatialOperator>
+  <ogc:SpatialOperator name="Contains"></ogc:SpatialOperator>
+  <ogc:SpatialOperator name="Overlaps"></ogc:SpatialOperator>
+  <ogc:SpatialOperator name="BBOX"></ogc:SpatialOperator>
+ </ogc:SpatialOperators>
+ </ogc:Spatial_Capabilities>
+ <ogc:Scalar_Capabilities>
+  <ogc:LogicalOperators></ogc:LogicalOperators>
+  <ogc:ComparisonOperators>
+   <ogc:ComparisonOperator>EqualTo</ogc:ComparisonOperator>
+   <ogc:ComparisonOperator>NotEqualTo</ogc:ComparisonOperator>
+   <ogc:ComparisonOperator>LessThan</ogc:ComparisonOperator>
+   <ogc:ComparisonOperator>GreaterThan</ogc:ComparisonOperator>
+   <ogc:ComparisonOperator>LessThanEqualTo</ogc:ComparisonOperator>
+   <ogc:ComparisonOperator>GreaterThanEqualTo</ogc:ComparisonOperator>
+   <ogc:ComparisonOperator>Between</ogc:ComparisonOperator>
+   <ogc:ComparisonOperator>Like</ogc:ComparisonOperator>
+   <ogc:ComparisonOperator>NullCheck</ogc:ComparisonOperator>
+  </ogc:ComparisonOperators>
+  <ogc:ArithmeticOperators>
+   <ogc:SimpleArithmetic></ogc:SimpleArithmetic>
+   <ogc:Functions>
+    <ogc:FunctionNames>
+     <ogc:FunctionName nArgs="1">abs</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">acos</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">asin</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">atan</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">avg</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">cbrt</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">ceil</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">ceiling</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">cos</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">cot</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">count</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">degrees</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">exp</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">floor</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">length</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">ln</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">log</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">min</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">max</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">radians</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">round</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">sin</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">sqrt</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">tan</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">trunc</ogc:FunctionName>
+    </ogc:FunctionNames>
+   </ogc:Functions>
+  </ogc:ArithmeticOperators>
+ </ogc:Scalar_Capabilities>
+ <ogc:Id_Capabilities>
+  <ogc:EID></ogc:EID>
+  <ogc:FID></ogc:FID>
+ </ogc:Id_Capabilities>
+</ogc:Filter_Capabilities>
+</WFS_Capabilities>

--- a/c2cgeoportal/tests/data/tinyows_getcapabilities_layer_filtered_user2.xml
+++ b/c2cgeoportal/tests/data/tinyows_getcapabilities_layer_filtered_user2.xml
@@ -1,0 +1,248 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WFS_Capabilities xmlns="http://www.opengis.net/wfs" xmlns:ows="http://www.opengis.net/ows" xmlns:ogc="http://www.opengis.net/ogc" version="1.1.0" xmlns:gml="http://www.opengis.net/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" updateSequence="0" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.opengis.net/wfs   http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
+ <ows:ServiceIdentification>
+  <ows:Title>TinyOWS Server - Test</ows:Title>
+  <ows:ServiceType>WFS</ows:ServiceType>
+  <ows:ServiceTypeVersion>1.0.0,1.1.0</ows:ServiceTypeVersion>
+ </ows:ServiceIdentification>
+ <ows:ServiceProvider>
+  <ows:ProviderName>TinyOWS Server</ows:ProviderName>
+  <ows:ProviderSite xlink:href="http://www.tinyows.org/"></ows:ProviderSite>
+  <ows:ServiceContact>
+   <ows:ContactInfo>
+    <ows:Address>
+    <ows:ElectronicMailAddress>tinyows-users@lists.maptools.org</ows:ElectronicMailAddress>
+    </ows:Address>
+   </ows:ContactInfo>
+  </ows:ServiceContact>
+ </ows:ServiceProvider>
+ <ows:OperationsMetadata>
+  <ows:Operation name="GetCapabilities">
+    <ows:DCP>
+     <ows:HTTP>
+      <ows:Get xlink:href="http://server.com/tinyows_proxy?"></ows:Get>
+     </ows:HTTP>
+    </ows:DCP>
+    <ows:DCP>
+     <ows:HTTP>
+      <ows:Post xlink:href="http://server.com/tinyows_proxy"></ows:Post>
+     </ows:HTTP>
+    </ows:DCP>
+  <ows:Parameter name="AcceptVersions">
+  <ows:Value>1.1.0</ows:Value>
+  <ows:Value>1.0.0</ows:Value>
+  </ows:Parameter>
+  <ows:Parameter name="AcceptFormats">
+  <ows:Value>text/xml</ows:Value>
+  </ows:Parameter>
+  <ows:Parameter name="Sections">
+  <ows:Value>ServiceIdentification</ows:Value>
+  <ows:Value>ServiceProvider</ows:Value>
+  <ows:Value>OperationsMetadata</ows:Value>
+  <ows:Value>FeatureTypeList</ows:Value>
+  <ows:Value>ServesGMLObjectTypeList</ows:Value>
+  <ows:Value>SupportsGMLObjectTypeList</ows:Value>
+  </ows:Parameter>
+   </ows:Operation>
+   <ows:Operation name="DescribeFeatureType">
+    <ows:DCP>
+     <ows:HTTP>
+      <ows:Get xlink:href="http://server.com/tinyows_proxy?"></ows:Get>
+     </ows:HTTP>
+    </ows:DCP>
+    <ows:DCP>
+     <ows:HTTP>
+      <ows:Post xlink:href="http://server.com/tinyows_proxy"></ows:Post>
+     </ows:HTTP>
+    </ows:DCP>
+  <ows:Parameter name="outputFormat">
+  <ows:Value>text/xml; subtype=gml/3.1.1</ows:Value>
+  <ows:Value>text/xml; subtype=gml/2.1.2</ows:Value>
+  </ows:Parameter>
+   </ows:Operation>
+   <ows:Operation name="GetFeature">
+    <ows:DCP>
+     <ows:HTTP>
+      <ows:Get xlink:href="http://server.com/tinyows_proxy?"></ows:Get>
+     </ows:HTTP>
+    </ows:DCP>
+    <ows:DCP>
+     <ows:HTTP>
+      <ows:Post xlink:href="http://server.com/tinyows_proxy"></ows:Post>
+     </ows:HTTP>
+    </ows:DCP>
+  <ows:Parameter name="resultType">
+  <ows:Value>results</ows:Value>
+  <ows:Value>hits</ows:Value>
+  </ows:Parameter>
+  <ows:Parameter name="outputFormat">
+  <ows:Value>text/xml; subtype=gml/3.1.1</ows:Value>
+  <ows:Value>text/xml; subtype=gml/2.1.2</ows:Value>
+  <ows:Value>application/json</ows:Value>
+  </ows:Parameter>
+   </ows:Operation>
+   <ows:Operation name="Transaction">
+    <ows:DCP>
+     <ows:HTTP>
+      <ows:Get xlink:href="http://server.com/tinyows_proxy?"></ows:Get>
+     </ows:HTTP>
+    </ows:DCP>
+    <ows:DCP>
+     <ows:HTTP>
+      <ows:Post xlink:href="http://server.com/tinyows_proxy"></ows:Post>
+     </ows:HTTP>
+    </ows:DCP>
+    <ows:Parameter name="inputFormat">
+     <ows:Value>text/xml; subtype=gml/3.1.1</ows:Value>
+    </ows:Parameter>
+    <ows:Parameter name="idgen">
+     <ows:Value>GenerateNew</ows:Value>
+     <ows:Value>UseExisting</ows:Value>
+    </ows:Parameter>
+   </ows:Operation>
+   <ows:Constraint name="LocalTraverseXLinkScope">
+    <ows:Value>0</ows:Value>
+   </ows:Constraint>
+   <ows:Constraint name="RemoteTraverseXLinkScope">
+    <ows:Value>0</ows:Value>
+   </ows:Constraint>
+ </ows:OperationsMetadata>
+ <FeatureTypeList>
+  <Operations>
+   <Operation>Query</Operation>
+   <Operation>Insert</Operation>
+   <Operation>Update</Operation>
+   <Operation>Delete</Operation>
+  </Operations>
+  
+  
+  
+ </FeatureTypeList>
+ <SupportsGMLObjectTypeList>
+  <GMLObjectType>
+   <Name>gml:AbstractGMLFeatureType</Name>
+   <OutputFormats>
+    <Format>text/xml; subtype=gml/2.1.2</Format>
+    <Format>text/xml; subtype=gml/3.1.1</Format>
+   </OutputFormats>
+  </GMLObjectType>
+  <GMLObjectType>
+   <Name>gml:PointType</Name>
+   <OutputFormats>
+    <Format>text/xml; subtype=gml/2.1.2</Format>
+    <Format>text/xml; subtype=gml/3.1.1</Format>
+   </OutputFormats>
+  </GMLObjectType>
+  <GMLObjectType>
+   <Name>gml:LineStringType</Name>
+   <OutputFormats>
+    <Format>text/xml; subtype=gml/2.1.2</Format>
+    <Format>text/xml; subtype=gml/3.1.1</Format>
+   </OutputFormats>
+  </GMLObjectType>
+  <GMLObjectType>
+   <Name>gml:PolygonType</Name>
+   <OutputFormats>
+    <Format>text/xml; subtype=gml/2.1.2</Format>
+    <Format>text/xml; subtype=gml/3.1.1</Format>
+   </OutputFormats>
+  </GMLObjectType>
+  <GMLObjectType>
+   <Name>gml:MultiPointType</Name>
+   <OutputFormats>
+    <Format>text/xml; subtype=gml/2.1.2</Format>
+    <Format>text/xml; subtype=gml/3.1.1</Format>
+   </OutputFormats>
+  </GMLObjectType>
+  <GMLObjectType>
+   <Name>gml:MultiLineStringType</Name>
+   <OutputFormats>
+    <Format>text/xml; subtype=gml/2.1.2</Format>
+    <Format>text/xml; subtype=gml/3.1.1</Format>
+   </OutputFormats>
+  </GMLObjectType>
+  <GMLObjectType>
+   <Name>gml:MultiPolygonType</Name>
+   <OutputFormats>
+    <Format>text/xml; subtype=gml/2.1.2</Format>
+    <Format>text/xml; subtype=gml/3.1.1</Format>
+   </OutputFormats>
+  </GMLObjectType>
+ </SupportsGMLObjectTypeList>
+<ogc:Filter_Capabilities>
+ <ogc:Spatial_Capabilities>
+  <ogc:GeometryOperands>
+   <ogc:GeometryOperand>gml:Envelope</ogc:GeometryOperand>
+   <ogc:GeometryOperand>gml:Point</ogc:GeometryOperand>
+   <ogc:GeometryOperand>gml:LineString</ogc:GeometryOperand>
+   <ogc:GeometryOperand>gml:Polygon</ogc:GeometryOperand>
+   <ogc:GeometryOperand>gml:Triangle</ogc:GeometryOperand>
+   <ogc:GeometryOperand>gml:PolyhedralSurface</ogc:GeometryOperand>
+   <ogc:GeometryOperand>gml:Tin</ogc:GeometryOperand>
+  </ogc:GeometryOperands>
+  <ogc:SpatialOperators>
+  <ogc:SpatialOperator name="Disjoint"></ogc:SpatialOperator>
+  <ogc:SpatialOperator name="Equals"></ogc:SpatialOperator>
+  <ogc:SpatialOperator name="DWithin"></ogc:SpatialOperator>
+  <ogc:SpatialOperator name="Beyond"></ogc:SpatialOperator>
+  <ogc:SpatialOperator name="Intersects"></ogc:SpatialOperator>
+  <ogc:SpatialOperator name="Touches"></ogc:SpatialOperator>
+  <ogc:SpatialOperator name="Crosses"></ogc:SpatialOperator>
+  <ogc:SpatialOperator name="Within"></ogc:SpatialOperator>
+  <ogc:SpatialOperator name="Contains"></ogc:SpatialOperator>
+  <ogc:SpatialOperator name="Overlaps"></ogc:SpatialOperator>
+  <ogc:SpatialOperator name="BBOX"></ogc:SpatialOperator>
+ </ogc:SpatialOperators>
+ </ogc:Spatial_Capabilities>
+ <ogc:Scalar_Capabilities>
+  <ogc:LogicalOperators></ogc:LogicalOperators>
+  <ogc:ComparisonOperators>
+   <ogc:ComparisonOperator>EqualTo</ogc:ComparisonOperator>
+   <ogc:ComparisonOperator>NotEqualTo</ogc:ComparisonOperator>
+   <ogc:ComparisonOperator>LessThan</ogc:ComparisonOperator>
+   <ogc:ComparisonOperator>GreaterThan</ogc:ComparisonOperator>
+   <ogc:ComparisonOperator>LessThanEqualTo</ogc:ComparisonOperator>
+   <ogc:ComparisonOperator>GreaterThanEqualTo</ogc:ComparisonOperator>
+   <ogc:ComparisonOperator>Between</ogc:ComparisonOperator>
+   <ogc:ComparisonOperator>Like</ogc:ComparisonOperator>
+   <ogc:ComparisonOperator>NullCheck</ogc:ComparisonOperator>
+  </ogc:ComparisonOperators>
+  <ogc:ArithmeticOperators>
+   <ogc:SimpleArithmetic></ogc:SimpleArithmetic>
+   <ogc:Functions>
+    <ogc:FunctionNames>
+     <ogc:FunctionName nArgs="1">abs</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">acos</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">asin</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">atan</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">avg</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">cbrt</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">ceil</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">ceiling</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">cos</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">cot</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">count</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">degrees</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">exp</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">floor</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">length</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">ln</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">log</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">min</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">max</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">radians</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">round</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">sin</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">sqrt</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">tan</ogc:FunctionName>
+     <ogc:FunctionName nArgs="1">trunc</ogc:FunctionName>
+    </ogc:FunctionNames>
+   </ogc:Functions>
+  </ogc:ArithmeticOperators>
+ </ogc:Scalar_Capabilities>
+ <ogc:Id_Capabilities>
+  <ogc:EID></ogc:EID>
+  <ogc:FID></ogc:FID>
+ </ogc:Id_Capabilities>
+</ogc:Filter_Capabilities>
+</WFS_Capabilities>

--- a/c2cgeoportal/tests/data/tinyows_getcapabilities_layer_filtered_user2.xml
+++ b/c2cgeoportal/tests/data/tinyows_getcapabilities_layer_filtered_user2.xml
@@ -114,9 +114,6 @@
    <Operation>Update</Operation>
    <Operation>Delete</Operation>
   </Operations>
-  
-  
-  
  </FeatureTypeList>
  <SupportsGMLObjectTypeList>
   <GMLObjectType>

--- a/c2cgeoportal/tests/data/tinyows_getcapabilities_request.xml
+++ b/c2cgeoportal/tests/data/tinyows_getcapabilities_request.xml
@@ -1,0 +1,6 @@
+<GetCapabilities
+  service="WFS"
+  xmlns="http://www.opengis.net/wfs"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.opengis.net/wfs
+  http://schemas.opengis.net/wfs/1.1.0/wfs.xsd"/>

--- a/c2cgeoportal/tests/data/tinyows_getfeature_request.xml
+++ b/c2cgeoportal/tests/data/tinyows_getfeature_request.xml
@@ -1,0 +1,11 @@
+<GetFeature
+  service="WFS"
+  version="1.0.0"
+  xmlns="http://www.opengis.net/wfs"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:tows="http://www.tinyows.org/"
+  xsi:schemaLocation="http://www.opengis.net/wfs
+  http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
+    <Query typeName="tows:parks">
+    </Query>
+</GetFeature>

--- a/c2cgeoportal/tests/data/tinyows_lockfeature_request.xml
+++ b/c2cgeoportal/tests/data/tinyows_lockfeature_request.xml
@@ -1,0 +1,15 @@
+<LockFeature
+  service="WFS"
+  version="1.0.0"
+  lockAction="ALL"
+  xmlns="http://www.opengis.net/wfs"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:tows="http://www.tinyows.org/"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xsi:schemaLocation="http://www.opengis.net/wfs ../wfs/1.0.0/WFS-transaction.xsd">
+    <Lock typeName="tows:parks">
+      <ogc:Filter>
+        <ogc:FeatureId fid="parks.1"/>
+      </ogc:Filter>
+    </Lock>
+</LockFeature>

--- a/c2cgeoportal/tests/data/tinyows_transaction_delete_request.xml
+++ b/c2cgeoportal/tests/data/tinyows_transaction_delete_request.xml
@@ -1,0 +1,7 @@
+<Transaction xmlns="http://www.opengis.net/wfs" xmlns:gml="http://www.opengis.net/gml" xmlns:tows="http://www.tinyows.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" service="WFS" xsi:schemaLocation="http://www.tinyows.org/ http://geomapfish-demo.gis.internal/tinyows?SERVICE=WFS&amp;VERSION=1.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=tows:parks&amp;SRSNAME=EPSG:4326">
+   <Delete typeName="tows:parks">
+      <Filter xmlns="http://www.opengis.net/ogc">
+         <FeatureId fid="parks.5" />
+      </Filter>
+   </Delete>
+</Transaction>

--- a/c2cgeoportal/tests/data/tinyows_transaction_insert_request.xml
+++ b/c2cgeoportal/tests/data/tinyows_transaction_insert_request.xml
@@ -1,0 +1,12 @@
+<Transaction xmlns="http://www.opengis.net/wfs" xmlns:gml="http://www.opengis.net/gml" xmlns:tows="http://www.tinyows.org/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" service="WFS" xsi:schemaLocation="http://www.tinyows.org/ http://geomapfish-demo.gis.internal/tinyows?SERVICE=WFS&amp;VERSION=1.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=tows:parks&amp;SRSNAME=EPSG:4326">
+   <Insert>
+      <parks xmlns="http://www.tinyows.org/">
+         <park_name>name</park_name>
+         <park_geom>
+            <gml:Point srsName="EPSG:4326">
+               <gml:coordinates cs="," ts=" ">-19.30038318682842657,28.31456290207971804</gml:coordinates>
+            </gml:Point>
+         </park_geom>
+      </parks>
+   </Insert>
+</Transaction>

--- a/c2cgeoportal/tests/data/tinyows_transaction_update_request.xml
+++ b/c2cgeoportal/tests/data/tinyows_transaction_update_request.xml
@@ -1,0 +1,25 @@
+<Transaction
+  xmlns="http://www.opengis.net/wfs"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  version="1.0.0"
+  service="WFS"
+  xsi:schemaLocation="http://www.tinyows.org/ http://geomapfish-demo.gis.internal/tinyows?SERVICE=WFS&amp;VERSION=1.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=tows:parks&amp;SRSNAME=EPSG:4326"
+  xmlns:gml="http://www.opengis.net/gml"
+  xmlns:tows="http://www.tinyows.org/">
+    <Update
+      xmlns="http://www.opengis.net/wfs"
+      typeName="tows:parks">
+        <Property
+          xmlns="http://www.opengis.net/wfs">
+            <Name xmlns="http://www.opengis.net/wfs">park_geom</Name>
+            <Value xmlns="http://www.opengis.net/wfs">
+              <gml:Point srsName="EPSG:4326">
+                <gml:coordinates cs="," ts=" ">-10.70124381897747057,31.93390198518197209</gml:coordinates>
+              </gml:Point>
+            </Value>
+        </Property>
+        <Filter xmlns="http://www.opengis.net/ogc">
+          <FeatureId xmlns="http://www.opengis.net/ogc" fid="parks.4"/>
+        </Filter>
+    </Update>
+</Transaction>

--- a/c2cgeoportal/tests/functional/test_filter_capabilities.py
+++ b/c2cgeoportal/tests/functional/test_filter_capabilities.py
@@ -44,33 +44,33 @@ from c2cgeoportal.tests.functional import (  # noqa
 
 @attr(functional=True)
 class TestFilterCapabilities(TestCase):
-    capabilities_file = 'c2cgeoportal/tests/data/tinyows_getcapabilities.xml'
+    capabilities_file = "c2cgeoportal/tests/data/tinyows_getcapabilities.xml"
 
     def test_capabilities_filter_featuretype(self):
         xml = load_file(TestFilterCapabilities.capabilities_file)
         layers_whitelist = set()
         filtered_xml = self._filter_xml(
-            xml, u'FeatureType', layers_whitelist)
+            xml, u"FeatureType", layers_whitelist)
 
-        self.assertTrue('<Name>tows:parks</Name>' not in filtered_xml)
+        self.assertTrue("<Name>tows:parks</Name>" not in filtered_xml)
 
     def test_capabilities_filter_featuretype_private_layer(self):
         xml = load_file(TestFilterCapabilities.capabilities_file)
         layers_whitelist = set()
-        layers_whitelist.add('parks')
-        filtered_xml = self._filter_xml(xml, u'FeatureType', layers_whitelist)
+        layers_whitelist.add("parks")
+        filtered_xml = self._filter_xml(xml, u"FeatureType", layers_whitelist)
 
-        self.assertTrue('<Name>tows:parks</Name>' in filtered_xml)
+        self.assertTrue("<Name>tows:parks</Name>" in filtered_xml)
 
     def _filter_xml(self, xml, tag_name, layers_whitelist):
         from c2cgeoportal.lib.filter_capabilities import _CapabilitiesFilter
 
         parser = sax.make_parser()
         result = StringIO()
-        downstream_handler = XMLGenerator(result, 'utf-8')
+        downstream_handler = XMLGenerator(result, "utf-8")
         filter_handler = _CapabilitiesFilter(
             parser, downstream_handler,
             tag_name, layers_whitelist=layers_whitelist
         )
         filter_handler.parse(StringIO(xml))
-        return unicode(result.getvalue(), 'utf-8')
+        return unicode(result.getvalue(), "utf-8")

--- a/c2cgeoportal/tests/functional/test_filter_capabilities.py
+++ b/c2cgeoportal/tests/functional/test_filter_capabilities.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2013-2014, Camptocamp SA
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# The views and conclusions contained in the software and documentation are those
+# of the authors and should not be interpreted as representing official policies,
+# either expressed or implied, of the FreeBSD Project.
+
+
+from unittest import TestCase
+from nose.plugins.attrib import attr
+
+from StringIO import StringIO
+from xml import sax
+from xml.sax.saxutils import XMLGenerator
+
+from c2cgeoportal.tests import load_file
+from c2cgeoportal.tests.functional import (  # noqa
+    tear_down_common as tearDownModule,
+    set_up_common as setUpModule
+)
+
+
+@attr(functional=True)
+class TestFilterCapabilities(TestCase):
+    capabilities_file = 'c2cgeoportal/tests/data/tinyows_getcapabilities.xml'
+
+    def test_capabilities_filter_featuretype(self):
+        xml = load_file(TestFilterCapabilities.capabilities_file)
+        layers_whitelist = set()
+        filtered_xml = self._filter_xml(
+            xml, u'FeatureType', layers_whitelist)
+
+        self.assertTrue('<Name>tows:parks</Name>' not in filtered_xml)
+
+    def test_capabilities_filter_featuretype_private_layer(self):
+        xml = load_file(TestFilterCapabilities.capabilities_file)
+        layers_whitelist = set()
+        layers_whitelist.add('parks')
+        filtered_xml = self._filter_xml(xml, u'FeatureType', layers_whitelist)
+
+        self.assertTrue('<Name>tows:parks</Name>' in filtered_xml)
+
+    def _filter_xml(self, xml, tag_name, layers_whitelist):
+        from c2cgeoportal.lib.filter_capabilities import _CapabilitiesFilter
+
+        parser = sax.make_parser()
+        result = StringIO()
+        downstream_handler = XMLGenerator(result, 'utf-8')
+        filter_handler = _CapabilitiesFilter(
+            parser, downstream_handler,
+            tag_name, layers_whitelist=layers_whitelist
+        )
+        filter_handler.parse(StringIO(xml))
+        return unicode(result.getvalue(), 'utf-8')

--- a/c2cgeoportal/tests/functional/test_tinyowsproxy.py
+++ b/c2cgeoportal/tests/functional/test_tinyowsproxy.py
@@ -48,10 +48,10 @@ def _create_dummy_request(username=None):
     from c2cgeoportal.models import DBSession, User
 
     request = create_dummy_request({
-        'tinyowsproxy': {
-            'tinyows_url': 'http://localhost/tinyows',
-            'online_resource': 'http://domain.com/tinyows_proxy',
-            'proxy_online_resource': 'http://domain.com/tinyows'
+        "tinyowsproxy": {
+            "tinyows_url": "http://localhost/tinyows",
+            "online_resource": "http://domain.com/tinyows_proxy",
+            "proxy_online_resource": "http://domain.com/tinyows"
         }
     })
     request.user = None if username is None else \
@@ -61,50 +61,50 @@ def _create_dummy_request(username=None):
 
 @attr(functional=True)
 class TestTinyOWSProxyView(TestCase):
-    data_base = 'c2cgeoportal/tests/data/'
+    data_base = "c2cgeoportal/tests/data/"
     capabilities_response_file = \
-        data_base + 'tinyows_getcapabilities_layer.xml'
+        data_base + "tinyows_getcapabilities_layer.xml"
     capabilities_response_filtered_file1 = \
-        data_base + 'tinyows_getcapabilities_layer_filtered_user1.xml'
+        data_base + "tinyows_getcapabilities_layer_filtered_user1.xml"
     capabilities_response_filtered_file2 = \
-        data_base + 'tinyows_getcapabilities_layer_filtered_user2.xml'
+        data_base + "tinyows_getcapabilities_layer_filtered_user2.xml"
     capabilities_request_file = \
-        data_base + 'tinyows_getcapabilities_request.xml'
+        data_base + "tinyows_getcapabilities_request.xml"
     describefeaturetype_request_file = \
-        data_base + 'tinyows_describefeaturetype_request.xml'
+        data_base + "tinyows_describefeaturetype_request.xml"
     describefeaturetype_request_multiple_file = \
-        data_base + 'tinyows_describefeaturetype_request_multiple.xml'
+        data_base + "tinyows_describefeaturetype_request_multiple.xml"
 
     def setUp(self):  # noqa
         from c2cgeoportal.models import User, Role, LayerV1, RestrictionArea, \
             Interface, DBSession
 
-        user1 = User(username=u'__test_user1', password=u'__test_user1')
-        role1 = Role(name=u'__test_role1', description=u'__test_role1')
+        user1 = User(username=u"__test_user1", password=u"__test_user1")
+        role1 = Role(name=u"__test_role1", description=u"__test_role1")
         user1.role_name = role1.name
-        user1.email = u'Tarenpion'
+        user1.email = u"Tarenpion"
 
-        user2 = User(username=u'__test_user2', password=u'__test_user2')
-        role2 = Role(name=u'__test_role2', description=u'__test_role2')
+        user2 = User(username=u"__test_user2", password=u"__test_user2")
+        role2 = Role(name=u"__test_role2", description=u"__test_role2")
         user2.role_name = role2.name
-        user2.email = u'Tarenpion'
+        user2.email = u"Tarenpion"
 
-        main = Interface(name=u'main')
+        main = Interface(name=u"main")
 
-        layer1 = LayerV1(u'layer_1', public=False)
+        layer1 = LayerV1(u"layer_1", public=False)
         layer1.interfaces = [main]
-        layer2 = LayerV1(u'layer_2', public=False)
+        layer2 = LayerV1(u"layer_2", public=False)
         layer2.interfaces = [main]
-        layer3 = LayerV1(u'layer_3', public=False)
+        layer3 = LayerV1(u"layer_3", public=False)
         layer3.interfaces = [main]
 
         area = "POLYGON((-100 30, -100 50, 100 50, 100 30, -100 30))"
         area = WKTElement(area, srid=21781)
-        restricted_area1 = RestrictionArea(u'__test_ra1', u'', [layer1, layer2], [role1], area, readwrite=True)
+        restricted_area1 = RestrictionArea(u"__test_ra1", u"", [layer1, layer2], [role1], area, readwrite=True)
 
         area = "POLYGON((-100 0, -100 20, 100 20, 100 0, -100 0))"
         area = WKTElement(area, srid=21781)
-        restricted_area2 = RestrictionArea(u'__test_ra2', u'', [layer1, layer2, layer3], [role2], area)
+        restricted_area2 = RestrictionArea(u"__test_ra2", u"", [layer1, layer2, layer3], [role2], area)
 
         DBSession.add_all([
             user1, user2, role1, role2,
@@ -118,37 +118,37 @@ class TestTinyOWSProxyView(TestCase):
         from c2cgeoportal.models import User, Role, LayerV1, RestrictionArea, \
             Interface, DBSession
 
-        DBSession.query(User).filter(User.username == '__test_user1').delete()
-        DBSession.query(User).filter(User.username == '__test_user2').delete()
+        DBSession.query(User).filter(User.username == "__test_user1").delete()
+        DBSession.query(User).filter(User.username == "__test_user2").delete()
 
         ra = DBSession.query(RestrictionArea).filter(
-            RestrictionArea.name == '__test_ra1'
+            RestrictionArea.name == "__test_ra1"
         ).one()
         ra.roles = []
         ra.layers = []
         DBSession.delete(ra)
         ra = DBSession.query(RestrictionArea).filter(
-            RestrictionArea.name == '__test_ra2'
+            RestrictionArea.name == "__test_ra2"
         ).one()
         ra.roles = []
         ra.layers = []
         DBSession.delete(ra)
 
-        r = DBSession.query(Role).filter(Role.name == '__test_role1').one()
+        r = DBSession.query(Role).filter(Role.name == "__test_role1").one()
         r.functionalities = []
         DBSession.delete(r)
-        r = DBSession.query(Role).filter(Role.name == '__test_role2').one()
+        r = DBSession.query(Role).filter(Role.name == "__test_role2").one()
         r.functionalities = []
         DBSession.delete(r)
 
-        for layer in DBSession.query(LayerV1).filter(LayerV1.name == 'layer_1').all():
+        for layer in DBSession.query(LayerV1).filter(LayerV1.name == "layer_1").all():
             DBSession.delete(layer)  # pragma: nocover
-        for layer in DBSession.query(LayerV1).filter(LayerV1.name == 'layer_2').all():
+        for layer in DBSession.query(LayerV1).filter(LayerV1.name == "layer_2").all():
             DBSession.delete(layer)
-        for layer in DBSession.query(LayerV1).filter(LayerV1.name == 'layer_3').all():
+        for layer in DBSession.query(LayerV1).filter(LayerV1.name == "layer_3").all():
             DBSession.delete(layer)
         DBSession.query(Interface).filter(
-            Interface.name == 'main'
+            Interface.name == "main"
         ).delete()
 
         transaction.commit()
@@ -166,7 +166,7 @@ class TestTinyOWSProxyView(TestCase):
                 pass
             resp = FakeResponse()
             resp.status = status
-            resp['content-type'] = "application/xml"
+            resp["content-type"] = "application/xml"
 
             return resp, content
 
@@ -184,7 +184,7 @@ class TestTinyOWSProxyView(TestCase):
 
     @attr(functional=True)
     def test_proxy_get_capabilities_user1(self):
-        request = _create_dummy_request(username=u'__test_user1')
+        request = _create_dummy_request(username=u"__test_user1")
         proxy = self.get_fake_proxy_(
             request,
             load_file(TestTinyOWSProxyView.capabilities_response_file),
@@ -194,11 +194,11 @@ class TestTinyOWSProxyView(TestCase):
         filtered = load_file(
             TestTinyOWSProxyView.capabilities_response_filtered_file1)
         self.assertEquals(filtered, response.body)
-        self.assertEquals('200 OK', response.status)
+        self.assertEquals("200 OK", response.status)
 
     @attr(functional=True)
     def test_proxy_get_capabilities_user2(self):
-        request = _create_dummy_request(username=u'__test_user2')
+        request = _create_dummy_request(username=u"__test_user2")
         proxy = self.get_fake_proxy_(
             request,
             load_file(TestTinyOWSProxyView.capabilities_response_file),
@@ -208,13 +208,13 @@ class TestTinyOWSProxyView(TestCase):
         filtered = load_file(
             TestTinyOWSProxyView.capabilities_response_filtered_file2)
         self.assertEquals(filtered, response.body)
-        self.assertEquals('200 OK', response.status)
+        self.assertEquals("200 OK", response.status)
 
     @attr(functional=True)
     def test_proxy_get_capabilities_get(self):
-        request = _create_dummy_request(username=u'__test_user1')
+        request = _create_dummy_request(username=u"__test_user1")
         request.params.update(dict(
-            service='wfs', version='1.1.0', request='GetCapabilities'
+            service="wfs", version="1.1.0", request="GetCapabilities"
         ))
 
         proxy = self.get_fake_proxy_(
@@ -226,11 +226,11 @@ class TestTinyOWSProxyView(TestCase):
         filtered = load_file(
             TestTinyOWSProxyView.capabilities_response_filtered_file1)
         self.assertEquals(filtered, response.body)
-        self.assertEquals('200 OK', response.status)
+        self.assertEquals("200 OK", response.status)
 
     @attr(functional=True)
     def test_proxy_get_capabilities_post(self):
-        request = _create_dummy_request(username=u'__test_user1')
+        request = _create_dummy_request(username=u"__test_user1")
         request.method = "POST"
         request.body = load_file(
             TestTinyOWSProxyView.capabilities_request_file)
@@ -244,13 +244,13 @@ class TestTinyOWSProxyView(TestCase):
         filtered = load_file(
             TestTinyOWSProxyView.capabilities_response_filtered_file1)
         self.assertEquals(filtered, response.body)
-        self.assertEquals('200 OK', response.status)
+        self.assertEquals("200 OK", response.status)
 
     @attr(functional=True)
     def test_proxy_get_capabilities_post_invalid_body(self):
         from pyramid.httpexceptions import HTTPBadRequest
 
-        request = _create_dummy_request(username=u'__test_user1')
+        request = _create_dummy_request(username=u"__test_user1")
         request.method = "POST"
         request.body = "This is not XML"
 
@@ -259,25 +259,25 @@ class TestTinyOWSProxyView(TestCase):
 
     @attr(functional=True)
     def test_proxy_describe_feature_type_get(self):
-        request = _create_dummy_request(username=u'__test_user1')
+        request = _create_dummy_request(username=u"__test_user1")
         request.params.update(dict(
-            service='wfs', version='1.1.0', request='DescribeFeatureType',
-            typename='tows:layer_1'
+            service="wfs", version="1.1.0", request="DescribeFeatureType",
+            typename="tows:layer_1"
         ))
 
         proxy = self.get_fake_proxy_(request, "unfiltered response", 200)
 
         response = proxy.proxy()
-        self.assertEquals('200 OK', response.status)
+        self.assertEquals("200 OK", response.status)
 
     @attr(functional=True)
     def test_proxy_describe_feature_type_invalid_layer(self):
         from pyramid.httpexceptions import HTTPForbidden
 
-        request = _create_dummy_request(username=u'__test_user1')
+        request = _create_dummy_request(username=u"__test_user1")
         request.params.update(dict(
-            service='wfs', version='1.1.0', request='DescribeFeatureType',
-            typename='tows:layer_3'
+            service="wfs", version="1.1.0", request="DescribeFeatureType",
+            typename="tows:layer_3"
         ))
 
         proxy = self.get_fake_proxy_(request, "", None)
@@ -285,7 +285,7 @@ class TestTinyOWSProxyView(TestCase):
 
     @attr(functional=True)
     def test_proxy_describe_feature_type_post(self):
-        request = _create_dummy_request(username=u'__test_user1')
+        request = _create_dummy_request(username=u"__test_user1")
         request.method = "POST"
         request.body = load_file(
             TestTinyOWSProxyView.describefeaturetype_request_file)
@@ -293,13 +293,13 @@ class TestTinyOWSProxyView(TestCase):
         proxy = self.get_fake_proxy_(request, "unfiltered response", 200)
 
         response = proxy.proxy()
-        self.assertEquals('200 OK', response.status)
+        self.assertEquals("200 OK", response.status)
 
     @attr(functional=True)
     def test_proxy_describe_feature_type_post_multiple_types(self):
         from pyramid.httpexceptions import HTTPBadRequest
 
-        request = _create_dummy_request(username=u'__test_user1')
+        request = _create_dummy_request(username=u"__test_user1")
         request.method = "POST"
         request.body = load_file(
             TestTinyOWSProxyView.describefeaturetype_request_multiple_file)
@@ -310,21 +310,21 @@ class TestTinyOWSProxyView(TestCase):
 
 @attr(functional=True)
 class TestTinyOWSProxyViewNoDb(TestCase):
-    data_base = 'c2cgeoportal/tests/data/'
+    data_base = "c2cgeoportal/tests/data/"
     capabilities_request_file = \
-        data_base + 'tinyows_getcapabilities_request.xml'
+        data_base + "tinyows_getcapabilities_request.xml"
     describefeature_request_file = \
-        data_base + 'tinyows_describefeaturetype_request.xml'
+        data_base + "tinyows_describefeaturetype_request.xml"
     getfeature_request_file = \
-        data_base + 'tinyows_getfeature_request.xml'
+        data_base + "tinyows_getfeature_request.xml"
     lockfeature_request_file = \
-        data_base + 'tinyows_lockfeature_request.xml'
+        data_base + "tinyows_lockfeature_request.xml"
     transaction_update_request_file = \
-        data_base + 'tinyows_transaction_update_request.xml'
+        data_base + "tinyows_transaction_update_request.xml"
     transaction_delete_request_file = \
-        data_base + 'tinyows_transaction_delete_request.xml'
+        data_base + "tinyows_transaction_delete_request.xml"
     transaction_insert_request_file = \
-        data_base + 'tinyows_transaction_insert_request.xml'
+        data_base + "tinyows_transaction_insert_request.xml"
 
     def test_parse_body_getcapabilities(self):
         from c2cgeoportal.views.tinyowsproxy import TinyOWSProxy
@@ -337,7 +337,7 @@ class TestTinyOWSProxyViewNoDb(TestCase):
 
         proxy = TinyOWSProxy(request)
         (operation, typename) = proxy._parse_body(request.body)
-        self.assertEquals('getcapabilities', operation)
+        self.assertEquals("getcapabilities", operation)
         self.assertEquals(set(), typename)
 
     def test_parse_body_describefeaturetype(self):
@@ -351,8 +351,8 @@ class TestTinyOWSProxyViewNoDb(TestCase):
 
         proxy = TinyOWSProxy(request)
         (operation, typename) = proxy._parse_body(request.body)
-        self.assertEquals('describefeaturetype', operation)
-        self.assertEquals(set(['layer_1']), typename)
+        self.assertEquals("describefeaturetype", operation)
+        self.assertEquals(set(["layer_1"]), typename)
 
     def test_parse_body_getfeature(self):
         from c2cgeoportal.views.tinyowsproxy import TinyOWSProxy
@@ -365,8 +365,8 @@ class TestTinyOWSProxyViewNoDb(TestCase):
 
         proxy = TinyOWSProxy(request)
         (operation, typename) = proxy._parse_body(request.body)
-        self.assertEquals('getfeature', operation)
-        self.assertEquals(set(['parks']), typename)
+        self.assertEquals("getfeature", operation)
+        self.assertEquals(set(["parks"]), typename)
 
     def test_parse_body_lockfeature(self):
         from c2cgeoportal.views.tinyowsproxy import TinyOWSProxy
@@ -379,8 +379,8 @@ class TestTinyOWSProxyViewNoDb(TestCase):
 
         proxy = TinyOWSProxy(request)
         (operation, typename) = proxy._parse_body(request.body)
-        self.assertEquals('lockfeature', operation)
-        self.assertEquals(set(['parks']), typename)
+        self.assertEquals("lockfeature", operation)
+        self.assertEquals(set(["parks"]), typename)
 
     def test_parse_body_transaction_update(self):
         from c2cgeoportal.views.tinyowsproxy import TinyOWSProxy
@@ -393,8 +393,8 @@ class TestTinyOWSProxyViewNoDb(TestCase):
 
         proxy = TinyOWSProxy(request)
         (operation, typename) = proxy._parse_body(request.body)
-        self.assertEquals('transaction', operation)
-        self.assertEquals(set(['parks']), typename)
+        self.assertEquals("transaction", operation)
+        self.assertEquals(set(["parks"]), typename)
 
     def test_parse_body_transaction_delete(self):
         from c2cgeoportal.views.tinyowsproxy import TinyOWSProxy
@@ -407,8 +407,8 @@ class TestTinyOWSProxyViewNoDb(TestCase):
 
         proxy = TinyOWSProxy(request)
         (operation, typename) = proxy._parse_body(request.body)
-        self.assertEquals('transaction', operation)
-        self.assertEquals(set(['parks']), typename)
+        self.assertEquals("transaction", operation)
+        self.assertEquals(set(["parks"]), typename)
 
     def test_parse_body_transaction_insert(self):
         from c2cgeoportal.views.tinyowsproxy import TinyOWSProxy
@@ -421,5 +421,5 @@ class TestTinyOWSProxyViewNoDb(TestCase):
 
         proxy = TinyOWSProxy(request)
         (operation, typename) = proxy._parse_body(request.body)
-        self.assertEquals('transaction', operation)
-        self.assertEquals(set(['parks']), typename)
+        self.assertEquals("transaction", operation)
+        self.assertEquals(set(["parks"]), typename)

--- a/c2cgeoportal/tests/functional/test_tinyowsproxy.py
+++ b/c2cgeoportal/tests/functional/test_tinyowsproxy.py
@@ -193,6 +193,7 @@ class TestTinyOWSProxyView(TestCase):
         response = proxy.proxy()
         filtered = load_file(
             TestTinyOWSProxyView.capabilities_response_filtered_file1)
+        response.body = response.body.replace("  \n", "")
         self.assertEquals(filtered, response.body)
         self.assertEquals("200 OK", response.status)
 
@@ -207,6 +208,7 @@ class TestTinyOWSProxyView(TestCase):
         response = proxy.proxy()
         filtered = load_file(
             TestTinyOWSProxyView.capabilities_response_filtered_file2)
+        response.body = response.body.replace("  \n", "")
         self.assertEquals(filtered, response.body)
         self.assertEquals("200 OK", response.status)
 
@@ -225,6 +227,7 @@ class TestTinyOWSProxyView(TestCase):
         response = proxy.proxy()
         filtered = load_file(
             TestTinyOWSProxyView.capabilities_response_filtered_file1)
+        response.body = response.body.replace("  \n", "")
         self.assertEquals(filtered, response.body)
         self.assertEquals("200 OK", response.status)
 
@@ -243,6 +246,7 @@ class TestTinyOWSProxyView(TestCase):
         response = proxy.proxy()
         filtered = load_file(
             TestTinyOWSProxyView.capabilities_response_filtered_file1)
+        response.body = response.body.replace("  \n", "")
         self.assertEquals(filtered, response.body)
         self.assertEquals("200 OK", response.status)
 

--- a/c2cgeoportal/tests/functional/test_tinyowsproxy.py
+++ b/c2cgeoportal/tests/functional/test_tinyowsproxy.py
@@ -264,6 +264,10 @@ class TestTinyOWSProxyView(TestCase):
     @attr(functional=True)
     def test_proxy_describe_feature_type_get(self):
         request = _create_dummy_request(username=u"__test_user1")
+        settings = request.registry.settings.get("tinyowsproxy")
+        settings["online_resource"] = ""
+        settings["proxy_online_resource"] = ""
+        settings["tinyows_host"] = "demo.gmf.org"
         request.params.update(dict(
             service="wfs", version="1.1.0", request="DescribeFeatureType",
             typename="tows:layer_1"

--- a/c2cgeoportal/tests/functional/test_tinyowsproxy.py
+++ b/c2cgeoportal/tests/functional/test_tinyowsproxy.py
@@ -1,0 +1,425 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2013-2014, Camptocamp SA
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# The views and conclusions contained in the software and documentation are those
+# of the authors and should not be interpreted as representing official policies,
+# either expressed or implied, of the FreeBSD Project.
+
+
+from unittest2 import TestCase
+from nose.plugins.attrib import attr
+
+from geoalchemy2 import WKTElement
+import transaction
+import sqlahelper
+
+from c2cgeoportal.tests import load_file
+from c2cgeoportal.tests.functional import (  # noqa
+    tear_down_common as tearDownModule,
+    set_up_common as setUpModule,
+    create_dummy_request, mapserv_url)
+
+Base = sqlahelper.get_base()
+
+
+def _create_dummy_request(username=None):
+    from c2cgeoportal.models import DBSession, User
+
+    request = create_dummy_request({
+        'tinyowsproxy': {
+            'tinyows_url': 'http://localhost/tinyows',
+            'online_resource': 'http://domain.com/tinyows_proxy',
+            'proxy_online_resource': 'http://domain.com/tinyows'
+        }
+    })
+    request.user = None if username is None else \
+        DBSession.query(User).filter_by(username=username).one()
+    return request
+
+
+@attr(functional=True)
+class TestTinyOWSProxyView(TestCase):
+    data_base = 'c2cgeoportal/tests/data/'
+    capabilities_response_file = \
+        data_base + 'tinyows_getcapabilities_layer.xml'
+    capabilities_response_filtered_file1 = \
+        data_base + 'tinyows_getcapabilities_layer_filtered_user1.xml'
+    capabilities_response_filtered_file2 = \
+        data_base + 'tinyows_getcapabilities_layer_filtered_user2.xml'
+    capabilities_request_file = \
+        data_base + 'tinyows_getcapabilities_request.xml'
+    describefeaturetype_request_file = \
+        data_base + 'tinyows_describefeaturetype_request.xml'
+    describefeaturetype_request_multiple_file = \
+        data_base + 'tinyows_describefeaturetype_request_multiple.xml'
+
+    def setUp(self):  # noqa
+        from c2cgeoportal.models import User, Role, LayerV1, RestrictionArea, \
+            Interface, DBSession
+
+        user1 = User(username=u'__test_user1', password=u'__test_user1')
+        role1 = Role(name=u'__test_role1', description=u'__test_role1')
+        user1.role_name = role1.name
+        user1.email = u'Tarenpion'
+
+        user2 = User(username=u'__test_user2', password=u'__test_user2')
+        role2 = Role(name=u'__test_role2', description=u'__test_role2')
+        user2.role_name = role2.name
+        user2.email = u'Tarenpion'
+
+        main = Interface(name=u'main')
+
+        layer1 = LayerV1(u'layer_1', public=False)
+        layer1.interfaces = [main]
+        layer2 = LayerV1(u'layer_2', public=False)
+        layer2.interfaces = [main]
+        layer3 = LayerV1(u'layer_3', public=False)
+        layer3.interfaces = [main]
+
+        area = "POLYGON((-100 30, -100 50, 100 50, 100 30, -100 30))"
+        area = WKTElement(area, srid=21781)
+        restricted_area1 = RestrictionArea(u'__test_ra1', u'', [layer1, layer2], [role1], area, readwrite=True)
+
+        area = "POLYGON((-100 0, -100 20, 100 20, 100 0, -100 0))"
+        area = WKTElement(area, srid=21781)
+        restricted_area2 = RestrictionArea(u'__test_ra2', u'', [layer1, layer2, layer3], [role2], area)
+
+        DBSession.add_all([
+            user1, user2, role1, role2,
+            restricted_area1, restricted_area2
+        ])
+        DBSession.flush()
+
+        transaction.commit()
+
+    def tearDown(self):  # noqa
+        from c2cgeoportal.models import User, Role, LayerV1, RestrictionArea, \
+            Interface, DBSession
+
+        DBSession.query(User).filter(User.username == '__test_user1').delete()
+        DBSession.query(User).filter(User.username == '__test_user2').delete()
+
+        ra = DBSession.query(RestrictionArea).filter(
+            RestrictionArea.name == '__test_ra1'
+        ).one()
+        ra.roles = []
+        ra.layers = []
+        DBSession.delete(ra)
+        ra = DBSession.query(RestrictionArea).filter(
+            RestrictionArea.name == '__test_ra2'
+        ).one()
+        ra.roles = []
+        ra.layers = []
+        DBSession.delete(ra)
+
+        r = DBSession.query(Role).filter(Role.name == '__test_role1').one()
+        r.functionalities = []
+        DBSession.delete(r)
+        r = DBSession.query(Role).filter(Role.name == '__test_role2').one()
+        r.functionalities = []
+        DBSession.delete(r)
+
+        for layer in DBSession.query(LayerV1).filter(LayerV1.name == 'layer_1').all():
+            DBSession.delete(layer)  # pragma: nocover
+        for layer in DBSession.query(LayerV1).filter(LayerV1.name == 'layer_2').all():
+            DBSession.delete(layer)
+        for layer in DBSession.query(LayerV1).filter(LayerV1.name == 'layer_3').all():
+            DBSession.delete(layer)
+        DBSession.query(Interface).filter(
+            Interface.name == 'main'
+        ).delete()
+
+        transaction.commit()
+
+    def get_fake_proxy_(self, request, response_body, status):
+        from c2cgeoportal.views.tinyowsproxy import TinyOWSProxy
+        from types import MethodType
+
+        proxy = TinyOWSProxy(request)
+
+        def fake_proxy(self, url, params=None, method=None, cache=False, body=None, headers=None):
+            content = response_body
+
+            class FakeResponse(dict):
+                pass
+            resp = FakeResponse()
+            resp.status = status
+            resp['content-type'] = "application/xml"
+
+            return resp, content
+
+        proxy._proxy = MethodType(fake_proxy, proxy, TinyOWSProxy)
+
+        return proxy
+
+    @attr(functional=True)
+    def test_proxy_not_auth(self):
+        from c2cgeoportal.views.tinyowsproxy import TinyOWSProxy
+        from pyramid.httpexceptions import HTTPUnauthorized
+
+        request = _create_dummy_request()
+        self.assertRaises(HTTPUnauthorized, TinyOWSProxy(request).proxy)
+
+    @attr(functional=True)
+    def test_proxy_get_capabilities_user1(self):
+        request = _create_dummy_request(username=u'__test_user1')
+        proxy = self.get_fake_proxy_(
+            request,
+            load_file(TestTinyOWSProxyView.capabilities_response_file),
+            200)
+
+        response = proxy.proxy()
+        filtered = load_file(
+            TestTinyOWSProxyView.capabilities_response_filtered_file1)
+        self.assertEquals(filtered, response.body)
+        self.assertEquals('200 OK', response.status)
+
+    @attr(functional=True)
+    def test_proxy_get_capabilities_user2(self):
+        request = _create_dummy_request(username=u'__test_user2')
+        proxy = self.get_fake_proxy_(
+            request,
+            load_file(TestTinyOWSProxyView.capabilities_response_file),
+            200)
+
+        response = proxy.proxy()
+        filtered = load_file(
+            TestTinyOWSProxyView.capabilities_response_filtered_file2)
+        self.assertEquals(filtered, response.body)
+        self.assertEquals('200 OK', response.status)
+
+    @attr(functional=True)
+    def test_proxy_get_capabilities_get(self):
+        request = _create_dummy_request(username=u'__test_user1')
+        request.params.update(dict(
+            service='wfs', version='1.1.0', request='GetCapabilities'
+        ))
+
+        proxy = self.get_fake_proxy_(
+            request,
+            load_file(TestTinyOWSProxyView.capabilities_response_file),
+            200)
+
+        response = proxy.proxy()
+        filtered = load_file(
+            TestTinyOWSProxyView.capabilities_response_filtered_file1)
+        self.assertEquals(filtered, response.body)
+        self.assertEquals('200 OK', response.status)
+
+    @attr(functional=True)
+    def test_proxy_get_capabilities_post(self):
+        request = _create_dummy_request(username=u'__test_user1')
+        request.method = "POST"
+        request.body = load_file(
+            TestTinyOWSProxyView.capabilities_request_file)
+
+        proxy = self.get_fake_proxy_(
+            request,
+            load_file(TestTinyOWSProxyView.capabilities_response_file),
+            200)
+
+        response = proxy.proxy()
+        filtered = load_file(
+            TestTinyOWSProxyView.capabilities_response_filtered_file1)
+        self.assertEquals(filtered, response.body)
+        self.assertEquals('200 OK', response.status)
+
+    @attr(functional=True)
+    def test_proxy_get_capabilities_post_invalid_body(self):
+        from pyramid.httpexceptions import HTTPBadRequest
+
+        request = _create_dummy_request(username=u'__test_user1')
+        request.method = "POST"
+        request.body = "This is not XML"
+
+        proxy = self.get_fake_proxy_(request, "", None)
+        self.assertRaises(HTTPBadRequest, proxy.proxy)
+
+    @attr(functional=True)
+    def test_proxy_describe_feature_type_get(self):
+        request = _create_dummy_request(username=u'__test_user1')
+        request.params.update(dict(
+            service='wfs', version='1.1.0', request='DescribeFeatureType',
+            typename='tows:layer_1'
+        ))
+
+        proxy = self.get_fake_proxy_(request, "unfiltered response", 200)
+
+        response = proxy.proxy()
+        self.assertEquals('200 OK', response.status)
+
+    @attr(functional=True)
+    def test_proxy_describe_feature_type_invalid_layer(self):
+        from pyramid.httpexceptions import HTTPForbidden
+
+        request = _create_dummy_request(username=u'__test_user1')
+        request.params.update(dict(
+            service='wfs', version='1.1.0', request='DescribeFeatureType',
+            typename='tows:layer_3'
+        ))
+
+        proxy = self.get_fake_proxy_(request, "", None)
+        self.assertRaises(HTTPForbidden, proxy.proxy)
+
+    @attr(functional=True)
+    def test_proxy_describe_feature_type_post(self):
+        request = _create_dummy_request(username=u'__test_user1')
+        request.method = "POST"
+        request.body = load_file(
+            TestTinyOWSProxyView.describefeaturetype_request_file)
+
+        proxy = self.get_fake_proxy_(request, "unfiltered response", 200)
+
+        response = proxy.proxy()
+        self.assertEquals('200 OK', response.status)
+
+    @attr(functional=True)
+    def test_proxy_describe_feature_type_post_multiple_types(self):
+        from pyramid.httpexceptions import HTTPBadRequest
+
+        request = _create_dummy_request(username=u'__test_user1')
+        request.method = "POST"
+        request.body = load_file(
+            TestTinyOWSProxyView.describefeaturetype_request_multiple_file)
+
+        proxy = self.get_fake_proxy_(request, "", None)
+        self.assertRaises(HTTPBadRequest, proxy.proxy)
+
+
+@attr(functional=True)
+class TestTinyOWSProxyViewNoDb(TestCase):
+    data_base = 'c2cgeoportal/tests/data/'
+    capabilities_request_file = \
+        data_base + 'tinyows_getcapabilities_request.xml'
+    describefeature_request_file = \
+        data_base + 'tinyows_describefeaturetype_request.xml'
+    getfeature_request_file = \
+        data_base + 'tinyows_getfeature_request.xml'
+    lockfeature_request_file = \
+        data_base + 'tinyows_lockfeature_request.xml'
+    transaction_update_request_file = \
+        data_base + 'tinyows_transaction_update_request.xml'
+    transaction_delete_request_file = \
+        data_base + 'tinyows_transaction_delete_request.xml'
+    transaction_insert_request_file = \
+        data_base + 'tinyows_transaction_insert_request.xml'
+
+    def test_parse_body_getcapabilities(self):
+        from c2cgeoportal.views.tinyowsproxy import TinyOWSProxy
+
+        request = _create_dummy_request()
+
+        capabilities_request = \
+            load_file(TestTinyOWSProxyViewNoDb.capabilities_request_file)
+        request.body = capabilities_request
+
+        proxy = TinyOWSProxy(request)
+        (operation, typename) = proxy._parse_body(request.body)
+        self.assertEquals('getcapabilities', operation)
+        self.assertEquals(set(), typename)
+
+    def test_parse_body_describefeaturetype(self):
+        from c2cgeoportal.views.tinyowsproxy import TinyOWSProxy
+
+        request = _create_dummy_request()
+
+        describefeature_request = \
+            load_file(TestTinyOWSProxyViewNoDb.describefeature_request_file)
+        request.body = describefeature_request
+
+        proxy = TinyOWSProxy(request)
+        (operation, typename) = proxy._parse_body(request.body)
+        self.assertEquals('describefeaturetype', operation)
+        self.assertEquals(set(['layer_1']), typename)
+
+    def test_parse_body_getfeature(self):
+        from c2cgeoportal.views.tinyowsproxy import TinyOWSProxy
+
+        request = _create_dummy_request()
+
+        getfeature_request = \
+            load_file(TestTinyOWSProxyViewNoDb.getfeature_request_file)
+        request.body = getfeature_request
+
+        proxy = TinyOWSProxy(request)
+        (operation, typename) = proxy._parse_body(request.body)
+        self.assertEquals('getfeature', operation)
+        self.assertEquals(set(['parks']), typename)
+
+    def test_parse_body_lockfeature(self):
+        from c2cgeoportal.views.tinyowsproxy import TinyOWSProxy
+
+        request = _create_dummy_request()
+
+        lockfeature_request = \
+            load_file(TestTinyOWSProxyViewNoDb.lockfeature_request_file)
+        request.body = lockfeature_request
+
+        proxy = TinyOWSProxy(request)
+        (operation, typename) = proxy._parse_body(request.body)
+        self.assertEquals('lockfeature', operation)
+        self.assertEquals(set(['parks']), typename)
+
+    def test_parse_body_transaction_update(self):
+        from c2cgeoportal.views.tinyowsproxy import TinyOWSProxy
+
+        request = _create_dummy_request()
+
+        transaction_update_request = \
+            load_file(TestTinyOWSProxyViewNoDb.transaction_update_request_file)
+        request.body = transaction_update_request
+
+        proxy = TinyOWSProxy(request)
+        (operation, typename) = proxy._parse_body(request.body)
+        self.assertEquals('transaction', operation)
+        self.assertEquals(set(['parks']), typename)
+
+    def test_parse_body_transaction_delete(self):
+        from c2cgeoportal.views.tinyowsproxy import TinyOWSProxy
+
+        request = _create_dummy_request()
+
+        transaction_delete_request = \
+            load_file(TestTinyOWSProxyViewNoDb.transaction_delete_request_file)
+        request.body = transaction_delete_request
+
+        proxy = TinyOWSProxy(request)
+        (operation, typename) = proxy._parse_body(request.body)
+        self.assertEquals('transaction', operation)
+        self.assertEquals(set(['parks']), typename)
+
+    def test_parse_body_transaction_insert(self):
+        from c2cgeoportal.views.tinyowsproxy import TinyOWSProxy
+
+        request = _create_dummy_request()
+
+        transaction_insert_request = \
+            load_file(TestTinyOWSProxyViewNoDb.transaction_insert_request_file)
+        request.body = transaction_insert_request
+
+        proxy = TinyOWSProxy(request)
+        (operation, typename) = proxy._parse_body(request.body)
+        self.assertEquals('transaction', operation)
+        self.assertEquals(set(['parks']), typename)

--- a/c2cgeoportal/views/mapserverproxy.py
+++ b/c2cgeoportal/views/mapserverproxy.py
@@ -78,9 +78,7 @@ class MapservProxy(Proxy):
         if "user_id" in params:  # pragma: no cover
             del params["user_id"]
 
-        self.lower_params = dict(
-            (k.lower(), unicode(v).lower()) for k, v in params.iteritems()
-        )
+        self.lower_params = self._get_lower_params(params)
 
         if self.user is not None:
             # We have a user logged in. We need to set group_id and
@@ -158,12 +156,6 @@ class MapservProxy(Proxy):
             response.cache_control.public = False
             response.cache_control.private = True
         return response
-
-    def _get_headers(self):
-        headers = self.request.headers
-        if "Cookie" in headers:  # pragma: no cover
-            headers.pop("Cookie")
-        return headers
 
     def _proxy_callback(self, role_id, *args, **kwargs):
         params = kwargs.get("params", {})

--- a/c2cgeoportal/views/proxy.py
+++ b/c2cgeoportal/views/proxy.py
@@ -211,3 +211,14 @@ class Proxy:
             response.cache_control.no_cache = True
 
         return response
+
+    def _get_lower_params(self, params):
+        return dict(
+            (k.lower(), unicode(v).lower()) for k, v in params.iteritems()
+        )
+
+    def _get_headers(self):
+        headers = self.request.headers
+        if 'Cookie' in headers:  # pragma: no cover
+            headers.pop('Cookie')
+        return headers

--- a/c2cgeoportal/views/proxy.py
+++ b/c2cgeoportal/views/proxy.py
@@ -219,6 +219,6 @@ class Proxy:
 
     def _get_headers(self):
         headers = self.request.headers
-        if 'Cookie' in headers:  # pragma: no cover
-            headers.pop('Cookie')
+        if "Cookie" in headers:  # pragma: no cover
+            headers.pop("Cookie")
         return headers

--- a/c2cgeoportal/views/tinyowsproxy.py
+++ b/c2cgeoportal/views/tinyowsproxy.py
@@ -51,12 +51,8 @@ class TinyOWSProxy(Proxy):
         Proxy.__init__(self, request)
         self.settings = request.registry.settings.get("tinyowsproxy", {})
 
-        assert self.settings.get("tinyows_url", ""), \
+        assert self.settings.get("tinyows_url", "") != "", \
             "tinyowsproxy.tinyows_url must be set"
-        assert self.settings.get("online_resource", ""), \
-            "tinyowsproxy.online_resource must be set"
-        assert self.settings.get("proxy_online_resource", ""), \
-            "tinyowsproxy.proxy_online_resource must be set"
 
     def _get_wfs_url(self):
         return self.settings.get("tinyows_url")
@@ -134,7 +130,7 @@ class TinyOWSProxy(Proxy):
 
     def _get_headers(self):
         headers = Proxy._get_headers(self)
-        if self.settings.get("tinyows_host", "") != "":
+        if "tinyows_host" in self.settings:
             headers["Host"] = self.settings.get("tinyows_host")
         return headers
 
@@ -151,8 +147,8 @@ class TinyOWSProxy(Proxy):
 
         content = self._filter_urls(
             content,
-            self.settings.get("online_resource"),
-            self.settings.get("proxy_online_resource"))
+            self.settings.get("online_resource", ""),
+            self.settings.get("proxy_online_resource", ""))
 
         headers = {
             "Content-Type": resp["content-type"],
@@ -162,7 +158,10 @@ class TinyOWSProxy(Proxy):
         return self._build_response(resp, content, cache, "tinyows", headers)
 
     def _filter_urls(self, content, online_resource, proxy_online_resource):
-        return content.replace(online_resource, proxy_online_resource)
+        if online_resource != "" and proxy_online_resource != "":
+            return content.replace(online_resource, proxy_online_resource)
+        else:
+            return content
 
     def _parse_body(self, body):
         """

--- a/c2cgeoportal/views/tinyowsproxy.py
+++ b/c2cgeoportal/views/tinyowsproxy.py
@@ -132,6 +132,12 @@ class TinyOWSProxy(Proxy):
         writable_layers = get_writable_layers(self.role_id)
         return typenames.issubset(writable_layers)
 
+    def _get_headers(self):
+        headers = Proxy._get_headers(self)
+        if self.settings.get("tinyows_host", "") != "":
+            headers['Host'] = self.settings.get("tinyows_host")
+        return headers
+
     def _proxy_callback(self, operation, role_id, *args, **kwargs):
         cache = kwargs.get('cache', False)
         resp, content = self._proxy(*args, **kwargs)
@@ -140,7 +146,6 @@ class TinyOWSProxy(Proxy):
             content = filter_wfst_capabilities(
                 content, role_id,
                 self._get_wfs_url(),
-                self.request.headers,
                 self.settings.get('proxies', None)
             )
 

--- a/c2cgeoportal/views/tinyowsproxy.py
+++ b/c2cgeoportal/views/tinyowsproxy.py
@@ -1,0 +1,185 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2011-2015, Camptocamp SA
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# The views and conclusions contained in the software and documentation are those
+# of the authors and should not be interpreted as representing official policies,
+# either expressed or implied, of the FreeBSD Project.
+
+
+import logging
+
+from pyramid.view import view_config
+from xml.etree import ElementTree
+from pyramid.httpexceptions import (
+    HTTPForbidden, HTTPBadRequest, HTTPUnauthorized)
+
+from c2cgeoportal.lib.caching import get_region
+from c2cgeoportal.lib.filter_capabilities import (
+    filter_wfst_capabilities, normalize_tag, normalize_typename,
+    get_writable_layers)
+from c2cgeoportal.views.proxy import Proxy
+
+cache_region = get_region()
+log = logging.getLogger(__name__)
+
+
+class TinyOWSProxy(Proxy):
+
+    def __init__(self, request):
+        Proxy.__init__(self, request)
+        self.settings = request.registry.settings.get("tinyowsproxy", {})
+
+        assert self.settings.get('tinyows_url', ''), \
+            'tinyowsproxy.tinyows_url must be set'
+        assert self.settings.get('online_resource', ''), \
+            'tinyowsproxy.online_resource must be set'
+        assert self.settings.get('proxy_online_resource', ''), \
+            'tinyowsproxy.proxy_online_resource must be set'
+
+    def _get_wfs_url(self):
+        return self.settings.get("tinyows_url")
+
+    @view_config(route_name='tinyowsproxy')
+    def proxy(self):
+        self.user = self.request.user
+
+        if self.user is None:
+            raise HTTPUnauthorized(
+                "Authentication required",
+                headers=[("WWW-Authenticate", "Basic realm=\"TinyOWS\"")])
+        self.role_id = None if self.user is None else self.user.role.id
+
+        # params hold the parameters we're going to send to TinyOWS
+        params = dict(self.request.params)
+        self.lower_params = self._get_lower_params(params)
+
+        operation = self.lower_params.get('request', None)
+        typenames = \
+            set([normalize_typename(self.lower_params.get('typename'))]) \
+            if 'typename' in self.lower_params \
+            else set()
+
+        method = self.request.method
+        if method == 'POST':
+            try:
+                (operation, typenames_post) = \
+                    self._parse_body(self.request.body)
+            except Exception as e:
+                log.error("Error while parsing POST request body")
+                log.exception(e)
+                raise HTTPBadRequest(
+                    'Error parsing the request (see logs for more details)')
+
+            typenames = typenames.union(typenames_post)
+
+        if operation is None or operation == '':
+            operation = 'getcapabilities'
+
+        if operation == 'describefeaturetype':
+            # for DescribeFeatureType we require that exactly one type-name
+            # is given, otherwise we would have to filter the result
+            if len(typenames) != 1:
+                raise HTTPBadRequest(
+                    'Exactly one type-name must be given for ' +
+                    'DescribeFeatureType requests')
+
+        if not self._is_allowed(typenames):
+            raise HTTPForbidden(
+                'No access rights for at least one of the given type-names')
+
+        # we want clients to cache GetCapabilities and DescribeFeatureType req.
+        use_cache = method == 'GET' and operation in \
+            (u'getcapabilities', u'describefeaturetype')
+
+        response = self._proxy_callback(
+            operation=operation,
+            url=self._get_wfs_url(), params=params, cache=use_cache,
+            headers=self._get_headers(), body=self.request.body,
+            role_id=self.role_id
+        )
+        if use_cache:
+            response.cache_control.public = False
+            response.cache_control.private = True
+        return response
+
+    def _is_allowed(self, typenames):
+        """
+        Checks if the current user has the rights to access the given
+        type-names.
+        """
+        writable_layers = get_writable_layers(self.role_id)
+        return typenames.issubset(writable_layers)
+
+    def _proxy_callback(self, operation, role_id, *args, **kwargs):
+        cache = kwargs.get('cache', False)
+        resp, content = self._proxy(*args, **kwargs)
+
+        if operation == 'getcapabilities':
+            content = filter_wfst_capabilities(
+                content, role_id,
+                self._get_wfs_url(),
+                self.request.headers,
+                self.settings.get('proxies', None)
+            )
+
+        content = self._filter_urls(
+            content,
+            self.settings.get('online_resource'),
+            self.settings.get('proxy_online_resource'))
+
+        headers = {
+            "Content-Type": resp["content-type"],
+            "Access-Control-Allow-Origin": "*",
+        }
+
+        return self._build_response(resp, content, cache, "tinyows", headers)
+
+    def _filter_urls(self, content, online_resource, proxy_online_resource):
+        return content.replace(online_resource, proxy_online_resource)
+
+    def _parse_body(self, body):
+        """
+        Read the WFS-T request body and extract the referenced type-names
+        and request method.
+        """
+        xml = ElementTree.fromstring(body)
+        wfs_request = normalize_tag(xml.tag)
+
+        # get the type names
+        typenames = set()
+        for child in xml:
+            tag = normalize_tag(child.tag)
+            if tag == 'typename':
+                typenames.add(child.text)
+            elif tag in ('query', 'lock', 'update', 'delete'):
+                typenames.add(child.get('typeName'))
+            elif tag == 'insert':
+                for insert_child in child:
+                    typenames.add(normalize_tag(insert_child.tag))
+
+        # remove the namespace from the typenames
+        typenames = {normalize_typename(t) for t in typenames}
+
+        return (wfs_request, typenames)

--- a/doc/administrator/editing.rst
+++ b/doc/administrator/editing.rst
@@ -76,7 +76,7 @@ corresponding to this field is *Related Postgres table* in the admin interface.
 
 .. warning::
 
-    Acctually the editing widn't work well with many ediable layers.
+    Actually, the editing doesn't work well with many editable layers.
 
 
 Configuring security

--- a/doc/administrator/index.rst
+++ b/doc/administrator/index.rst
@@ -23,3 +23,4 @@ Content:
    mapfile
    administrate
    editing
+   tinyows

--- a/doc/administrator/tinyows.rst
+++ b/doc/administrator/tinyows.rst
@@ -1,0 +1,140 @@
+.. _administrator_tinyows:
+
+WFS-T with TinyOWS
+==================
+Based on `TinyOWS <http://mapserver.org/tinyows/>`__ c2cgeoportal layers can be
+edited via WFS-T, for example using QGIS as a client. c2cgeoportal acts as a
+proxy to TinyOWS to limit access to authorized users.
+
+The following explains how to configure WFS-T for a c2cgeoportal layer.
+
+Apache configuration for TinyOWS
+---------------------------------
+
+When creating a c2cgeoportal project using the :ref:`Paste skeletons <integrator_create_application>`
+there will already be a default Apache configuration file for TinyOWS under the
+location ``apache/tinyows.conf.mako``. Uncomment the lines in this file to
+enable TinyOWS::
+
+    ScriptAlias /${instanceid}/tinyows /usr/lib/cgi-bin/tinyows
+    <Location /${instanceid}/tinyows>
+      SetEnv TINYOWS_CONFIG_FILE ${directory}/mapserver/tinyows.xml
+
+      # restrict access to localhost so that all requests go through the proxy
+      Options All
+      Order deny,allow
+      Deny from all
+      Allow from 127.0.0.1 ::1
+    </Location>
+
+Make sure that the location of TinyOWS (``/usr/lib/cgi-bin/tinyows``) matches
+your installation. The configuration restricts the access to TinyOWS to
+``localhost`` so that all external requests go through the TinyOWS proxy of
+c2cgeoportal.
+
+TinyOWS configuration
+---------------------
+
+The configuration of TinyOWS is made in a XML file, which is located at
+``mapserver/tinyows.xml.mako``::
+
+    <tinyows
+        online_resource="http://${host}/${instanceid}/wsgi/tinyows_proxy"
+        schema_dir="/usr/share/tinyows/schema/"
+        log="tinyows.log"
+        log_level="1"
+        check_schema="0">
+
+      <contact
+          name="GeoMapFish"
+          site="http://www.geomapfish.org/"
+          email="geomapfish@googlegroups.com" />
+
+      <metadata
+          name="GeoMapFish TinyOWS Server"
+          title="GeoMapFish TinyOWS Server" />
+
+      <pg
+          host="${dbhost}"
+          user="${dbuser}"
+          password="${dbpassword}"
+          port="${dbport}"
+          dbname="${db}" />
+
+      <layer
+          retrievable="1"
+          writable="1"
+          ns_prefix="tows"
+          ns_uri="http://www.tinyows.org/"
+          name="point"
+          schema="edit"
+          table="point"
+          title="Points"
+          pkey="id" />
+    </tinyows>
+
+In the root element ``tinyows`` the following properties have to be set:
+
+1. ``online_resource`` - This should be the URL to the TinyOWS proxy, usually
+   ``http://${host}/${instanceid}/wsgi/tinyows_proxy``.
+2. ``schema_dir`` - The path to the TinyOWS schema directory. Adapt this path
+   according to your installation.
+3. ``log`` - Path to the TinyOWS log file. This file must be writable.
+4. ``log_level`` - The log level (default: 1). Please refer to the
+   `TinyOWS documentation <http://mapserver.org/tinyows/configfile.html#tinyows-element>`__
+   for more information.
+5. ``check_schema`` - If the input data is validated against the schema when
+   creating new features. In a vhost environment the schema check has to be
+   disabled, so that the proxy can function properly. This doesn't disable
+   the validation database-side though!
+
+The database connection is configured in the element ``pg``. By default the
+same database as for the c2cgeoportal application will be used.
+
+The layers that should be accessible with TinyOWS have to specified with
+``layer`` elements::
+
+      <layer
+          retrievable="1"
+          writable="1"
+          ns_prefix="tows"
+          ns_uri="http://www.tinyows.org/"
+          name="point"
+          schema="edit"
+          table="point"
+          title="Points"
+          pkey="id" />
+
+In this example a layer named ``point`` is created for table ``point`` in the
+database schema ``edit`` with the primary key column ``id``. This layer is both
+``retrievable`` and ``writable``.
+
+The referenced database table must contain a single geometry column and must
+provide a sequence for the primary key so that new entities can be created.
+
+The layer's name must match the name of a c2cgeoportal layer. This c2cgeoportal
+layer must be assigned to a restriction-area  whose``readwrite`` flag is
+enabled. The restriction-area will be used inside the proxy to restrict the
+access to a layer to the users of a restriction-area.
+
+.. warning::
+
+    The actual *area* of a restriction-area is ignored in the TinyOWS proxy.
+    The proxy only checks for authorized users. To limit the access to a
+    specific area, the ``geobbox`` property has to be set for a layer in the
+    TinyOWS XML configuration. Please refer to the
+    `TinyOWS documentation <http://mapserver.org/tinyows/configfile.html#layer-element>`__
+    for more information.
+
+After the configuration is made, re-build the c2cgeoportal application::
+
+    make <profile>.mk build
+
+Editing a layer with WFS-T
+--------------------------
+
+The configured layers can now be edited using your favorite GIS supporting
+WFS-T. For example in QGIS add a new WFS layer with the URL
+``http://${host}/${instanceid}/wsgi/tinyows_proxy`` (e.g.
+``http://geomapfish.demo-camptocamp.com/demo/wsgi/tinyows_proxy``). For the
+authentication use your c2cgeoportal account details.


### PR DESCRIPTION
This PR adds a proxy for TinyOWS which checks if a user has the rights to access a layer. A user has the right to read or write a layer, if the layer belongs to one of the user's restrictions areas and the `readwrite` flag of that restriction area is set to `True`.

It is important to note that the proxy does not take into account the area of a restriction area, contrary to the MapServer proxy which makes sure that only the features inside the defined area are returned. This is because the restriction extent would have to be hard-coded in the TinyOWS configuration file (see attribute [geobbox](http://mapserver.org/tinyows/configfile.html#layer-element)). So, if the access should restricted to a certain area, this area would have to be set in the configuration file.

This PR is not yet finished, but reviews are already welcome! Still to do:

* [x] Update documentation
* [x] Update demo