### PR TITLE
Upgrade print to 3.3.0.

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -281,7 +281,7 @@ PRINT_WAR ?= print-$(INSTANCE_ID).war
 PRINT_OUTPUT ?= /srv/tomcat/tomcat1/webapps
 PRINT_OUTPUT_WAR =
 PRINT_TMP ?= /tmp
-JASPERREPORTS_VERSION ?= 5.6.1
+JASPERREPORTS_VERSION ?= 6.1.1
 TOMCAT_SERVICE_COMMAND ?= sudo /etc/init.d/tomcat-tomcat1
 ifneq ($(TOMCAT_SERVICE_COMMAND),)
 TOMCAT_STOP_COMMAND ?= $(TOMCAT_SERVICE_COMMAND) stop
@@ -291,11 +291,11 @@ ifeq ($(PRINT_VERSION), 3)
 PRINT_OUTPUT_WAR = $(PRINT_OUTPUT)/$(PRINT_WAR)
 PRINT_BASE_WAR ?= print-servlet.war
 PRINT_INPUT += print-apps WEB-INF
-PRINT_REQUIREMENT += \
+PRINT_EXTRA_LIBS += \
 	$(PRINT_BASE_DIR)/WEB-INF/lib/jasperreports-functions-$(JASPERREPORTS_VERSION).jar \
 	$(PRINT_BASE_DIR)/WEB-INF/lib/joda-time-1.6.jar \
-	$(PRINT_BASE_DIR)/WEB-INF/lib/jasperreports-fonts-$(JASPERREPORTS_VERSION).jar \
-	$(PRINT_BASE_DIR)/WEB-INF/lib/postgresql-9.3-1102.jdbc41.jar \
+	$(PRINT_BASE_DIR)/WEB-INF/lib/postgresql-9.3-1102.jdbc41.jar
+PRINT_REQUIREMENT += $(PRINT_EXTRA_LIBS) \
 	$(PRINT_BASE_DIR)/WEB-INF/classes/logback.xml \
 	$(PRINT_BASE_DIR)/WEB-INF/classes/mapfish-spring-application-context-override.xml \
 	$(shell $(FIND) $(PRINT_BASE_DIR)/print-apps)
@@ -423,11 +423,7 @@ cleanall: clean
 		.build/externs/angular-1.4-q_templated.js \
 		.build/externs/angular-1.4-http-promise_templated.js \
 		.build/externs/jquery-1.9.js
-	rm -f $(PRINT_BASE_DIR)/$(PRINT_BASE_WAR) \
-		print/WEB-INF/lib/jasperreports-functions-${JASPERREPORTS_VERSION}.jar \
-		print/WEB-INF/lib/joda-time-1.6.jar \
-		print/WEB-INF/lib/jasperreports-fonts-${JASPERREPORTS_VERSION}.jar \
-		print/WEB-INF/lib/postgresql-9.3-1102.jdbc41.jar
+	rm -f $(PRINT_BASE_DIR)/$(PRINT_BASE_WAR) $(PRINT_EXTRA_LIBS)
 
 .PHONY: flake8
 flake8: $(VENV_BIN)/flake8
@@ -870,10 +866,6 @@ print/WEB-INF/lib/jasperreports-functions-$(JASPERREPORTS_VERSION).jar:
 print/WEB-INF/lib/joda-time-1.6.jar:
 	mkdir -p $(dir $@)
 	curl --max-redirs 0 --location --output $@ http://maven.ibiblio.org/maven2/joda-time/joda-time/1.6/joda-time-1.6.jar
-
-print/WEB-INF/lib/jasperreports-fonts-$(JASPERREPORTS_VERSION).jar:
-	mkdir -p $(dir $@)
-	curl --location --output $@ http://sourceforge.net/projects/jasperreports/files/jasperreports/JasperReports%20$(JASPERREPORTS_VERSION)/jasperreports-fonts-$(JASPERREPORTS_VERSION).jar/download
 
 print/WEB-INF/lib/postgresql-9.3-1102.jdbc41.jar:
 	mkdir -p $(dir $@)

--- a/c2cgeoportal/scaffolds/update/CONST_print_url
+++ b/c2cgeoportal/scaffolds/update/CONST_print_url
@@ -1,1 +1,1 @@
-https://repo1.maven.org/maven2/org/mapfish/print/print-servlet/3.2.0/print-servlet-3.2.0.war
+https://repo1.maven.org/maven2/org/mapfish/print/print-servlet/3.3.0/print-servlet-3.3.0.war

--- a/c2cgeoportal/scaffolds/update/print/Dockerfile
+++ b/c2cgeoportal/scaffolds/update/print/Dockerfile
@@ -1,4 +1,4 @@
-FROM camptocamp/mapfish_print:latest
+FROM camptocamp/mapfish_print:3.3.0
 MAINTAINER Camptocamp "info@camptocamp.com"
 
 RUN rm -rf webapps/ROOT/print-apps


### PR DESCRIPTION
Took the opportinity to fix a few things:
* The Jasper version changed.
* The lib jasperreports-fonts is already included in the print.
* DRY in the makefile for the cleaning of print libs.
* Moved the print Dockerfile from create to update (no reason for the user
  to change it).