### PR TITLE
Remove groups when all child layers have been stripped out of getcap

### DIFF
--- a/c2cgeoportal/tests/functional/c2cgeoportal_test.map.in
+++ b/c2cgeoportal/tests/functional/c2cgeoportal_test.map.in
@@ -134,6 +134,41 @@ MAP
     END
 
     LAYER
+        NAME "testpoint_protected_2"
+        GROUP "testpoint_group_2"
+        TYPE POINT
+        STATUS ON
+        CONNECTIONTYPE postgis
+        CONNECTION "user=${vars:dbuser} password=${vars:dbpassword} dbname=${vars:db} host=${vars:dbhost}"
+        DATA "the_geom from (SELECT tp.* FROM main.testpoint AS tp, ${vars:mapserver_join_tables} WHERE ST_Contains(${vars:mapserver_join_area}, ST_GeomFromText(ST_AsText(tp.the_geom), 21781)) AND ${vars:mapserver_join_where} 'testpoint_protected_2') as foo using unique id using srid=21781"
+        METADATA
+            "wms_title" "countries"
+            "wms_srs" "epsg:21781"
+            # gml_ settings for GetFeatureInfo
+            "gml_include_items" "all"
+            "gml_exclude_items" "id"
+            "gml_geometries" "the_geom"
+            "gml_the_geom_type" "point"
+
+            ${vars:mapserver_layer_metadata}
+        END
+        DUMP TRUE # for GetFeatureInfo
+        TEMPLATE "template"
+        PROJECTION
+           "init=epsg:21781"
+        END
+        CLASS
+            NAME "testpoint_protected"
+            STYLE
+                SYMBOL "square"
+                SIZE 16
+                COLOR 0 0 0
+                OUTLINECOLOR 0 0 0
+            END
+        END
+    END
+
+    LAYER
         NAME "testpoint_protected_query_with_collect"
         TYPE POINT
         STATUS ON

--- a/c2cgeoportal/tests/functional/test_entry.py
+++ b/c2cgeoportal/tests/functional/test_entry.py
@@ -445,12 +445,19 @@ class TestEntryView(TestCase):
             ])
         )
 
-        result = '["testpoint_unprotected", "testpoint_protected", ' \
-            '"testpoint_protected_query_with_collect", ' \
-            '"testpoint_substitution", "testpoint_column_restriction", ' \
-            '"test_wmsfeatures", "test_wmstime", "test_wmstime2"]'
-        self.assertEquals(response['WFSTypes'], result)
-        self.assertEquals(response['externalWFSTypes'], result)
+        result = [
+            "testpoint_unprotected",
+            "testpoint_protected",
+            "testpoint_protected_2",
+            "testpoint_protected_query_with_collect",
+            "testpoint_substitution",
+            "testpoint_column_restriction",
+            "test_wmsfeatures",
+            "test_wmstime",
+            "test_wmstime2"
+        ]
+        self.assertEquals(json.loads(response['WFSTypes']), result)
+        self.assertEquals(json.loads(response['externalWFSTypes']), result)
 
     def test_permalink_themes(self):
         from c2cgeoportal.views.entry import Entry


### PR DESCRIPTION
As for now, the filter_capabilities tool removes not allowed layers from the WMS getcapabilities response. On the other hand if the removed layers are contained in a mapserver group, the group remains even though no embedded layers are shown.

This PR makes sure the group is removed as well if all contained layers have been removed.

Most of the code is from @sbrunner