### PR TITLE
Backport print and Tomcat service on Windows

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -214,6 +214,7 @@ PRINT_REQUIREMENT += \
 	$(PRINT_BASE_DIR)/WEB-INF/lib/postgresql-9.3-1102.jdbc41.jar \
 	$(PRINT_BASE_DIR)/WEB-INF/classes/logback.xml \
 	$(PRINT_BASE_DIR)/WEB-INF/classes/mapfish-spring-application-context-override.xml
+PRINT_TMP ?= /tmp
 TOMCAT_SERVICE_COMMAND ?= sudo /etc/init.d/tomcat-tomcat1
 ifneq ($(TOMCAT_SERVICE_COMMAND),)
 TOMCAT_STOP_COMMAND ?= $(TOMCAT_SERVICE_COMMAND) stop
@@ -670,9 +671,9 @@ $(VENV_BIN)/flake8: .build/dev-requirements.timestamp
 print: $(PRINT_OUTPUT)/$(PRINT_WAR)
 
 $(PRINT_OUTPUT)/$(PRINT_WAR): $(PRINT_REQUIREMENT)
-	cp $(PRINT_BASE_DIR)/$(PRINT_BASE_WAR) /tmp/$(PRINT_WAR)
-	cd $(PRINT_BASE_DIR) && jar -uf /tmp/$(PRINT_WAR) $(PRINT_INPUT)
-	chmod g+r,o+r /tmp/$(PRINT_WAR)
+	cp $(PRINT_BASE_DIR)/$(PRINT_BASE_WAR) $(PRINT_TMP)/$(PRINT_WAR)
+	cd $(PRINT_BASE_DIR) && jar -uf $(PRINT_TMP)/$(PRINT_WAR) $(PRINT_INPUT)
+	chmod g+r,o+r $(PRINT_TMP)/$(PRINT_WAR)
 ifneq ($(TOMCAT_STOP_COMMAND),)
 	$(TOMCAT_STOP_COMMAND)
 endif

--- a/doc/integrator/requirements.rst
+++ b/doc/integrator/requirements.rst
@@ -113,3 +113,21 @@ Cygwin's git for Windows. To do so:
 
 * Open a Cygwin bash
 * Run ``git config core.autocrlf true``
+
+Print
+^^^^^^
+
+If using MapFish Print v3 (thus defining ``PRINT_VERSION ?= 3`` in your
+makefile), then you should define the service name of your Tomcat server. In
+your makefile, define the following variables:
+
+.. prompt:: bash
+
+    PRINT_TMP = .
+    TOMCAT_START_COMMAND = net START Tomcat7
+    TOMCAT_STOP_COMMAND = net STOP Tomcat7
+
+The first line disables the tmp folder, which is not working on Windows.
+The next two lines define the commands to start and stop your Tomcat service
+(here it would be ``Tomcat7``). On Windows, these commands differ from the one
+used on Linux.


### PR DESCRIPTION
If using Mapfish print v3, then there are some commands which are run to start/stop the Tomcat service.

On Windows, the syntax of these ones is not the same then on Linux.

This PR:
* Defines a new print variable in `CONST_Makefile_tmpl` which is null by default (thus not altering the current build process).
* Adds some doc in the Windows specific section

If anybody has a better idea, then it is welcomed...

Please review