### PR TITLE
Pillow and other wheels in Windows

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_requirements.txt
+++ b/c2cgeoportal/scaffolds/update/CONST_requirements.txt
@@ -3,6 +3,7 @@
 -r CONST_versions.txt
 psycopg2==2.6
 Shapely==1.5.6
+Pillow==2.7.0
 https://github.com/camptocamp/pyramid_closure/archive/819bc43420b3cd924d8698c5a9606592c19dbb15.zip#egg=pyramid_closure
 https://github.com/Pylons/pyramid/archive/1e02bbfc0df09259bf207112acf019c8dba44a90.zip#egg=pyramid
 -e .

--- a/c2cgeoportal/scaffolds/update/CONST_requirements_windows.txt
+++ b/c2cgeoportal/scaffolds/update/CONST_requirements_windows.txt
@@ -1,8 +1,9 @@
 --index-url http://pypi.camptocamp.net/pypi
 --find-links http://pypi.camptocamp.net/internal-pypi/index/c2cgeoportal-win
 -r CONST_versions.txt
-http://www.lfd.uci.edu/~gohlke/pythonlibs/sjdmq9dh/psycopg2-2.5.5-cp27-none-win32.whl
-http://www.lfd.uci.edu/~gohlke/pythonlibs/sjdmq9dh/Shapely-1.5.7-cp27-none-win32.whl
+wheels/psycopg2-2.5.5-cp27-none-win32.whl
+wheels/Shapely-1.5.7-cp27-none-win32.whl
+wheels/Pillow-2.8.1-cp27-none-win32.whl
 -e git+https://github.com/camptocamp/pyramid_closure@819bc43420b3cd924d8698c5a9606592c19dbb15#egg=pyramid_closure
 -e git+https://github.com/Pylons/pyramid@1e02bbfc0df09259bf207112acf019c8dba44a90#egg=pyramid
 -e .

--- a/c2cgeoportal/scaffolds/update/CONST_versions.txt
+++ b/c2cgeoportal/scaffolds/update/CONST_versions.txt
@@ -37,7 +37,6 @@ papyrus-ogcproxy==0.2.dev1
 Paste==1.7.5.1
 PasteDeploy==1.5.2
 PasteScript==1.7.5
-Pillow==2.7.0
 polib==1.0.6
 postmarkup==1.2.2
 Pygments==2.0.2

--- a/doc/integrator/install_application.rst
+++ b/doc/integrator/install_application.rst
@@ -167,8 +167,32 @@ In the ``<package>.mk`` add::
 Windows Specific Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Some changes in the apache wsgi and mapserver configurations are required to make
-c2cgeoportal work on Windows.
+Some Python modules cannot currently be installed through the Python Package
+Index (pypi) and they have to be downloaded manually and stored. This is
+because these packages use DLLs and binaries which would have to be compiled
+using a C compiler.
+
+Furthermore, some changes in the apache wsgi and mapserver configurations are
+required to make c2cgeoportal work on Windows.
+
+Python Wheels
+^^^^^^^^^^^^^
+
+You should create a "wheels" folder at the root folder of your project.
+
+Then, go to http://www.lfd.uci.edu/~gohlke/pythonlibs/, search and download the
+following packages:
+
+* Psycopg2
+* Shapely
+* Pillow
+
+If your project is configured for Windows, then ``make`` will expect this folder
+to exist and contain these wheels.
+
+To be sure to use the right version of these packages, open the
+``CONST_requirements.txt`` file modify the versions of these three packages
+according to the file you have downloaded.
 
 apache/wsgi.conf.mako
 ^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
I have the same problem with Pillow as we had with Psycopg2 and Shapely.

It has to be installed using a wheel containing the already compiled dll and binaries.

Furthermore, we cannot keep these `http://www.lfd.uci.edu/~gohlke/pythonlibs/sjdmq9dh/Shapely-1.5.7-cp27-none-win32.whl` kind of URLs, because they are only valid a day... (the `sjdmq9dh` code changes each day...)

I also tried to explain that in the doc...

Please review