### PR TITLE
Make git modules folder overridable in Makefile

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -20,6 +20,8 @@ PRINT_VERSION ?= 3
 PIP_CMD ?= $(VENV_BIN)/pip
 PIP_INSTALL_ARGS += install --trusted-host pypi.camptocamp.net
 
+GIT_MODULES_FOLDER ?= .git/modules/
+
 ifeq ($(CGXP), TRUE)
 DEFAULT_WEB_RULE += build-cgxp
 endif
@@ -578,10 +580,10 @@ update-git-submodules:
 	git submodule foreach git submodule sync
 	git submodule foreach git submodule update --init
 
-.git/modules/$(PACKAGE)/static/lib/cgxp/modules/%/HEAD: .git/modules/$(PACKAGE)/static/lib/cgxp/HEAD
+$(GIT_MODULES_FOLDER)$(PACKAGE)/static/lib/cgxp/modules/%/HEAD: $(GIT_MODULES_FOLDER)$(PACKAGE)/static/lib/cgxp/HEAD
 	if [ -e $@ ]; then touch $@; else git submodule foreach git submodule update --init; fi
 
-.git/modules/$(PACKAGE)/static/lib/cgxp/HEAD:
+$(GIT_MODULES_FOLDER)$(PACKAGE)/static/lib/cgxp/HEAD:
 	git submodule update --init
 
 
@@ -593,26 +595,26 @@ $(VENV_BIN)/jsbuild: .build/dev-requirements.timestamp
 
 $(JSBUILD_MAIN_OUTPUT_FILES): $(JSBUILD_MAIN_FILES) $(JSBUILD_MAIN_CONFIG) \
 	$(VENV_BIN)/jsbuild \
-	.git/modules/$(PACKAGE)/static/lib/cgxp/modules/openlayers/HEAD \
-	.git/modules/$(PACKAGE)/static/lib/cgxp/HEAD
+	$(GIT_MODULES_FOLDER)$(PACKAGE)/static/lib/cgxp/modules/openlayers/HEAD \
+	$(GIT_MODULES_FOLDER)$(PACKAGE)/static/lib/cgxp/HEAD
 	mkdir -p $(dir $@)
 	$(VENV_BIN)/jsbuild $(JSBUILD_MAIN_CONFIG) $(JSBUILD_ARGS) -j $(notdir $@) -o $(OUTPUT_DIR)
 
 $(CSS_BASE_OUTPUT): $(VENV_BIN)/cssmin \
-	.git/modules/$(PACKAGE)/static/lib/cgxp/modules/openlayers/HEAD \
-	.git/modules/$(PACKAGE)/static/lib/cgxp/HEAD \
+	$(GIT_MODULES_FOLDER)$(PACKAGE)/static/lib/cgxp/modules/openlayers/HEAD \
+	$(GIT_MODULES_FOLDER)$(PACKAGE)/static/lib/cgxp/HEAD \
 	$(CSS_BASE_FILES)
 	$(VENV_BIN)/c2c-cssmin $(CSSMIN_ARGS) $@ $(CSS_BASE_FILES)
 
 $(CSS_API_OUTPUT): $(VENV_BIN)/cssmin \
-	.git/modules/$(PACKAGE)/static/lib/cgxp/modules/openlayers/HEAD \
-	.git/modules/$(PACKAGE)/static/lib/cgxp/HEAD \
+	$(GIT_MODULES_FOLDER)$(PACKAGE)/static/lib/cgxp/modules/openlayers/HEAD \
+	$(GIT_MODULES_FOLDER)$(PACKAGE)/static/lib/cgxp/HEAD \
 	$(CSS_API_FILES)
 	$(VENV_BIN)/c2c-cssmin $(CSSMIN_ARGS) $@ $(CSS_API_FILES)
 
 $(CSS_XAPI_OUTPUT): $(VENV_BIN)/cssmin \
-	.git/modules/$(PACKAGE)/static/lib/cgxp/modules/openlayers/HEAD \
-	.git/modules/$(PACKAGE)/static/lib/cgxp/HEAD \
+	$(GIT_MODULES_FOLDER)$(PACKAGE)/static/lib/cgxp/modules/openlayers/HEAD \
+	$(GIT_MODULES_FOLDER)$(PACKAGE)/static/lib/cgxp/HEAD \
 	$(CSS_XAPI_FILES)
 	$(VENV_BIN)/c2c-cssmin $(CSSMIN_ARGS) $@ $(CSS_XAPI_FILES)
 


### PR DESCRIPTION
Useful for projects with an intermediate "main/" folder. Such projects must have in their ``<project>.mk``:
```
GIT_MODULES_FOLDER ?= ../.git/modules/main/
```

Ported from a @sbrunner patch.