### PR TITLE
Support openjdk 8 in java version checking

### DIFF
--- a/c2cgeoportal/scaffolds/create/print/print-apps/+package+/config.yaml.mako
+++ b/c2cgeoportal/scaffolds/create/print/print-apps/+package+/config.yaml.mako
@@ -38,11 +38,8 @@ templates:
         - !configureHttpRequests &configureHttpRequests
             httpProcessors:
             - !mapUri
-                matchers:
-                - !dnsMatch
-                    host: ${host}
                 mapping:
-                    (https?)://${host}/(.*): "http://127.0.0.1/$2"
+                    (https?)://${__import__('re').escape(host)}/(.*): "http://127.0.0.1/$2"
             - !forwardHeaders
                 matchers:
                 - !localMatch {}

--- a/c2cgeoportal/scaffolds/update/CONST_packages.yaml
+++ b/c2cgeoportal/scaffolds/update/CONST_packages.yaml
@@ -6,7 +6,7 @@ common:
         version: 2.7
     python-dev: 2.7
     java:
-        cmd: java -version 2>&1 | grep 'java version' | awk '{{print $3}}' | sed 's/"//g' | sed 's/_/./g'
+        cmd: java -version 2>&1 | grep  -E '(java|openjdk) version' | awk '{{print $3}}' | sed 's/"//g' | sed 's/_/./g'
         version: 1.7.0
 
 main:


### PR DESCRIPTION
Mine reports that:
      openjdk version "1.8.0_66-internal"

Remove useless dnsMatch for the mapUri rule.
