### PR TITLE
Stop using deprecated configuration for print logging

### DIFF
--- a/c2cgeoportal/scaffolds/create/print/WEB-INF/classes/logback.xml.mako
+++ b/c2cgeoportal/scaffolds/create/print/WEB-INF/classes/logback.xml.mako
@@ -21,9 +21,9 @@
 <configuration>
 
     <appender name="standardOut" class="ch.qos.logback.core.ConsoleAppender">
-        <layout class="ch.qos.logback.classic.PatternLayout">
+        <encoder>
             <Pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</Pattern>
-        </layout>
+        </encoder>
     </appender>
 
     <appender name="File" class="ch.qos.logback.core.rolling.RollingFileAppender">
@@ -36,13 +36,14 @@
             <maxHistory>30</maxHistory>
         </rollingPolicy>
 
-        <layout class="ch.qos.logback.classic.PatternLayout">
+        <encoder>
             <Pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</Pattern>
-        </layout>
+        </encoder>
     </appender>
 
     <logger name="org.mapfish" level="${"DEBUG" if development else "ERROR"}" />
-    <logger name="org.springframework" level="OFF" />
+    <logger name="org.springframework" level="WARN" />
+    <logger name="org.apache" level="WARN" />
     <!-- Set spec logger to INFO to log all print spec json data -->
     <logger name="org.mapfish.print.servlet.BaseMapServlet.spec" level="OFF" />
     <logger name="com.codahale.metrics" level="INFO" />


### PR DESCRIPTION
We use to have this error message:
WARN in ch.qos.logback.core.ConsoleAppender[standardOut] -
  This appender no longer admits a layout as a sub-component, set an encoder instead.

Upgraded the print to 3ff8727.