### PR TITLE
Fix encoding issue in httplib when doing print request from IE11.

### DIFF
--- a/c2cgeoportal/views/proxy.py
+++ b/c2cgeoportal/views/proxy.py
@@ -96,6 +96,8 @@ class Proxy:
             body = StringIO(self.request.body)
 
         try:
+            # fix encoding issue with IE
+            url = url.encode("UTF8")
             if method in ("POST", "PUT"):
                 resp, content = http.request(
                     url, method=method, body=body, headers=headers


### PR DESCRIPTION
reported from https://github.com/camptocamp/jura_c2cgeoportal/issues/40