### PR TITLE
Use full virtualenv path for more robustness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ C2C_TEMPLATE_CMD = .build/venv/bin/c2c-template --vars $(VARS_FILE)
 
 DEVELOPPEMENT ?= FALSE
 
+VIRTUALENV_CMD ?= /usr/bin/virtualenv
 PIP_CMD ?= .build/venv/bin/pip
 PIP_INSTALL_ARGS += install --trusted-host pypi.camptocamp.net
 
@@ -155,7 +156,7 @@ c2cgeoportal/locale/en/LC_MESSAGES/c2cgeoportal.po: c2cgeoportal/locale/c2cgeopo
 
 .build/venv.timestamp:
 	mkdir -p $(dir $@)
-	virtualenv --setuptools --no-site-packages .build/venv
+	$(VIRTUALENV_CMD) --setuptools --no-site-packages .build/venv
 	$(PIP_CMD) install \
 		--index-url http://pypi.camptocamp.net/pypi \
 		'pip>=6' 'setuptools>=12' $(PIP_REDIRECT)

--- a/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -1,3 +1,4 @@
+VIRTUALENV_CMD ?= /usr/bin/virtualenv
 VENV_BIN ?= .build/venv/bin
 PYTHON_VERSION = $(shell $(VENV_BIN)/python -c "import sys; print('%i.%i' % (sys.version_info.major, sys.version_info.minor))" 2> /dev/null)
 PACKAGE = {{package}}
@@ -673,7 +674,7 @@ $(VENV_BIN)/flake8: .build/dev-requirements.timestamp
 
 .build/venv.timestamp-noclean:
 	mkdir -p $(dir $@)
-	virtualenv --setuptools --no-site-packages .build/venv
+	$(VIRTUALENV_CMD) --setuptools --no-site-packages .build/venv
 	$(PIP_CMD) install \
 		--index-url http://pypi.camptocamp.net/pypi \
 		'pip>=6' 'setuptools>=12'

--- a/doc/integrator/upgrade_application.rst
+++ b/doc/integrator/upgrade_application.rst
@@ -118,7 +118,7 @@ Get the right version of the egg:
 .. prompt:: bash
 
     mkdir .build
-    virtualenv --setuptools --no-site-packages .build/venv
+    /usr/bin/virtualenv --setuptools --no-site-packages .build/venv
     .build/venv/bin/pip install --index-url http://pypi.camptocamp.net/pypi 'pip>=6' 'setuptools>=12'
     .build/venv/bin/pip install --index-url http://pypi.camptocamp.net/pypi \
         --trusted-host pypi.camptocamp.net --find-links http://pypi.camptocamp.net/internal-pypi/index/c2cgeoportal \

--- a/doc/update_online.sh
+++ b/doc/update_online.sh
@@ -45,7 +45,7 @@ do
 
     # create a virtual env if none exists already
     if [[ ! -d env ]]; then
-        virtualenv env
+        /usr/bin/virtualenv env
     fi
 
     # install or update Sphinx

--- a/travis.mk
+++ b/travis.mk
@@ -1,5 +1,6 @@
 VARS_FILE ?= vars_travis.yaml
 VARS_FILES += vars_travis.yaml
 PIP_CMD = travis/pip.sh
+VIRTUALENV_CMD = virtualenv
 
 include Makefile

--- a/travis/build.mk
+++ b/travis/build.mk
@@ -8,6 +8,7 @@ REQUIREMENTS += -e /home/travis/build/camptocamp/c2cgeoportal
 PRINT_OUTPUT = /var/lib/tomcat7/webapps
 
 PIP_CMD = /home/travis/build/camptocamp/c2cgeoportal/travis/pip.sh
+VIRTUALENV_CMD = virtualenv
 
 TOMCAT_SERVICE_COMMAND =
 


### PR DESCRIPTION
I use https://github.com/brainsik/virtualenv-burrito (on my laptop and on dev servers). I use this to install recent versions of virtualenv and virtualenvwrapper in my homedir. This also adds `/home/elemoine/.venvburrito/bin` to my `PATH`, meaning that the `virtualenv` command is `/home/elemoine/.venvburrito/bin/virtualenv` in my case.

And building c2cgeoportal projects doesn't work with recent versions of virtualenv (and pip). So, for more robustness, this PR suggests using `/usr/bin/virtualenv` instead of `virtualenv` in `Makefile` and `CONST_Makefile`.

Please review.