### PR TITLE
Fix change of user with the same role.

### DIFF
--- a/c2cgeoportal/__init__.py
+++ b/c2cgeoportal/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2011-2015, Camptocamp SA
+# Copyright (c) 2011-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/forms.py
+++ b/c2cgeoportal/forms.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2011-2015, Camptocamp SA
+# Copyright (c) 2011-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/lib/__init__.py
+++ b/c2cgeoportal/lib/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2011-2015, Camptocamp SA
+# Copyright (c) 2011-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without
@@ -152,8 +152,11 @@ class C2CPregenerator:  # pragma: no cover
             from c2cgeoportal.lib.cacheversion import get_cache_version
             query["cache_version"] = get_cache_version()
 
-        if self.role and request.user and request.user.role:
-            query["role"] = request.user.role.id
+        if self.role and request.user:
+            # The templates change if the user is logged in or not. Usually it's
+            # the role that is making a difference, but the username is put in
+            # some JS files. So we add the username to hit different cache entries.
+            query["username"] = request.user.username
 
         kw["_query"] = query
         return elements, kw

--- a/c2cgeoportal/lib/authentication.py
+++ b/c2cgeoportal/lib/authentication.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2014-2015, Camptocamp SA
+# Copyright (c) 2014-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/lib/cacheversion.py
+++ b/c2cgeoportal/lib/cacheversion.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2011-2015, Camptocamp SA
+# Copyright (c) 2011-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/lib/caching.py
+++ b/c2cgeoportal/lib/caching.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2012-2015, Camptocamp SA
+# Copyright (c) 2012-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/lib/dbreflection.py
+++ b/c2cgeoportal/lib/dbreflection.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2011-2015, Camptocamp SA
+# Copyright (c) 2011-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/lib/email_.py
+++ b/c2cgeoportal/lib/email_.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2013-2015, Camptocamp SA
+# Copyright (c) 2013-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/lib/filter_capabilities.py
+++ b/c2cgeoportal/lib/filter_capabilities.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2014-2015, Camptocamp SA
+# Copyright (c) 2014-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/lib/functionality.py
+++ b/c2cgeoportal/lib/functionality.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2011-2015, Camptocamp SA
+# Copyright (c) 2011-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/lib/raster/dbfutils.py
+++ b/c2cgeoportal/lib/raster/dbfutils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2012-2015, Camptocamp SA
+# Copyright (c) 2012-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/lib/raster/georaster.py
+++ b/c2cgeoportal/lib/raster/georaster.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2012-2015, Camptocamp SA
+# Copyright (c) 2012-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/lib/raster/shputils.py
+++ b/c2cgeoportal/lib/raster/shputils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2012-2015, Camptocamp SA
+# Copyright (c) 2012-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/lib/sqlalchemy_.py
+++ b/c2cgeoportal/lib/sqlalchemy_.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2013-2015, Camptocamp SA
+# Copyright (c) 2013-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/lib/wmstparsing.py
+++ b/c2cgeoportal/lib/wmstparsing.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2013-2015, Camptocamp SA
+# Copyright (c) 2013-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/models.py
+++ b/c2cgeoportal/models.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2011-2015, Camptocamp SA
+# Copyright (c) 2011-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/resources.py
+++ b/c2cgeoportal/resources.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2011-2015, Camptocamp SA
+# Copyright (c) 2011-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/scaffolds/update/CONST_alembic/main/env.py
+++ b/c2cgeoportal/scaffolds/update/CONST_alembic/main/env.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2015, Camptocamp SA
+# Copyright (c) 2014-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/scaffolds/update/CONST_alembic/main/versions/164ac0819a61_add_image_format_to_wmts_layer.py
+++ b/c2cgeoportal/scaffolds/update/CONST_alembic/main/versions/164ac0819a61_add_image_format_to_wmts_layer.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2015, Camptocamp SA
+# Copyright (c) 2015-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/scaffolds/update/CONST_alembic/main/versions/166ff2dcc48d_create_database.py
+++ b/c2cgeoportal/scaffolds/update/CONST_alembic/main/versions/166ff2dcc48d_create_database.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2014-2015, Camptocamp SA
+# Copyright (c) 2014-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/scaffolds/update/CONST_alembic/main/versions/1d5d4abfebd1_add_restricted_theme.py
+++ b/c2cgeoportal/scaffolds/update/CONST_alembic/main/versions/1d5d4abfebd1_add_restricted_theme.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2015, Camptocamp SA
+# Copyright (c) 2014-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/scaffolds/update/CONST_alembic/main/versions/20137477bd02_update_icons_url.py
+++ b/c2cgeoportal/scaffolds/update/CONST_alembic/main/versions/20137477bd02_update_icons_url.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2014-2015, Camptocamp SA
+# Copyright (c) 2014-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/scaffolds/update/CONST_alembic/main/versions/22e6dfb556de_add_description_tree_.py
+++ b/c2cgeoportal/scaffolds/update/CONST_alembic/main/versions/22e6dfb556de_add_description_tree_.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2015, Camptocamp SA
+# Copyright (c) 2015-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/scaffolds/update/CONST_alembic/main/versions/2b8ed8c1df94_set_layergroup_treeitem_is_as_a_primary_.py
+++ b/c2cgeoportal/scaffolds/update/CONST_alembic/main/versions/2b8ed8c1df94_set_layergroup_treeitem_is_as_a_primary_.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2015, Camptocamp SA
+# Copyright (c) 2015-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/scaffolds/update/CONST_alembic/main/versions/32527659d57b_move_exclude_properties_from_layerv1_to_.py
+++ b/c2cgeoportal/scaffolds/update/CONST_alembic/main/versions/32527659d57b_move_exclude_properties_from_layerv1_to_.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2015, Camptocamp SA
+# Copyright (c) 2015-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/scaffolds/update/CONST_alembic/main/versions/415746eb9f6_changes_for_v2.py
+++ b/c2cgeoportal/scaffolds/update/CONST_alembic/main/versions/415746eb9f6_changes_for_v2.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2014-2015, Camptocamp SA
+# Copyright (c) 2014-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/scaffolds/update/CONST_alembic/main/versions/5109242131ce_add_column_time_widget.py
+++ b/c2cgeoportal/scaffolds/update/CONST_alembic/main/versions/5109242131ce_add_column_time_widget.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2015, Camptocamp SA
+# Copyright (c) 2015-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/scaffolds/update/CONST_alembic/main/versions/54645a535ad6_add_ordering_in_relation.py
+++ b/c2cgeoportal/scaffolds/update/CONST_alembic/main/versions/54645a535ad6_add_ordering_in_relation.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2014-2015, Camptocamp SA
+# Copyright (c) 2014-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/scaffolds/update/CONST_alembic/static/env.py
+++ b/c2cgeoportal/scaffolds/update/CONST_alembic/static/env.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015, Camptocamp SA
+# Copyright (c) 2015-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/scaffolds/update/CONST_alembic/static/versions/1da396a88908_move_user_table_to_static_schema.py
+++ b/c2cgeoportal/scaffolds/update/CONST_alembic/static/versions/1da396a88908_move_user_table_to_static_schema.py
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2015, Camptocamp SA
+# Copyright (c) 2015-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/scaffolds/update/CONST_alembic/static/versions/3f89a7d71a5e_alter_column_url_to_remove_limitation.py
+++ b/c2cgeoportal/scaffolds/update/CONST_alembic/static/versions/3f89a7d71a5e_alter_column_url_to_remove_limitation.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2014-2015, Camptocamp SA
+# Copyright (c) 2014-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/scaffolds/update/CONST_alembic/static/versions/5472fbc19f39_add_temp_password_column.py
+++ b/c2cgeoportal/scaffolds/update/CONST_alembic/static/versions/5472fbc19f39_add_temp_password_column.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2015, Camptocamp SA
+# Copyright (c) 2015-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/scripts/c2ctool.py
+++ b/c2cgeoportal/scripts/c2ctool.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2014-2015, Camptocamp SA
+# Copyright (c) 2014-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/scripts/db2pot.py
+++ b/c2cgeoportal/scripts/db2pot.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2014-2015, Camptocamp SA
+# Copyright (c) 2014-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/scripts/manage_users.py
+++ b/c2cgeoportal/scripts/manage_users.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2011-2015, Camptocamp SA
+# Copyright (c) 2011-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/scripts/print_tpl.py
+++ b/c2cgeoportal/scripts/print_tpl.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2011-2015, Camptocamp SA
+# Copyright (c) 2011-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/subscribers.py
+++ b/c2cgeoportal/subscribers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2011-2015, Camptocamp SA
+# Copyright (c) 2011-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/views/check_collector.py
+++ b/c2cgeoportal/views/check_collector.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2012-2015, Camptocamp SA
+# Copyright (c) 2012-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/views/checker.py
+++ b/c2cgeoportal/views/checker.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2011-2015, Camptocamp SA
+# Copyright (c) 2011-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/views/echo.py
+++ b/c2cgeoportal/views/echo.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2012-2015, Camptocamp SA
+# Copyright (c) 2012-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/views/entry.py
+++ b/c2cgeoportal/views/entry.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2011-2015, Camptocamp SA
+# Copyright (c) 2011-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/views/export.py
+++ b/c2cgeoportal/views/export.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2011-2015, Camptocamp SA
+# Copyright (c) 2011-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/views/fulltextsearch.py
+++ b/c2cgeoportal/views/fulltextsearch.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2011-2015, Camptocamp SA
+# Copyright (c) 2011-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/views/geometry_processing.py
+++ b/c2cgeoportal/views/geometry_processing.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2012-2015, Camptocamp SA
+# Copyright (c) 2012-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/views/layers.py
+++ b/c2cgeoportal/views/layers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2012-2015, Camptocamp SA
+# Copyright (c) 2012-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/views/mapserverproxy.py
+++ b/c2cgeoportal/views/mapserverproxy.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2011-2015, Camptocamp SA
+# Copyright (c) 2011-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/views/pdfreport.py
+++ b/c2cgeoportal/views/pdfreport.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2011-2015, Camptocamp SA
+# Copyright (c) 2011-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/views/printproxy.py
+++ b/c2cgeoportal/views/printproxy.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2011-2015, Camptocamp SA
+# Copyright (c) 2011-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/views/profile.py
+++ b/c2cgeoportal/views/profile.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2012-2015, Camptocamp SA
+# Copyright (c) 2012-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/views/proxy.py
+++ b/c2cgeoportal/views/proxy.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2011-2015, Camptocamp SA
+# Copyright (c) 2011-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/views/raster.py
+++ b/c2cgeoportal/views/raster.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2012-2015, Camptocamp SA
+# Copyright (c) 2012-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/views/shortener.py
+++ b/c2cgeoportal/views/shortener.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2013-2015, Camptocamp SA
+# Copyright (c) 2013-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/c2cgeoportal/views/tinyowsproxy.py
+++ b/c2cgeoportal/views/tinyowsproxy.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2015, Camptocamp SA
+# Copyright (c) 2015-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013-2015, Camptocamp SA
+# Copyright (c) 2013-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/travis/quote
+++ b/travis/quote
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2011-2015, Camptocamp SA
+# Copyright (c) 2011-2016, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
When doing a logout and login with a different user within the same
group, the "Logged in as" text on the top right corner was still showing
the previous username.

That was because the edit.js, view.js, ... pages were having role= added
as parameter to avoid the cache, not the username. So the page was not
reloaded by the browser and the username sitting in those files was
remaining at the old value.

The fix is to add username= instead of role= to the URLs.