### PR TITLE
deploy is a custom c2c package, it shouldnt be checked by default

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_packages.yaml
+++ b/c2cgeoportal/scaffolds/update/CONST_packages.yaml
@@ -15,7 +15,6 @@ main:
         cmd: sudo -u postgres psql template_postgis -c "select PostGIS_lib_version();" -At
         #cmd: dpkg -l | grep postgis | grep ^ii | awk '{{print $3}}' | head -n 1
         version: 2.0
-    deploy: 0.4
     java:
         cmd: java -version 2>&1 | grep 'java version' | awk '{{print $3}}' | sed 's/"//g' | sed 's/_/./g'
         version: 1.7.0


### PR DESCRIPTION
should the deploy package really be checked at that level?
because this will only work on a c2c server, since deploy is a c2c specific package