### PR TITLE
Add support for datepicker widget

### DIFF
--- a/c2cgeoportal/forms.py
+++ b/c2cgeoportal/forms.py
@@ -399,6 +399,10 @@ time_options = [
     ("value", _("value")),
     ("range", _("range")),
 ]
+time_widget_options = [
+    ("slider", _("slider")),
+    ("datepicker", _("datepicker")),
+]
 
 # Layer V1
 LayerV1 = FieldSet(models.LayerV1)
@@ -419,6 +423,10 @@ LayerV1.time_mode.set(
     renderer=SelectFieldRenderer,
     options=time_options,
 )
+LayerV1.time_widget.set(
+    renderer=SelectFieldRenderer,
+    options=time_widget_options,
+)
 LayerV1.interfaces.set(renderer=CheckBoxSet)
 LayerV1.ui_metadata.set(readonly=True)
 LayerV1.restrictionareas.set(renderer=CheckBoxSet)
@@ -434,6 +442,10 @@ LayerInternalWMS.time_mode.set(
     renderer=SelectFieldRenderer,
     options=time_options,
 )
+LayerInternalWMS.time_widget.set(
+    renderer=SelectFieldRenderer,
+    options=time_widget_options,
+)
 LayerInternalWMS.interfaces.set(renderer=CheckBoxSet)
 LayerInternalWMS.ui_metadata.set(readonly=True)
 LayerInternalWMS.restrictionareas.set(renderer=CheckBoxSet)
@@ -448,6 +460,10 @@ LayerExternalWMS.image_type.set(
 LayerExternalWMS.time_mode.set(
     renderer=SelectFieldRenderer,
     options=time_options,
+)
+LayerExternalWMS.time_widget.set(
+    renderer=SelectFieldRenderer,
+    options=time_widget_options,
 )
 LayerExternalWMS.interfaces.set(renderer=CheckBoxSet)
 LayerExternalWMS.ui_metadata.set(readonly=True)

--- a/c2cgeoportal/lib/wmstparsing.py
+++ b/c2cgeoportal/lib/wmstparsing.py
@@ -39,19 +39,22 @@ class TimeInformation(object):
     * ``extent`` A time extent instance (``TimeExtentValue`` or
                  ``TimeExtentInterval``)
     * ``mode`` The layer mode ("single", "range" or "disabled")
+    * ``widget`` The layer mode ("slider" (default) or "datepicker")
     """
     def __init__(self):
         self.extent = None
         self.mode = None
+        self.widget = None
         self.layer = None
 
-    def merge(self, layer, extent, mode):
+    def merge(self, layer, extent, mode, widget):
         layer_apply = \
             self.layer == layer or \
             (not self.has_time() and extent is not None)
 
         self.merge_extent(extent)
         self.merge_mode(mode)
+        self.merge_widget(widget)
 
         if layer_apply:
             layer["time"] = self.to_dict()
@@ -77,6 +80,18 @@ class TimeInformation(object):
             else:
                 self.mode = mode
 
+    def merge_widget(self, widget):
+        widget = "slider" if not widget else widget
+
+        if self.widget:
+            if self.widget != widget:
+                raise ValueError(
+                    "Could not mix time widget '%s' and '%s'"
+                    % (widget, self.widget)
+                )
+        else:
+            self.widget = widget
+
     def has_time(self):
         return self.extent is not None
 
@@ -84,6 +99,7 @@ class TimeInformation(object):
         if self.has_time():
             time = self.extent.to_dict()
             time["mode"] = self.mode
+            time["widget"] = self.widget
             return time
         else:
             return None

--- a/c2cgeoportal/models.py
+++ b/c2cgeoportal/models.py
@@ -567,6 +567,11 @@ class LayerV1(Layer):
         "range",
         native_enum=False), default="disabled", nullable=False,
         label=_(u"Time mode"))
+    time_widget = Column(Enum(
+        "slider",
+        "datepicker",
+        native_enum=False), default="slider", nullable=True,
+        label=_(u"Time widget"))
 
     def __init__(
         self, name=u"", public=True, icon=u"",
@@ -604,6 +609,11 @@ class LayerInternalWMS(Layer):
         native_enum=False), default="disabled", nullable=False,
         label=_(u"Time mode")
     )
+    time_widget = Column(Enum(
+        "slider",
+        "datepicker",
+        native_enum=False), default="slider", nullable=True,
+        label=_(u"Time widget"))
 
     def __init__(self, name=u"", public=True, icon=u""):
         Layer.__init__(self, name=name, public=public)
@@ -636,6 +646,11 @@ class LayerExternalWMS(Layer):
         "range",
         native_enum=False), default="disabled", nullable=False,
         label=_(u"Time mode"))
+    time_widget = Column(Enum(
+        "slider",
+        "datepicker",
+        native_enum=False), default="slider", nullable=True,
+        label=_(u"Time widget"))
 
     def __init__(self, name=u"", public=True):
         Layer.__init__(self, name=name, public=public)

--- a/c2cgeoportal/scaffolds/update/CONST_alembic/main/versions/5109242131ce_add_column_time_widget.py
+++ b/c2cgeoportal/scaffolds/update/CONST_alembic/main/versions/5109242131ce_add_column_time_widget.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2015, Camptocamp SA
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# The views and conclusions contained in the software and documentation are those
+# of the authors and should not be interpreted as representing official policies,
+# either expressed or implied, of the FreeBSD Project.
+
+"""add column time_widget
+
+Revision ID: 5109242131ce
+Revises: 164ac0819a61
+Create Date: 2015-04-27 17:31:41.760977
+"""
+
+from alembic import op, context
+from sqlalchemy import Column
+from sqlalchemy.types import Unicode
+
+# revision identifiers, used by Alembic.
+revision = "5109242131ce"
+down_revision = "164ac0819a61"
+
+
+def upgrade():
+    schema = context.get_context().config.get_main_option("schema")
+
+    # Instructions
+    for table in ["layerv1", "layer_internal_wms", "layer_external_wms"]:
+        op.add_column(table, Column("time_widget", Unicode(10), default=u"slider"), schema=schema)
+        op.execute("UPDATE %(schema)s.%(table)s SET time_widget = 'slider'" % {
+            "schema": schema, "table": table
+        })
+
+
+def downgrade():
+    schema = context.get_context().config.get_main_option("schema")
+
+    # Instructions
+    for table in ["layerv1", "layer_internal_wms", "layer_external_wms"]:
+        op.drop_column(table, "time_widget", schema=schema)

--- a/c2cgeoportal/tests/functional/test_entry.py
+++ b/c2cgeoportal/tests/functional/test_entry.py
@@ -1179,6 +1179,7 @@ class TestEntryView(TestCase):
             "maxValue": "2010-01-01T00:00:00Z",
             "minValue": "2000-01-01T00:00:00Z",
             "mode": "single",
+            "widget": "slider",
             "minDefValue": "2000-01-01T00:00:00Z",
             "maxDefValue": None,
         })
@@ -1193,6 +1194,7 @@ class TestEntryView(TestCase):
         layer_t2.is_legend_expanded = False
         layer_t2.public = True
         layer_t2.time_mode = "single"
+        layer_t2.time_widget = "slider"
         time = TimeInformation()
         entry._layer(layer_t2, wms=wms, wms_layers=wms_layers, time=time)
         self.assertEqual(time.to_dict(), {
@@ -1201,6 +1203,7 @@ class TestEntryView(TestCase):
             "maxValue": "2020-01-01T00:00:00Z",
             "minValue": "2015-01-01T00:00:00Z",
             "mode": "single",
+            "widget": "slider",
             "minDefValue": "2015-01-01T00:00:00Z",
             "maxDefValue": None,
         })
@@ -1216,6 +1219,7 @@ class TestEntryView(TestCase):
             "maxValue": "2020-01-01T00:00:00Z",
             "minValue": "2000-01-01T00:00:00Z",
             "mode": "single",
+            "widget": "slider",
             "minDefValue": "2000-01-01T00:00:00Z",
             "maxDefValue": None,
         })
@@ -1230,6 +1234,7 @@ class TestEntryView(TestCase):
         layer.is_legend_expanded = False
         layer.public = True
         layer.time_mode = "single"
+        layer.time_widget = "datepicker"
         time = TimeInformation()
         entry._layer(layer, wms=wms, wms_layers=wms_layers, time=time)
         self.assertEqual(time.to_dict(), {
@@ -1238,6 +1243,7 @@ class TestEntryView(TestCase):
             "maxValue": "2020-01-01T00:00:00Z",
             "minValue": "2000-01-01T00:00:00Z",
             "mode": "single",
+            "widget": "datepicker",
             "minDefValue": "2000-01-01T00:00:00Z",
             "maxDefValue": None,
         })

--- a/c2cgeoportal/tests/functional/test_themes_time.py
+++ b/c2cgeoportal/tests/functional/test_themes_time.py
@@ -87,6 +87,7 @@ class TestThemesTimeView(TestCase):
         layer_wms_group = LayerInternalWMS(name=u"__test_layer_time_group", public=True)
         layer_wms_group.layer = "test_wmstimegroup"
         layer_wms_group.time_mode = "range"
+        layer_wms_group.time_widget = "datepicker"
         layer_wms_group.interfaces = [main]
 
         layer_group_1 = LayerGroup(name=u"__test_layer_group_1")
@@ -174,7 +175,8 @@ class TestThemesTimeView(TestCase):
                         "minDefValue": "2000-01-01T00:00:00Z",
                         "minValue": "2000-01-01T00:00:00Z",
                         "mode": u"single",
-                        "resolution": "year"
+                        "resolution": "year",
+                        "widget": "slider"
                     },
                     "children": [{
                         "name": u"__test_layer_time_1",
@@ -192,7 +194,8 @@ class TestThemesTimeView(TestCase):
                             "minDefValue": "2000-01-01T00:00:00Z",
                             "minValue": "2000-01-01T00:00:00Z",
                             "mode": u"single",
-                            "resolution": "year"
+                            "resolution": "year",
+                            "widget": "slider"
                         },
                     }]
                 }, {
@@ -204,7 +207,8 @@ class TestThemesTimeView(TestCase):
                         "minDefValue": "2000-01-01T00:00:00Z",
                         "minValue": "2000-01-01T00:00:00Z",
                         "mode": u"single",
-                        "resolution": "year"
+                        "resolution": "year",
+                        "widget": "slider"
                     },
                     "children": [{
                         "name": u"__test_layer_time_1",
@@ -224,7 +228,8 @@ class TestThemesTimeView(TestCase):
                             "minDefValue": "2000-01-01T00:00:00Z",
                             "minValue": "2000-01-01T00:00:00Z",
                             "mode": u"range",
-                            "resolution": "year"
+                            "resolution": "year",
+                            "widget": "datepicker"
                         },
                     }]
                 }]

--- a/c2cgeoportal/tests/test_wmstparsing.py
+++ b/c2cgeoportal/tests/test_wmstparsing.py
@@ -212,3 +212,9 @@ class TestTimeInformation(TestCase):
         ti = TimeInformation()
         ti.merge_mode("single")
         self.assertRaises(ValueError, ti.merge_mode, "range")
+
+    def test_merge_different_widgets(self):
+        from c2cgeoportal.lib.wmstparsing import TimeInformation
+        ti = TimeInformation()
+        ti.merge_widget("single")
+        self.assertRaises(ValueError, ti.merge_widget, "datepicker")

--- a/c2cgeoportal/views/entry.py
+++ b/c2cgeoportal/views/entry.py
@@ -265,7 +265,7 @@ class Entry(object):
                         wms_layer_obj.timepositions,
                         wms_layer_obj.defaulttimeposition
                     )
-                    time.merge(l, extent, layer.time_mode)
+                    time.merge(l, extent, layer.time_mode, layer.time_widget)
 
                 for child_layer in wms_layer_obj.layers:
                     if child_layer.timepositions:
@@ -274,7 +274,7 @@ class Entry(object):
                             child_layer.defaulttimeposition
                         )
                         # The time mode comes from the layer group
-                        time.merge(l, extent, layer.time_mode)
+                        time.merge(l, extent, layer.time_mode, layer.time_widget)
 
         except ValueError:  # pragma no cover
             errors.add(

--- a/doc/integrator/wmstime.rst
+++ b/doc/integrator/wmstime.rst
@@ -5,8 +5,8 @@ WMSTime Layer
 
 c2cgeoportal supports `WMS Time layers <http://mapserver.org/ogc/wms_time.html>`_.
 
-When the time is enabled for a layer group, a slider is added to this group in
-the layer tree which enables changing the layer time.
+When the time is enabled for a layer group, a time widget (a slider or datepicker)
+is added to this group in the layer tree which enables changing the layer time.
 
 Configuration
 -------------
@@ -59,29 +59,36 @@ Some examples for the interval definition:
 * An interval of one year: ``P1Y``
 * An interval of six months: ``P6M``
 
+For more information please refer to the `MapServer documentation
+<http://mapserver.org/ogc/wms_time.html>`_.
+
 Admin interface
 ~~~~~~~~~~~~~~~
 
 Most of the configuration is done in the mapfile as described in the above
-section. However the slider time mode must be configured via the admin
-interface.
+section. However the time widget must be configured via the admin interface.
+Two different widget types are available: A time slider and a datepicker
+widget. The preferred widget can be selected in the admin interface (field
+``Time widget``).
 
-The slider time mode is one of:
+Besides, the time mode can be changed. The time mode is one of:
 
 * ``single``
 * ``range``
 * ``disabled``
 
-The ``single`` mode is used to display a slider with a single thumb. The WMS
-Time layer will display data that are relative to the time selected by the
-thumb.
+The ``single`` mode displays a widget to select a single time or date. For a
+slider widget, a slider with a single thumb will be displayed. If datepicker is
+selected as widget, a single datepicker will be shown to select a single date.
+The WMS Time layer will display data that is relative to the selected time or date.
 
-The ``range`` mode is used to display a slider with two thumbs. In such a case,
-the layer will display data that are relative to the range defined by the two
-thumbs.
+The ``range`` mode displays a widget to select a time range. For a slider widget,
+a slider with two thumbs is shown. For the datepicker widget, two datepicker
+fields are displayed to select the start and end date.
+In mode ``range`` the layer will display data that is relative to the defined range.
 
-The ``disabled`` mode allows hidding the slider. No time parameter will be sent
-to the GetMap request in such a case.
+The ``disabled`` mode hides the time widget. No time parameter will be sent
+to the GetMap request in this case.
 
 Merging configurations
 ----------------------
@@ -94,12 +101,12 @@ Time layers of the same group.
 Some of those limitations apply to the mapfile:
 
 * The WMS Time layers of a same group must all be configured with either a
-  list of discrete values or an interval. It is not possible to mix the 2
+  list of discrete values or an interval. It is not possible to mix the two
   different types of definition within the same group,
 * If the WMS Time layers of a group use the ``min/max/interval``, they must
   all use the same interval.
 
 There is also a limitation that applies to the admin interface: all the WMS Time
-layers of a group should be configured to use the same time mode (``single`` or
-``range``) except for layers with time mode ``disabled`` that can be mixed
+layers of a group should be configured to use the same widget and the same time mode
+(``single`` or ``range``) except for layers with time mode ``disabled`` that can be mixed
 within others.


### PR DESCRIPTION
Adds a field `time_widget` to the layer models to specify the time widget to use (slider or datepicker). See https://github.com/camptocamp/cgxp/pull/938