### PR TITLE
Set click pixel tolerance to 5px, be able to accept click and longpress

### DIFF
--- a/c2cgeoportal/scaffolds/create/+package+/static/mobile/config.js_tmpl
+++ b/c2cgeoportal/scaffolds/create/+package+/static/mobile/config.js_tmpl
@@ -22,7 +22,7 @@ try {
 
     App.WFSTypes = jsonFormat.read('${dumps(wfs_types) | n}');
 
-    // Query mode. Can be either 'click' or 'longpress'
+    // Query mode. Can be either "click", "longpress", "both" or "none"
     App.queryMode = 'longpress';
 
     App.tilesURL = jsonFormat.read('${dumps(request.registry.settings["tiles_url"]) | n}');

--- a/c2cgeoportal/scaffolds/update/+package+/static/mobile/app/view/Main.js
+++ b/c2cgeoportal/scaffolds/update/+package+/static/mobile/app/view/Main.js
@@ -154,7 +154,7 @@ Ext.define("App.view.Main", {
      * mapContainer - {<DOMElement>}
      */
     addQueryControls: function(mapContainer) {
-        if (App.queryMode == 'click') {
+        if (["click", "both"].indexOf(App.queryMode) !== -1) {
             var self = this;
             OpenLayers.Control.Click = OpenLayers.Class(OpenLayers.Control, {
                 autoActivate: true,
@@ -170,6 +170,7 @@ Ext.define("App.view.Main", {
                             }
                         },
                         {
+                            pixelTolerance: 5,
                             'single': true
                         }
                     );
@@ -177,7 +178,8 @@ Ext.define("App.view.Main", {
             });
 
             this.getMap().addControl(new OpenLayers.Control.Click({}));
-        } else {
+        }
+        if (["longpress", "both"].indexOf(App.queryMode) !== -1) {
             mapContainer.on('longpress', function(event, node) {
                 var map = this.getMap();
                 var el = Ext.get(map.div);


### PR DESCRIPTION
Fix #1201

The in the `<package>/static/mobile/config.js` file `App.queryMode` should be set to "click" or "both".
