### PR TITLE
Convert METADATA wms_srs to uppercase

### DIFF
--- a/c2cgeoportal/scaffolds/create/mapserver/c2cgeoportal.map.mako
+++ b/c2cgeoportal/scaffolds/create/mapserver/c2cgeoportal.map.mako
@@ -71,7 +71,7 @@ MAP
             "wms_title" "changeme"
             "wms_abstract" "changeme"
             "wms_onlineresource" "http://${host}/${instanceid}/wsgi/mapserv_proxy"
-            "wms_srs" "epsg:21781"
+            "wms_srs" "EPSG:21781"
             "wms_encoding" "UTF-8"
             "wms_enable_request" "*"
             "wfs_enable_request" "!*"
@@ -105,7 +105,7 @@ MAP
         #DATA "geometrie FROM (SELECT geo.geom as geom FROM geodata.table AS geo) AS foo USING UNIQUE gid USING srid=21781"
         METADATA
             "wms_title" "layer_name" # For WMS
-            "wms_srs" "epsg:21781" # For WMS
+            "wms_srs" "EPSG:21781" # For WMS
 
             "wfs_enable_request" "*" # Enable WFS for this layer
             "gml_include_items" "all" # For GetFeatureInfo and WFS GetFeature (QuerryBuilder)

--- a/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -12,6 +12,34 @@ Version 1.6.3
     + encodeExternalLayer: {},
     + additionalAttributes: [],
 
+2. In all `mapserver/*.map` or `mapserver/*.map.mako` files, convert all SRS
+   codes in METADATA sections to uppercase.
+
+   Lowercase SRS codes may cause incompatibility problems with some client
+   tools including CGXP WMSBrowser plugin.
+
+   Exemple:
+
+    METADATA
+        ...
+        "wms_srs" "epsg:21781 epsg:3857"
+        ...
+    END
+
+   should be converted to:
+
+    METADATA
+        ...
+        "wms_srs" "EPSG:21781 EPSG:3857"
+        ...
+    END
+
+   Note that “epsg” has to be in lowercase when used in the PROJ4 ‘init’ directive.
+
+    PROJECTION
+        "init=epsg:21781"
+    END
+
 
 Version 1.6.2
 =============


### PR DESCRIPTION
Change "wms_srs" "epsg:..." to "wms_srs" "EPSG:..." in c2cgeoportal.map.mako.
Tell to do the same in all mapfiles in the changelog.