### PR TITLE
do not inject role in all generated urls

### DIFF
--- a/c2cgeoportal/lib/__init__.py
+++ b/c2cgeoportal/lib/__init__.py
@@ -149,12 +149,16 @@ class C2CPregenerator:  # pragma: no cover
 
         query = kw.get("_query", {})
 
+        cacheburst = ''
         if self.version:
             from c2cgeoportal.lib.cacheversion import get_cache_version
-            query["cache_version"] = get_cache_version()
+            cacheburst = get_cache_version()
 
         if self.role and request.user and request.user.role:
-            query["role"] = request.user.role.id
+            cacheburst += str(request.user.role.id)
+
+        if cacheburst != '':
+            query['cacheburst'] = cacheburst
 
         kw["_query"] = query
         return elements, kw


### PR DESCRIPTION
if role is injected in all the url, it becomes impossible to change it afterward (for example as in project epfl_geoportail)m, because Openlayers only merge params if they dont exist. 
if the parameter already, as with "role" in this case, OL skip the parameter inclusion, meaning the parameter value will always be the one included server-side.

this PR propose to change the unique cache id by removing the auto injection of role in all generated urls.

this is only a proposal, open for discussion.