### PR TITLE
Use GML3 for vector layer in PDF report service

### DIFF
--- a/c2cgeoportal/views/pdfreport.py
+++ b/c2cgeoportal/views/pdfreport.py
@@ -151,11 +151,12 @@ class PdfReport(Proxy):  # pragma: no cover
             mapserv_url,
             "&".join(["%s=%s" % i for i in {
                 "service": "WFS",
-                "version": "1.0.0",
+                "version": "1.1.0",
+                "outputformat": "gml3",
                 "request": "GetFeature",
                 "typeName": self.layername,
                 "featureid": self.layername + "." + id,
-                "srsName": srs
+                "srsName": "epsg:" + str(srs)
             }.items()])
         )
 


### PR DESCRIPTION
The vector layer was requested in GML2, which caused problems with MFP (polygons were parsed as empty geometry). This PR proposes to use GML3 which is parsed correctly.