### PR TITLE
Make make clean remove the main Apache conf file

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -335,6 +335,7 @@ clean: template-clean
 	rm -f $(JSBUILD_MOBILE_OUTPUT_FILES)
 	rm -rf $(PACKAGE)/static/mobile/build
 	rm -rf $(PACKAGE)/static/mobile/archive
+	rm -f $(APACHE_CONF_DIR)/$(INSTANCE_ID).conf
 
 .PHONY: cleanall
 cleanall: clean
@@ -342,7 +343,6 @@ cleanall: clean
 	rm -rf node_modules
 	rm -f $(PRINT_OUTPUT)/$(PRINT_WAR)
 	rm -rf $(PRINT_OUTPUT)/$(PRINT_WAR:.war=)
-	rm -f $(APACHE_CONF_DIR)/$(INSTANCE_ID).conf
 
 .PHONY: flake8
 flake8: $(VENV_BIN)/flake8


### PR DESCRIPTION
Currently, running `make clean` breaks `apache2ctl configtest` (and `apache2ctl graceful`) for every developer on the server. This commit fixes the problem by making `make clean` also remove the main Apache config file for the project.