### PR TITLE
Rebuild libs after an update

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -566,6 +566,7 @@ update:
 	git submodule foreach git submodule update --init
 ifeq ($(NGEO), TRUE)
 	npm install --force
+	touch .build/node_modules.timestamp
 endif
 
 .PHONY: update-git-submodules


### PR DESCRIPTION
add missing touch on .build/node_modules.timestamp

Back-port of https://github.com/Geoportail-Luxembourg/geoportailv3/pull/642