### PR TITLE
Add check for the downloaded JARs

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -737,18 +737,22 @@ endif
 print/WEB-INF/lib/jasperreports-functions-5.6.1.jar:
 	mkdir -p $(dir $@)
 	curl --location --output $@ http://sourceforge.net/projects/jasperreports/files/jasperreports/JasperReports%205.6.1/jasperreports-functions-5.6.1.jar/download
+	unzip -t -q $@
 
 print/WEB-INF/lib/joda-time-1.6.jar:
 	mkdir -p $(dir $@)
 	curl --max-redirs 0 --location --output $@ http://maven.ibiblio.org/maven2/joda-time/joda-time/1.6/joda-time-1.6.jar
+	unzip -t -q $@
 
 print/WEB-INF/lib/jasperreports-fonts-5.6.1.jar:
 	mkdir -p $(dir $@)
 	curl --location --output $@ http://sourceforge.net/projects/jasperreports/files/jasperreports/JasperReports%205.6.1/jasperreports-fonts-5.6.1.jar/download
+	unzip -t -q $@
 
 print/WEB-INF/lib/postgresql-9.3-1102.jdbc41.jar:
 	mkdir -p $(dir $@)
 	curl --max-redirs 0 --location --output $@ https://jdbc.postgresql.org/download/postgresql-9.3-1102.jdbc41.jar
+	unzip -t -q $@
 
 # Tile cloud chain
 apache/mapcache.xml: tilegeneration/config.yaml .build/dev-requirements.timestamp


### PR DESCRIPTION
The places we download from are often returning HTML files instead of the
JARs we request. The leads to very obscure and hard to debug errors in the
print. So checks will serve as early detection of those problems.