### PR TITLE
ngeo-related changes for the 1.6 branch

### DIFF
--- a/c2cgeoportal/scaffolds/create/build.json_tmpl
+++ b/c2cgeoportal/scaffolds/create/build.json_tmpl
@@ -3,7 +3,7 @@
     "node_modules/openlayers/src/**/*.js",
     "node_modules/openlayers/build/ol.ext/**/*.js",
     "node_modules/ngeo/src/**/*.js",
-    "geoportailv3/static/js/**/*.js",
+    "{{package}}/static/js/**/*.js",
     ".build/templatecache.js"
   ],
   "compile": {
@@ -34,7 +34,7 @@
       "ol.ENABLE_WEBGL=false"
     ],
     "js": [
-      "geoportailv3/static/js/main.js",
+      "{{package}}/static/js/main.js",
       "node_modules/openlayers/externs/olx.js",
       "node_modules/ngeo/externs/ngeox.js",
       "node_modules/openlayers/externs/oli.js"

--- a/c2cgeoportal/scaffolds/create/build.json_tmpl
+++ b/c2cgeoportal/scaffolds/create/build.json_tmpl
@@ -20,9 +20,9 @@
       "node_modules/ngeo/externs/d3.js",
       "node_modules/ngeo/externs/twbootstrap.js",
       "node_modules/ngeo/externs/typeahead.js",
-      ".build/externs/angular-1.3.js",
-      ".build/externs/angular-1.3-q.js",
-      ".build/externs/angular-1.3-http-promise.js",
+      ".build/externs/angular-1.4.js",
+      ".build/externs/angular-1.4-q_templated.js",
+      ".build/externs/angular-1.4-http-promise_templated.js",
       ".build/externs/jquery-1.9.js"
     ],
     "define": [

--- a/c2cgeoportal/scaffolds/create/build.json_tmpl
+++ b/c2cgeoportal/scaffolds/create/build.json_tmpl
@@ -4,7 +4,7 @@
     "node_modules/openlayers/build/ol.ext/**/*.js",
     "node_modules/ngeo/src/**/*.js",
     "{{package}}/static/js/**/*.js",
-    ".build/templatecache.js"
+    "{{package}}/static/build/templatecache.js"
   ],
   "compile": {
     "closure_entry_point": "app_main",

--- a/c2cgeoportal/scaffolds/create/package.json
+++ b/c2cgeoportal/scaffolds/create/package.json
@@ -8,7 +8,7 @@
     "async": "~0.2.10"
   },
   "devDependencies": {
-    "angular": "1.3.4",
+    "angular": "1.4.7",
     "angular-gettext": "1.1.3",
     "angular-gettext-tools": "1.0.4",
     "bootstrap": "^3.3.0",

--- a/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -13,6 +13,23 @@ Version 1.6.5
      - ".build/templatecache.js"
      + "{{package}}/static/build/templatecache.js"
 
+3. If you use ngeo you need to update your project to Angular 1.4.x (1.4.7 is the latest version). For this
+   you need to change two files: `build.json` and `package.json`.
+
+   Changes to `build.json`:
+
+     -      ".build/externs/angular-1.3.js",
+     -      ".build/externs/angular-1.3-q.js",
+     -      ".build/externs/angular-1.3-http-promise.js",
+     +      ".build/externs/angular-1.4.js",
+     +      ".build/externs/angular-1.4-q_templated.js",
+     +      ".build/externs/angular-1.4-http-promise_templated.js",
+
+   Changes to `package.json`:
+
+     -    "angular": "1.3.4",
+     +    "angular": "1.4.7",
+
 
 Version 1.6.3
 =============

--- a/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -7,6 +7,12 @@ Version 1.6.5
 1. In the PDF report config the show_map attribute will be removed and a map is added in the config hierarchy.
    See the doc to update your config: http://docs.camptocamp.net/c2cgeoportal/master/integrator/pdfreport.html
 
+2. If you use ngeo in your project edit `build.json`, located at the root of the project, and change the
+   `templatecache.js` line:
+
+     - ".build/templatecache.js"
+     + "{{package}}/static/build/templatecache.js"
+
 
 Version 1.6.3
 =============

--- a/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -502,7 +502,7 @@ $(OUTPUT_DIR)/build.css: $(LESS_FILES) .build/node_modules.timestamp
 	./node_modules/.bin/lessc $(PACKAGE)/static/less/$(PACKAGE).less $@
 
 .build/build.js: build.json $(OL_JS_FILES) $(NGEO_JS_FILES) $(APP_JS_FILES) \
-		.build/templatecache.js \
+		$(OUTPUT_DIR)/templatecache.js \
 		.build/externs/angular-1.3.js \
 		.build/externs/angular-1.3-q.js \
 		.build/externs/angular-1.3-http-promise.js \
@@ -510,7 +510,8 @@ $(OUTPUT_DIR)/build.css: $(LESS_FILES) .build/node_modules.timestamp
 		.build/node_modules.timestamp
 	./node_modules/openlayers/node_modules/.bin/closure-util build $< $@
 
-.build/templatecache.js: templatecache.mako.js $(APP_PARTIALS_FILES)
+$(OUTPUT_DIR)/templatecache.js: templatecache.mako.js $(APP_PARTIALS_FILES)
+	mkdir -p $(dir $@)
 	$(VENV_BIN)/mako-render --var "partials=$(APP_PARTIALS_FILES)" $< > $@
 
 .build/externs/angular-1.3.js:

--- a/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -503,9 +503,9 @@ $(OUTPUT_DIR)/build.css: $(LESS_FILES) .build/node_modules.timestamp
 
 .build/build.js: build.json $(OL_JS_FILES) $(NGEO_JS_FILES) $(APP_JS_FILES) \
 		$(OUTPUT_DIR)/templatecache.js \
-		.build/externs/angular-1.3.js \
-		.build/externs/angular-1.3-q.js \
-		.build/externs/angular-1.3-http-promise.js \
+		.build/externs/angular-1.4.js \
+		.build/externs/angular-1.4-q_templated.js \
+		.build/externs/angular-1.4-http-promise_templated.js \
 		.build/externs/jquery-1.9.js \
 		.build/node_modules.timestamp
 	./node_modules/openlayers/node_modules/.bin/closure-util build $< $@
@@ -514,19 +514,19 @@ $(OUTPUT_DIR)/templatecache.js: templatecache.mako.js $(APP_PARTIALS_FILES)
 	mkdir -p $(dir $@)
 	PYTHONIOENCODING=UTF-8 $(VENV_BIN)/mako-render --var "partials=$(APP_PARTIALS_FILES)" $< > $@
 
-.build/externs/angular-1.3.js:
+.build/externs/angular-1.4.js:
 	mkdir -p $(dir $@)
-	wget -O $@ https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/angular-1.3.js
+	wget -O $@ https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/angular-1.4.js
 	touch $@
 
-.build/externs/angular-1.3-q.js:
+.build/externs/angular-1.4-q_templated.js:
 	mkdir -p $(dir $@)
-	wget -O $@ https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/angular-1.3-q.js
+	wget -O $@ https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/angular-1.4-q_templated.js
 	touch $@
 
-.build/externs/angular-1.3-http-promise.js:
+.build/externs/angular-1.4-http-promise_templated.js:
 	mkdir -p $(dir $@)
-	wget -O $@ https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/angular-1.3-http-promise.js
+	wget -O $@ https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/angular-1.4-http-promise_templated.js
 	touch $@
 
 .build/externs/jquery-1.9.js:

--- a/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -512,7 +512,7 @@ $(OUTPUT_DIR)/build.css: $(LESS_FILES) .build/node_modules.timestamp
 
 $(OUTPUT_DIR)/templatecache.js: templatecache.mako.js $(APP_PARTIALS_FILES)
 	mkdir -p $(dir $@)
-	$(VENV_BIN)/mako-render --var "partials=$(APP_PARTIALS_FILES)" $< > $@
+	PYTHONIOENCODING=UTF-8 $(VENV_BIN)/mako-render --var "partials=$(APP_PARTIALS_FILES)" $< > $@
 
 .build/externs/angular-1.3.js:
 	mkdir -p $(dir $@)


### PR DESCRIPTION
This PR targets the 1.6 branch. It basically includes three changes:

* `build.json` is now a template (`build.json_tmpl`), and `{{package}}` is used instead of `geoportailv3` in the file.
* https://github.com/elemoine/c2cgeoportal/commit/6b6769a9641b3d88924ab6dad5327995daaab17a is backported to use the Angular template cache in debug mode.
* Switch from Angular v1.3 to Angular v1.4, v1.4 being what ngeo relies on (although ngeo also works with 1.3), and v1.4 being what the Luxembourg project already uses.