### PR TITLE
Ignore the node_modules folder in the template generation

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -281,7 +281,7 @@ PY_FILES = $(shell find $(PACKAGE) -type f -name '*.py' -print)
 TEMPLATES_FILES = $(shell find $(PACKAGE)/templates -type f -print)
 
 # Templates
-TEMPLATE_EXCLUDE += .build print/templates \
+TEMPLATE_EXCLUDE += .build node_modules print/templates \
 	CONST_alembic/main/script.py.mako \
 	CONST_alembic/static/script.py.mako \
 	$(PACKAGE)/static/lib


### PR DESCRIPTION
Same as #1915 :-) but in the 1.6 branch