### PR TITLE
Use IE11 document mode

### DIFF
--- a/c2cgeoportal/scaffolds/create/+package+/templates/edit.html_tmpl
+++ b/c2cgeoportal/scaffolds/create/+package+/templates/edit.html_tmpl
@@ -5,7 +5,7 @@
         <meta name="Content-Language" content="${lang}" />
         <meta name="keywords" content="{{package}}, mapfish, editor, geoportal">
         <meta name="description" content="{{package}} Geoportal Editor.">
-        <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7; IE=EmulateIE9; IE=EmulateIE10">
+        <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7; IE=EmulateIE9; IE=EmulateIE11;">
         <title>{{package}} Geoportal Editor</title>
         <link rel="shortcut icon" type="image/x-icon" href="${request.static_url('{{package}}:static/images/favicon.ico')}">
 

--- a/c2cgeoportal/scaffolds/create/+package+/templates/index.html_tmpl
+++ b/c2cgeoportal/scaffolds/create/+package+/templates/index.html_tmpl
@@ -5,7 +5,7 @@
         <meta name="Content-Language" content="${lang}" />
         <meta name="keywords" content="{{package}}, geoportal">
         <meta name="description" content="{{package}} Geoportal Application.">
-        <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7; IE=EmulateIE9; IE=EmulateIE10">
+        <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7; IE=EmulateIE9; IE=EmulateIE11;">
 % if not no_redirect and mobile_url is not None:
         <script>
             if(('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch) {

--- a/c2cgeoportal/scaffolds/create/+package+/templates/routing.html_tmpl
+++ b/c2cgeoportal/scaffolds/create/+package+/templates/routing.html_tmpl
@@ -5,7 +5,7 @@
         <meta name="Content-Language" content="${lang}" />
         <meta name="keywords" content="{{package}}, mapfish, routing, geoportal">
         <meta name="description" content="{{package}} Routing.">
-        <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7; IE=EmulateIE9; IE=EmulateIE10">
+        <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7; IE=EmulateIE9; IE=EmulateIE11;">
         <title>{{package}} Routing</title>
         <link rel="shortcut icon" type="image/x-icon" href="${request.static_url('{{package}}:static/images/favicon.ico')}">
 

--- a/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -70,6 +70,12 @@ Version 1.6.3
       - check_collector.hosts
     + - admin_interface
 
+6. In the `{{package}}/templates/index.html`, `{{package}}/templates/edit.html`
+   and `{{package}}/templates/routing.html` do the following changes to use IE11 when available :
+
+      - <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7; IE=EmulateIE9; IE=EmulateIE10">
+      + <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7; IE=EmulateIE9; IE=EmulateIE11">
+
 
 Version 1.6.2
 =============


### PR DESCRIPTION
~~Use IE11 document mode when available (currently IE11 uses IE10 document mode to render the geoportal).~~

~~After discussion with Stephane, we won't use the notation: ``<meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7; IE=EmulateIE9; IE=edge">`` because this is less understandable.~~

Use IE11 document mode instead of IE10 document mode to avoid some bugs with ext. IE10 will use IE9 document mode.
