### PR TITLE
Better TileCloud chain integration

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -1,6 +1,14 @@
 This file includes migration steps for each release of c2cgeoportal.
 
 
+Version 1.6.6
+=============
+
+1. Now the files `apache/mapcache.xml` and `apache/tiles.conf` will be generated automatically,
+   then you can remove your custom build rules. To disable it set in your Makefile:
+   `TILECLOUD_CHAIN ?= FALSE`.
+
+
 Version 1.6.5
 =============
 

--- a/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -38,7 +38,7 @@ WEB_RULE ?= $(DEFAULT_WEB_RULE)
 
 DEFAULT_BUILD_RULES ?= test-packages .build/requirements.timestamp $(WEB_RULE) build-server apache
 ifeq ($(TILECLOUD_CHAIN), TRUE)
-DEFAULT_BUILD_RULES += test-packages-tilecloud-chain
+DEFAULT_BUILD_RULES += test-packages-tilecloud-chain apache/mapcache.xml apache/tiles.conf
 endif
 ifeq ($(MOBLE), TRUE)
 DEFAULT_BUILD_RULES += test-packages-mobile
@@ -346,6 +346,7 @@ checks: flake8 $(CLIENT_CHECK_RULE) $(WEB_RULE)
 .PHONY: clean
 clean: template-clean
 	rm -f .build/*.timestamp
+	rm -f apache/mapcache.xml apache/tiles.conf
 	rm -rf $(OUTPUT_DIR)/
 	rm -f $(JSBUILD_MOBILE_OUTPUT_FILES)
 	rm -rf $(PACKAGE)/static/mobile/build
@@ -750,6 +751,13 @@ print/WEB-INF/lib/postgresql-9.3-1102.jdbc41.jar:
 	wget http://jdbc.postgresql.org/download/postgresql-9.3-1102.jdbc41.jar -O $@
 	touch $@
 
+# Tile cloud chain
+apache/mapcache.xml: tilegeneration/config.yaml .build/dev-requirements.timestamp
+	$(VENV_BIN)/generate_controller --generate-mapcache-config
+
+apache/mapcache.xml: tilegeneration/config.yaml .build/dev-requirements.timestamp
+	$(VENV_BIN)/generate_controller --generate-apache-config
+
 # Apache config
 .PHONY: apache
 apache: .build/apache.timestamp
@@ -770,6 +778,7 @@ $(APACHE_CONF_DIR)/$(INSTANCE_ID).conf:
 	$(APACHE_GRACEFUL)
 	touch $@
 
+# Upgrade
 UPGRADE_MAKE_FILE ?= $(INSTANCE_ID).mk
 UPGRADE_ARGS ?=
 

--- a/doc/integrator/make.rst
+++ b/doc/integrator/make.rst
@@ -74,29 +74,31 @@ Custom rules
 ------------
 
 In the ``<package>.mk`` file we can create some other rules.
-Here is a simple example that creates the `apache/mapcache.xml` file
+Here is a simple example that creates the
+`/var/sig/tiles/1.0.0/WMTSCapabilities.xml` file
 and removes it on the `clean` rule:
 
 .. code:: makefile
 
-    PRE_RULES = apache/mapcache.xml
+    PRE_RULES = /var/sig/tiles/1.0.0/WMTSCapabilities.xml
 
-    apache/mapcache.xml: tilegeneration/config.yaml .build/dev-requirements.timestamp
-        $(VENV_BIN)/generate_controller --mapcache
+    /var/sig/tiles/1.0.0/WMTSCapabilities.xml: tilegeneration/config.yaml .build/dev-requirements.timestamp
+        $(VENV_BIN)/generate_controller --capabilities
 
     clean: project-clean
     .PHONY: project-clean
     project-clean:
-        rm -f apache/mapcache.xml
+        rm -f /var/sig/tiles/1.0.0/WMTSCapabilities.xml
 
 ``tilegeneration/config.yaml`` and ``.build/dev-requirements.timestamp`` are the files
 that must be built to run the current rule.
 
-``$(VENV_BIN)/generate_controller --mapcache`` is the command that generates the wanted file.
+``$(VENV_BIN)/generate_controller --capabilities`` is the command that generates the wanted file.
 
-.. note::
+Note
+----
 
-   The ``.build/*.timestamp`` files are not really required  but they are flags
-   indicating that an other rule is correctly done.
+The ``.build/*.timestamp`` files are not really required  but they are flags
+indicating that an other rule is correctly done.
 
 Upstream `make documentation <https://www.gnu.org/software/make/manual/make.html>`_.


### PR DESCRIPTION
The files `apache/mapcache.xml` and `apache/tiles.conf` will be generated
automatically.