### PR TITLE
Removes graceful-fs, no more needed

### DIFF
--- a/c2cgeoportal/scripts/import_ngeo_apps.py
+++ b/c2cgeoportal/scripts/import_ngeo_apps.py
@@ -156,7 +156,6 @@ def main():
                 "coveralls",
                 "fs-extra",
                 "gaze",
-                "graceful-fs",
                 "jsdoc",
                 "jsdom",
                 "karma",


### PR DESCRIPTION
See: https://github.com/camptocamp/ngeo/pull/1401