### PR TITLE
Use export_local_property_definitions Closure Compiler flag

### DIFF
--- a/c2cgeoportal/scaffolds/create/build.json
+++ b/c2cgeoportal/scaffolds/create/build.json
@@ -82,6 +82,7 @@
     ],
     "angular_pass": true,
     "compilation_level": "ADVANCED",
+    "export_local_property_definitions": true,
     "warning_level": "VERBOSE",
     "generate_exports": true,
     "language_in": "ECMASCRIPT5_STRICT",


### PR DESCRIPTION
Needed to use the `@export` jsdoc annotation