### PR TITLE
Security fixes

### DIFF
--- a/c2cgeoportal/scaffolds/create/+package+/templates/edit.js_tmpl
+++ b/c2cgeoportal/scaffolds/create/+package+/templates/edit.js_tmpl
@@ -35,6 +35,9 @@ Ext.onReady(function() {
     // Server errors (if any)
     var serverError = ${serverError | n};
 
+    // Used to transmit event through the application
+    var EVENTS = new Ext.util.Observable();
+
     var WMTS_OPTIONS = {
         url: ${tiles_url | n},
         getURL: function() {

--- a/c2cgeoportal/scaffolds/create/+package+/templates/viewer.js_tmpl
+++ b/c2cgeoportal/scaffolds/create/+package+/templates/viewer.js_tmpl
@@ -36,7 +36,7 @@ Ext.onReady(function() {
     // Server errors (if any)
     var serverError = ${serverError | n};
 
-    // Used to transmit event throw the application
+    // Used to transmit event through the application
     var EVENTS = new Ext.util.Observable();
 
     var WMTS_OPTIONS = {
@@ -157,7 +157,7 @@ Ext.onReady(function() {
 % if permalink_themes:
                 permalinkThemes: ${permalink_themes | n},
 % endif
-                defaultThemes: ["default_theme_to_load"],
+                //defaultThemes: ["default_theme_to_load"],
                 uniqueTheme: true,
                 wmsURL: "${request.route_url('mapserverproxy') | n}",
                 wmsOptions: {

--- a/c2cgeoportal/scaffolds/create/jsbuild/app.cfg.mako_tmpl
+++ b/c2cgeoportal/scaffolds/create/jsbuild/app.cfg.mako_tmpl
@@ -166,6 +166,8 @@ include =
     OpenLayers/Control/OverviewMap.js
     OpenLayers/Control/NavigationHistory.js
     OpenLayers/Layer/Vector.js
+    OpenLayers/Layer/WMTS.js
+    OpenLayers/Layer/WMS.js
     OpenLayers/Renderer/SVG.js
     OpenLayers/Renderer/VML.js
     plugins/OLSource.js #GXP

--- a/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -300,7 +300,7 @@ CONFIG_VARS += sqlalchemy.url schema parentschema enable_admin_interface pyramid
 	available_locale_names cache admin_interface functionalities external_themes_url \
 	raster shortener hide_capabilities mapserverproxy tinyowsproxy print_url tiles_url \
 	checker check_collector default_max_age jsbuild package srid \
-	reset_password fulltextsearch headers
+	reset_password fulltextsearch headers authorized_referers
 ENVIRONMENT_VARS += INSTANCE_ID=${INSTANCE_ID} \
 	APACHE_ENTRY_POINT=$(APACHE_ENTRY_POINT) \
 	DEVELOPMENT=${DEVELOPMENT} \

--- a/c2cgeoportal/scaffolds/update/CONST_vars.yaml_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_vars.yaml_tmpl
@@ -310,6 +310,11 @@ vars:
           url: http://{host}/{instanceid}/wsgi
           type: main
 
+    # What web page is authorized to use the API
+    authorized_referers:
+    - http://{host}/{instanceid}
+    - https://{host}/{instanceid}
+
 interpreted:
     python:
     - authtkt.secret

--- a/c2cgeoportal/tests/functional/__init__.py
+++ b/c2cgeoportal/tests/functional/__init__.py
@@ -166,3 +166,17 @@ def create_dummy_request(additional_settings={}, *args, **kargs):
     request.registry.validate_user = default_user_validator
     request.client_addr = None
     return request
+
+
+def add_user_property(request):
+    """
+    Add the "user" property to the given request.
+    Disable referer checking.
+    """
+    from c2cgeoportal import _create_get_user_from_request
+    request.referer = "http://example.com/app"
+    request.set_property(
+        _create_get_user_from_request({"authorized_referers": [request.referer]}),
+        name="user",
+        reify=True
+    )

--- a/c2cgeoportal/tests/functional/test_groups_finder.py
+++ b/c2cgeoportal/tests/functional/test_groups_finder.py
@@ -4,7 +4,8 @@ from unittest import TestCase
 
 from c2cgeoportal.tests.functional import (  # noqa
     tear_down_common as tearDownModule,
-    set_up_common as setUpModule
+    set_up_common as setUpModule,
+    add_user_property
 )
 
 
@@ -48,11 +49,6 @@ class TestGroupsFinder(TestCase):
 
     def _create_request(self):
         from pyramid.request import Request
-        from c2cgeoportal import get_user_from_request
         request = Request({})
-        request.set_property(
-            get_user_from_request,
-            name="user",
-            reify=True
-        )
+        add_user_property(request)
         return request

--- a/c2cgeoportal/tests/functional/test_request_property.py
+++ b/c2cgeoportal/tests/functional/test_request_property.py
@@ -5,7 +5,8 @@ from unittest import TestCase
 
 from c2cgeoportal.tests.functional import (  # noqa
     tear_down_common as tearDownModule,
-    set_up_common as setUpModule
+    set_up_common as setUpModule,
+    add_user_property
 )
 
 
@@ -50,7 +51,6 @@ class TestRequestProperty(TestCase):
 
     def test_request_right_auth(self):
         from pyramid.testing import DummyRequest
-        from c2cgeoportal import get_user_from_request
         from c2cgeoportal import default_user_validator
         from c2cgeoportal.lib.authentication import create_authentication
 
@@ -62,15 +62,12 @@ class TestRequestProperty(TestCase):
             "authtkt_cookie_name": "__test",
             "authtkt_secret": "123",
         })
-        request.set_property(
-            get_user_from_request, name="user", reify=True
-        )
+        add_user_property(request)
 
         self.assertEqual(request.user.username, u"__test_user")
 
     def test_request_wrong_auth(self):
         from pyramid.testing import DummyRequest
-        from c2cgeoportal import get_user_from_request
         from c2cgeoportal import default_user_validator
         from c2cgeoportal.lib.authentication import create_authentication
 
@@ -82,9 +79,7 @@ class TestRequestProperty(TestCase):
             "authtkt_cookie_name": "__test",
             "authtkt_secret": "123",
         })
-        request.set_property(
-            get_user_from_request, name="user", reify=True
-        )
+        add_user_property(request)
 
         self.assertEqual(request.user, None)
 
@@ -110,9 +105,6 @@ class TestRequestProperty(TestCase):
 
     def _create_request(self):
         from pyramid.request import Request
-        from c2cgeoportal import get_user_from_request
         request = Request({})
-        request.set_property(
-            get_user_from_request, name="user"
-        )
+        add_user_property(request)
         return request

--- a/c2cgeoportal/views/entry.py
+++ b/c2cgeoportal/views/entry.py
@@ -959,7 +959,7 @@ class Entry(object):
             d["permalink_themes"] = json.dumps(permalink_themes.split(","))
 
         set_common_headers(
-            self.request, "cgxp_viewer", PRIVATE_CACHE,
+            self.request, "cgxp_viewer", NO_CACHE,
             vary=True, content_type="application/javascript",
         )
 

--- a/doc/integrator/security.rst
+++ b/doc/integrator/security.rst
@@ -58,3 +58,17 @@ Available services are:
 - profile
 - raster
 - error
+
+Authorized referers
+-------------------
+
+To mitigate `CSRF <https://en.wikipedia.org/wiki/Cross-site_request_forgery>`_
+attacks, the server validates the referer against a list of authorized referers.
+
+By default, only the pages coming from the server are allowed. You can change
+that list by adding an ``authorized_referers`` list in your
+``vars_<project>.yaml`` file.
+
+This solution is not the most secure (some people have browser extensions that
+reset the referer), but that is the easiest to implement with all our different
+JS frameworks.


### PR DESCRIPTION
Added a protection against CSRF attacks.
Validate the query referer against a list of authorized referers.

The best solution would be to add a token only the main page
knows when the user logs in (via a cookie). Adding a header to all the requests
would mean a lot of changes:

* Extjs: ``Ext.Ajax.setDefaultHeaders``
* OL: ``OpenLayers.Request.DEFAULT_CONFIG.headers``
* JQuery: ``$.ajaxSetup({headers: {...}})``
* Angular: ``$httpProvider.defaults.headers``

Fixed details in edit.js and view.js    
The edit page was failing because:
* EVENTS was undefined
* WMS and WMTS where undefined
    
The view page was always showing the restricted warning even after
logging in because:
* view.js was cached
* non existant default theme
