### PR TITLE
Add a missing instruction for Windows upgrades in the docs

### DIFF
--- a/doc/integrator/upgrade_application.rst
+++ b/doc/integrator/upgrade_application.rst
@@ -41,7 +41,8 @@ Easy upgrading an application
 
         ``make -f <makefile> clean``
 
-    * Change the version in ``setup.py`` to the version you wish to install
+    * Change the version in ``setup.py`` and ``CONST_requirements_windows.txt``
+      to the version you wish to install.
     * Build your application:
 
         ``make -f <makefile> build``
@@ -49,6 +50,8 @@ Easy upgrading an application
     *  Put your modifications under git revision:
 
         ``git add setup.py``
+
+        ``git add CONST_requirements_windows.txt``
 
         ``git commit -m "Upgrade c2cgeoportal version"``
 


### PR DESCRIPTION
Titles says it all.

It only applies to the specific Windows instructions.

@sbrunner, I created a PR to update the 1.6 branch. I just hope that this is right...