### PR TITLE
set version of pip not causing error when installing PasteScript

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -19,7 +19,7 @@ PRINT_VERSION ?= 3
 
 PIP_CMD ?= $(VENV_BIN)/pip
 PIP_INSTALL_ARGS += install --trusted-host pypi.camptocamp.net
-PIP_VERSION ?= pip>=6
+PIP_VERSION ?= pip>=7,<8
 SETUPTOOL_VERSION ?= setuptools>=12
 
 GIT_MODULES_FOLDER ?= .git/modules/


### PR DESCRIPTION
because pip version 8.* is currently not compatible