### PR TITLE
Use of maven central repository

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -741,7 +741,7 @@ print/WEB-INF/lib/jasperreports-functions-5.6.1.jar:
 
 print/WEB-INF/lib/joda-time-1.6.jar:
 	mkdir -p $(dir $@)
-	curl --max-redirs 0 --location --output $@ http://maven.ibiblio.org/maven2/joda-time/joda-time/1.6/joda-time-1.6.jar
+	curl --max-redirs 0 --location --output $@ http://central.maven.org/maven2/joda-time/joda-time/1.6/joda-time-1.6.jar
 	unzip -t -q $@
 
 print/WEB-INF/lib/jasperreports-fonts-5.6.1.jar:


### PR DESCRIPTION
It is better to use the official maven repository instead of a custom maven
repository. ibiblio is currently down.