### PR TITLE
Fixed box query for GeoServer

### DIFF
--- a/c2cgeoportal/views/entry.py
+++ b/c2cgeoportal/views/entry.py
@@ -778,8 +778,9 @@ class Entry(object):
                 name = featureType.getElementsByTagNameNS(self.WFS_NS, "Name").item(0)
                 if name:
                     name_value = name.childNodes[0].data
-                    # ignore namespace
-                    if name_value.find(":") >= 0:  # pragma nocover
+                    # ignore namespace when not using geoserver
+                    if name_value.find(":") >= 0 and \
+                            not self.mapserver_settings["geoserver"]:  # pragma nocover
                         name_value = name_value.split(":")[1]
                     featuretypes.append(name_value)
                 else:  # pragma nocover

--- a/doc/integrator/backend.rst
+++ b/doc/integrator/backend.rst
@@ -13,3 +13,4 @@ user other backends.
 
    backend_qgis
    backend_arcgis
+   backend_geoserver

--- a/doc/integrator/backend_geoserver.rst
+++ b/doc/integrator/backend_geoserver.rst
@@ -1,0 +1,22 @@
+.. _integrator_backend_geoserver:
+
+Specific configuration for GeoServer
+=========================================
+
+Viewer configuration
+--------------------
+
+In the ``<package>/templates/viewer.js`` file, make sure no namespace is added for WFS::
+
+    cgxp.WFS_FEATURE_NS = undefined;
+
+Application configuration
+-------------------------
+
+In the ``vars_<project>.yaml`` file, define in the ``vars`` section:
+
+.. code:: yaml
+
+    mapserverproxy:
+        mapserv_url: http://your.geoserver/geoserver/wms
+        geoserver: true


### PR DESCRIPTION
Geoserver uses namespaces for representing the different workspaces.
Because of that, one cannot remove it.

I took the opportunity to start the GeoServer backend documentation.