### PR TITLE
Fix locale_negotiator for fulltextsearch

### DIFF
--- a/c2cgeoportal/__init__.py
+++ b/c2cgeoportal/__init__.py
@@ -317,10 +317,10 @@ def _add_static_view(config, name, path):
 def locale_negotiator(request):
     lang = request.params.get("lang")
     if lang is None:
-        # if best_match returns None then Pyramid will use what's defined in
-        # the default_locale_name configuration variable
+        # if best_match returns None then use the default_locale_name configuration variable
         return request.accept_language.best_match(
-            request.registry.settings.get("available_locale_names"))
+            request.registry.settings.get("available_locale_names"),
+            default_match=request.registry.settings.get("default_locale_name"))
     return lang
 
 

--- a/c2cgeoportal/tests/test_locale_negociator.py
+++ b/c2cgeoportal/tests/test_locale_negociator.py
@@ -54,7 +54,7 @@ class TestLocalNegociator(TestCase):
 
         request.headers["accept-language"] = "en-us,en;q=0.3,fr;q=0.7"
         lang = locale_negotiator(request)
-        self.assertEquals(lang, None)
+        self.assertEquals(lang, "de")
 
     def test_lang_is_available(self):
         from c2cgeoportal import locale_negotiator


### PR DESCRIPTION
This function was relying on Piramid to use default_locale_name if no locale
is found. But fulltextsearch is using this function directly and was returing
status=500 if the browser's languages were not matching the list of available
languages.