### PR TITLE
Makefile print section & yaml directory variable

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -672,14 +672,26 @@ $(VENV_BIN)/flake8: .build/dev-requirements.timestamp
 print: $(PRINT_OUTPUT)/$(PRINT_WAR)
 
 $(PRINT_OUTPUT)/$(PRINT_WAR): $(PRINT_REQUIREMENT)
+ifeq ($(VENV_BIN), .build/venv/bin)
 	cp $(PRINT_BASE_DIR)/$(PRINT_BASE_WAR) $(PRINT_TMP)/$(PRINT_WAR)
 	cd $(PRINT_BASE_DIR) && jar -uf $(PRINT_TMP)/$(PRINT_WAR) $(PRINT_INPUT)
 	chmod g+r,o+r $(PRINT_TMP)/$(PRINT_WAR)
+else
+	mkdir -p $(PRINT_BASE_DIR)/$(PRINT_TMP)
+	cp $(PRINT_BASE_DIR)/$(PRINT_BASE_WAR) $(PRINT_BASE_DIR)/$(PRINT_TMP)/$(PRINT_WAR)
+	cd $(PRINT_BASE_DIR) && jar -uf $(PRINT_TMP)/$(PRINT_WAR) $(PRINT_INPUT)
+endif
+
 ifneq ($(TOMCAT_STOP_COMMAND),)
 	$(TOMCAT_STOP_COMMAND)
 endif
 	rm -rf $(PRINT_OUTPUT)/$(PRINT_WAR:.war=)
-	mv /tmp/$(PRINT_WAR) $(PRINT_OUTPUT)
+ifeq ($(VENV_BIN), .build/venv/bin)
+	mv $(PRINT_TMP)/$(PRINT_WAR) $(PRINT_OUTPUT)
+else
+	mv $(PRINT_BASE_DIR)/$(PRINT_TMP)/$(PRINT_WAR) $(PRINT_OUTPUT)
+	cd $(PRINT_BASE_DIR) && rm -fd $(PRINT_TMP)
+endif
 ifneq ($(TOMCAT_START_COMMAND),)
 	$(TOMCAT_START_COMMAND)
 endif

--- a/c2cgeoportal/scaffolds/update/CONST_vars.yaml_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_vars.yaml_tmpl
@@ -47,7 +47,7 @@ vars:
     waitress_port: 5000
     enable_admin_interface: True
 
-    directory: pwd | tr -d '\n'
+    directory: __import__('os').getcwd()
     python_path: __import__('distutils').sysconfig.get_python_lib()
 
     # Authentication settings
@@ -295,9 +295,8 @@ interpreted:
     python:
     - authtkt.secret
     - python_path
+    - directory
     environment:
     - instanceid
     - apache_entry_point
     - development
-    bash:
-    - directory

--- a/doc/integrator/requirements.rst
+++ b/doc/integrator/requirements.rst
@@ -123,7 +123,7 @@ your makefile, define the following variables:
 
 .. prompt:: bash
 
-    PRINT_TMP = .
+    PRINT_TMP = tmp
     TOMCAT_START_COMMAND = net START Tomcat7
     TOMCAT_STOP_COMMAND = net STOP Tomcat7
 


### PR DESCRIPTION
This PR does implement two things:
* Print section for Windows: this is needed because Cygwin handles the existing bash commands in the Windows drive definition, thus it is "not" working. I opted for a specific Windows section, because the behavior differs quite a lot between Linux and Windows systems.
* directory variable: if this variable is defined through bash (in Windows...), then `${directory}` is substituted by `/cygdrive/c/...` everywhere. This does not work when calling the app through Apache (or even pserve) as this one expects to get values like `C:/...` on Windows. Defining `directory` using Python resolves this issue

Please review