### PR TITLE
Add the copy_to metadata key on server side.

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -62,6 +62,20 @@ Version 1.6.3
    LAYER definitions will be a great performance improvement, see:
    http://docs.camptocamp.net/c2cgeoportal/1.6/administrator/mapfile.html#performance-improvement
 
+5. In `vars_*.yaml` files where `admin_interface` section is overridden:
+
+    * Add `available_metadata` subsection:
+
+        vars:
+            ...
+
+            admin_interface:
+                ...
+
+      +         # The list of available variable names for the `UI metadatas` form.
+      +         available_metadata:
+      +         - copy_to
+
 
 Version 1.6.2
 =============

--- a/c2cgeoportal/scaffolds/update/CONST_vars.yaml_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_vars.yaml_tmpl
@@ -123,6 +123,10 @@ vars:
         map_y: 5860000
         map_zoom: 10
 
+    # The list of available variable names for the `UI metadatas` form.
+        available_metadata:
+        - copy_to
+
     # The list of functionalities that can be configured
     # through the admin interface.
         available_functionalities:

--- a/doc/administrator/editing.rst
+++ b/doc/administrator/editing.rst
@@ -99,3 +99,28 @@ administration interface.
 Binding restriction areas and layers together can be done from either the
 ``Restriction Area`` objects or the ``Layer`` objects in the admin interface.
 Likewise for binding roles and restriction areas.
+
+
+Enabling `Copy to` functionality
+--------------------------------
+
+In the ``edit`` interface, you can give the user the possibility to copy
+features from one layer (source layer) to another layer (destination layer).
+
+In the ``admin`` interface, open the ``UI metadatas`` list and add a new record:
+
+    * Name: Select ``copy_to``.
+    * Value: Enter the list of choices for destination layer, as mapserver
+     layer names, separated by commas.
+    * Item: Select the source layer.
+
+Exemple:
+
+    * Name: ``copy_to``
+    * Value: ``polygon2,polygon3,polygon4``
+    * Item: ``polygon``
+
+.. note::
+
+   * Source and destination layers must have the same geometry type.
+   * Only the geometry will be copied, the attributes will not be.


### PR DESCRIPTION
This comes with https://github.com/camptocamp/cgxp/pull/1002.
Adds the copy_to metadata key in CONST_vars.yaml template.
Document the change in changelog and administrator documentation.