### PR TITLE
Use Angular templatecache also in debug mode

### DIFF
--- a/c2cgeoportal/scaffolds/create/+package+/templates/ngeo.html_tmpl
+++ b/c2cgeoportal/scaffolds/create/+package+/templates/ngeo.html_tmpl
@@ -35,6 +35,7 @@
     <script src="${request.static_url('%s/closure/goog/base.js' % closure_library_path)}"></script>
     <script src="${request.route_url('deps.js')}"></script>
     <script src="${request.static_url('{{package}}:static-ngeo/js/main.js')}"></script>
+    <script src="${request.static_url('{{package}}:static-ngeo/build/templatecache.js')}"></script>
 % else:
     <script src="${request.static_url('{{package}}:static-ngeo/build/build.js')}"></script>
 % endif

--- a/c2cgeoportal/scaffolds/create/build.json_tmpl
+++ b/c2cgeoportal/scaffolds/create/build.json_tmpl
@@ -5,7 +5,7 @@
     "node_modules/ngeo/src/**/*.js",
     "node_modules/ngeo/contribs/gmf/**/*.js",
     "{{package}}/static-ngeo/js/**/*.js",
-    ".build/templatecache.js"
+    "{{package}}/static-ngeo/build/templatecache.js"
   ],
   "compile": {
     "closure_entry_point": "app_main",

--- a/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -516,7 +516,7 @@ $(APP_OUTPUT_DIR)/build.min.css: $(LESS_FILES) .build/node_modules.timestamp
 
 $(APP_OUTPUT_DIR)/templatecache.js: templatecache.js.mako $(APP_PARTIALS_FILES) .build/dev-requirements.timestamp
 	mkdir -p $(dir $@)
-	$(VENV_BIN)/mako-render --var "partials=$(APP_PARTIALS_FILES)" $< > $@
+	PYTHONIOENCODING=UTF-8 $(VENV_BIN)/mako-render --var "partials=$(APP_PARTIALS_FILES)" $< > $@
 
 .build/externs/angular-1.4.js:
 	mkdir -p $(dir $@)

--- a/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -506,7 +506,7 @@ $(APP_OUTPUT_DIR)/build.min.css: $(LESS_FILES) .build/node_modules.timestamp
 	./node_modules/.bin/lessc $(LESS_ARGS) $(PACKAGE)/static-ngeo/less/$(PACKAGE).less $@
 
 .build/build.js: build.json $(OL_JS_FILES) $(NGEO_JS_FILES) $(APP_JS_FILES) \
-		.build/templatecache.js \
+		$(APP_OUTPUT_DIR)/templatecache.js \
 		.build/externs/angular-1.4.js \
 		.build/externs/angular-1.4-q_templated.js \
 		.build/externs/angular-1.4-http-promise_templated.js \
@@ -514,7 +514,8 @@ $(APP_OUTPUT_DIR)/build.min.css: $(LESS_FILES) .build/node_modules.timestamp
 		.build/node_modules.timestamp
 	./node_modules/openlayers/node_modules/.bin/closure-util build $< $@
 
-.build/templatecache.js: templatecache.js.mako $(APP_PARTIALS_FILES) .build/dev-requirements.timestamp
+$(APP_OUTPUT_DIR)/templatecache.js: templatecache.js.mako $(APP_PARTIALS_FILES) .build/dev-requirements.timestamp
+	mkdir -p $(dir $@)
 	$(VENV_BIN)/mako-render --var "partials=$(APP_PARTIALS_FILES)" $< > $@
 
 .build/externs/angular-1.4.js:


### PR DESCRIPTION
This is a backport of https://github.com/Geoportail-Luxembourg/geoportailv3/pull/848, where we decided to use the Angular template cache in non-debug mode as well as in debug mode.