### PR TITLE
Update docs for multi-instance setup and introduce CSS_CUSTOM_FILES variable

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -110,7 +110,8 @@ CSS_BASE_FILES += \
 	$(PACKAGE)/static/lib/cgxp/ext/Ext/examples/ux/css/Spinner.css \
 	$(PACKAGE)/static/css/proj.css \
 	$(PACKAGE)/static/css/proj-map.css \
-	$(PACKAGE)/static/css/proj-widgets.css
+	$(PACKAGE)/static/css/proj-widgets.css \
+	$(CSS_CUSTOM_FILES)
 CSS_BASE_OUTPUT = $(OUTPUT_DIR)/app.css
 
 CSS_API_FILES += \


### PR DESCRIPTION
The first commit introduces the variable `CSS_CUSTOM_FILES` which allows to include instance-specific CSS files into the CSS build, so that CSS styles can be overridden in an instance. The instance-specific CSS files will be minified together will the other files.

Usage: e.g. `instance1.mk`

    INSTANCE_ID = instance1
    INSTANCE = instance1
    VARS_FILE = vars_instance1.yaml
    CSS_CUSTOM_FILES = project/static/css/proj-instance1.css

    include project.mk


The second commit updates the docs.