### PR TITLE
Replace : by = in SQL query

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_vars.yaml_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_vars.yaml_tmpl
@@ -33,7 +33,7 @@ vars:
     # mapserver visible area
     mapserver_join_area: ra.area
     # mapserver join close
-    mapserver_join_where: 'rra.role_id: %role_id% AND rra.restrictionarea_id: ra.id AND lra.restrictionarea_id: ra.id AND lra.layer_id: la.id AND la.name:'
+    mapserver_join_where: 'rra.role_id = %role_id% AND rra.restrictionarea_id = ra.id AND lra.restrictionarea_id = ra.id AND lra.layer_id = la.id AND la.name = '
     # mapserver metadata for validation
     mapserver_layer_metadata: ""
     mapserver_layer_validation:


### PR DESCRIPTION
I do not think that `:` is the good relational equal operator in SQL. In my opinion, it should be `=` (and this is working in my project...)

Or did I miss something concerning new SQL syntax ?