### PR TITLE
Update Shapely version for Windows

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_requirements_windows.txt
+++ b/c2cgeoportal/scaffolds/update/CONST_requirements_windows.txt
@@ -2,7 +2,7 @@
 --find-links http://pypi.camptocamp.net/internal-pypi/index/c2cgeoportal-win
 -r CONST_versions.txt
 wheels/psycopg2-2.5.5-cp27-none-win32.whl
-wheels/Shapely-1.5.7-cp27-none-win32.whl
+wheels/Shapely-1.5.13-cp27-none-win32.whl
 wheels/Pillow-2.8.1-cp27-none-win32.whl
 https://github.com/Pylons/pyramid/archive/1e02bbfc0df09259bf207112acf019c8dba44a90.zip#egg=pyramid>=1.6.dev
 https://github.com/camptocamp/pyramid_closure/archive/819bc43420b3cd924d8698c5a9606592c19dbb15.zip#egg=pyramid_closure


### PR DESCRIPTION
This PR updates the version of the Shapely wheel for instances running on Windows (I think SITN might be the only one on Windows...).

I need that because we have some troubles running our instances on Shapely 1.5.7 (some DLL mix up... don't ask... Windows...)

This PR is meant to be merged into the 1.6 branch.

Thanks !