### PR TITLE
Add a new resourceproxy service, allowing to load external resources.

### DIFF
--- a/c2cgeoportal/__init__.py
+++ b/c2cgeoportal/__init__.py
@@ -622,6 +622,9 @@ def includeme(config):
     # mako templates to get the root of the "layers" web service
     config.add_route("layers_root", "/layers/", request_method="HEAD")
 
+    # Resource proxy (load external url, useful when loading non https content)
+    config.add_route("resourceproxy", "/resourceproxy", request_method="GET")
+
     # pyramid_formalchemy's configuration
     config.include("pyramid_formalchemy")
     config.include("fa.jquery")

--- a/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -291,8 +291,8 @@ VARS_DEPENDS += $(VARS_FILES) .build/node_modules.timestamp
 CONFIG_VARS += sqlalchemy.url schema parentschema enable_admin_interface pyramid_closure \
 	node_modules_path closure_library_path default_locale_name servers layers \
 	available_locale_names cache admin_interface functionalities external_themes_url \
-	raster shortener hide_capabilities mapserverproxy tinyowsproxy print_url tiles_url \
-	checker check_collector default_max_age jsbuild package srid \
+	raster shortener hide_capabilities mapserverproxy tinyowsproxy resourceproxy print_url \
+	tiles_url checker check_collector default_max_age jsbuild package srid \
 	reset_password fulltextsearch
 ENVIRONMENT_VARS += INSTANCE_ID=${INSTANCE_ID} \
 	APACHE_ENTRY_POINT=$(APACHE_ENTRY_POINT) \

--- a/c2cgeoportal/scaffolds/update/CONST_vars.yaml_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_vars.yaml_tmpl
@@ -196,6 +196,11 @@ vars:
         # the host has to be set explicitly in a vhost environment.
         # tinyows_host: {host}
 
+    resourceproxy:
+        # list of urls from which it is safe to load content
+        targets:
+          #exempletargetname: http://www.camptocamp.com/?param1=%s&param2=%s
+
     fulltextsearch:
         defaultlimit: 30
         maxlimit: 200

--- a/c2cgeoportal/views/resourceproxy.py
+++ b/c2cgeoportal/views/resourceproxy.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2011-2015, Camptocamp SA
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# The views and conclusions contained in the software and documentation are those
+# of the authors and should not be interpreted as representing official policies,
+# either expressed or implied, of the FreeBSD Project.
+
+
+import logging
+
+from pyramid.view import view_config
+from pyramid.httpexceptions import HTTPBadRequest
+from c2cgeoportal.views.proxy import Proxy
+from c2cgeoportal.lib.caching import NO_CACHE
+
+import ast
+
+log = logging.getLogger(__name__)
+
+
+class ResourceProxy(Proxy):
+
+    def __init__(self, request):  # pragma: no cover
+        Proxy.__init__(self, request)
+        self.request = request
+        self.settings = request.registry.settings.get("resourceproxy", {})
+
+    @view_config(route_name="resourceproxy")
+    def proxy(self):  # pragma: no cover
+        target = self.request.params.get("target", "")
+        targets = self.settings.get("targets", [])
+        if target in targets:  # pragma: no cover
+            url = targets[target]
+            values = ast.literal_eval(self.request.params.get("values", None))
+            url = url % values
+
+            resp, content = self._proxy(url=url)
+
+            cache_control = NO_CACHE
+            content_type = resp["content-type"]
+
+            return self._build_response(
+                resp, content, cache_control, "externalresource",
+                content_type=content_type
+            )
+        else:  # pragma: no cover
+            log.warning("target url not found: %s" % target)
+            return HTTPBadRequest("url not allowed")

--- a/doc/integrator/https.rst
+++ b/doc/integrator/https.rst
@@ -33,3 +33,25 @@ value of ``request.scheme``. For example::
     % endif
     /* ... */
     };
+
+Loading non https external resources
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you want to load non https external resources in your https application, you
+must use the resourceproxy service and add the list of hosts you want to access
+in your project `vars_<project>.yaml` configuration file:
+
+.. code:: yaml
+
+    resourceproxy:
+        # list of urls from which it is safe to load content
+        targets:
+          #exempletargetname: http://www.camptocamp.com/?param1=%s&param2=%s
+          rfinfo: http://www.rfinfo.vd.ch/rfinfo.php?no_commune=%s&no_immeuble=%s
+
+Then you can access resources by building urls using the following schema:
+``http://<host>/<instanceid>/wsgi/resourceproxy?target=<targetname>&values=(<valueparam1>,...)``.
+
+For example:
+
+``http://geoportail.camptocamp.com/main/wsgi/resourceproxy?target=rfinfo&values=(175,2633)``


### PR DESCRIPTION
Useful when the project is configured with https and you want to include non-https content. The resources url host must be specifically added in the project configuration to be allowed to be loaded.

Needed in the Morges project.