### PR TITLE
Match theme with a simple pattern

### DIFF
--- a/c2cgeoportal/__init__.py
+++ b/c2cgeoportal/__init__.py
@@ -149,7 +149,7 @@ def add_interface_cgxp(config, interface_name, route_names, routes, renderers): 
     # permalink theme: recover the theme for generating custom viewer.js url
     config.add_route(
         "%stheme" % route_names[0],
-        "%s%stheme/*themes" % (routes[0], "" if routes[0][-1] == "/" else "/"),
+        "%s%stheme/{themes}" % (routes[0], "" if routes[0][-1] == "/" else "/"),
     )
     config.add_view(
         Entry,
@@ -196,7 +196,7 @@ def add_interface_ngeo(config, interface_name, route_name, route, renderer):  # 
     # permalink theme: recover the theme for generating custom viewer.js url
     config.add_route(
         "%stheme" % route_name,
-        "%s%stheme/*themes" % (route, "" if route[-1] == "/" else "/"),
+        "%s%stheme/{themes}" % (route, "" if route[-1] == "/" else "/"),
         request_method="GET",
     )
     config.add_view(


### PR DESCRIPTION
The previous pattern was matching all the end of the URL, which was too much. If an Angular partial was erronously using a prefix with 'theme' it bugged the browser in an infinite loop.