### PR TITLE
Forward cookie header in checker and check_collector

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_vars.yaml_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_vars.yaml_tmpl
@@ -254,6 +254,7 @@ vars:
 
     # Checker configuration
     checker:
+        forward_headers: []
         fulltextsearch: text to search
         lang_files: [cgxp, cgxp-api]
         themes:

--- a/c2cgeoportal/tests/test_checker.py
+++ b/c2cgeoportal/tests/test_checker.py
@@ -90,3 +90,29 @@ class TestExportCSVView(TestCase):
                 }
             )
         )
+
+    def test_build_url_forward_headers(self):
+        request = DummyRequest()
+        request.environ = {
+            "SERVER_NAME": "example.com"
+        }
+        request.registry.settings = {
+            "checker": {
+                "forward_headers": ["Cookie"]
+            }
+        }
+        request.headers["Cookie"] = "test"
+        self.assertEqual(
+            build_url(
+                "Test",
+                "https://camptocamp.com/toto?titi#tutu",
+                request
+            ),
+            (
+                "https://camptocamp.com/toto?titi#tutu",
+                {
+                    "Cache-Control": "no-cache",
+                    "Cookie": "test",
+                }
+            )
+        )

--- a/c2cgeoportal/views/checker.py
+++ b/c2cgeoportal/views/checker.py
@@ -57,6 +57,12 @@ def build_url(name, url, request, headers=None):
     else:
         url_ = url
 
+    settings = request.registry.settings.get("checker", {})
+    for header in settings.get("forward_headers", []):
+        value = request.headers.get(header)
+        if value is not None:
+            headers[header] = value
+
     log.info("%s, URL: %s => %s" % (name, url, url_))
     return url_, headers
 

--- a/doc/integrator/checker.rst
+++ b/doc/integrator/checker.rst
@@ -50,6 +50,15 @@ Configuration in ``vars_<project>.yaml``:
         print_scale: 10000
         fulltextsearch: text to search
 
+If some of the checked services require an authenticated user, the
+``forward_headers`` permit to forward ``Cookie`` or ``Authorisation`` headers
+in the underlying requests.
+
+.. code:: yaml
+
+    checker:
+        forward_headers: ['Cookie', 'Authorisation']
+
 Check collector
 ---------------
 


### PR DESCRIPTION
When we apply ACL on views, we need cookie to be forwarded by the checker.
I need this for lyon airport where only login and logout views are public.