### PR TITLE
Docker: add alembic to the WSGI image

### DIFF
--- a/c2cgeoportal/scaffolds/create/+dot+dockerignore_tmpl
+++ b/c2cgeoportal/scaffolds/create/+dot+dockerignore_tmpl
@@ -3,10 +3,14 @@
 !.whiskey
 !{{package}}
 !{{package}}.egg-info
+!alembic.ini
+!alembic_static.ini
 !apache/application.wsgi
 !requirements.txt
+!CONST_alembic
 !CONST_requirements.txt
 !CONST_versions.txt
+!run_alembic.sh
 !setup.cfg
 !setup.py
 !development.ini

--- a/c2cgeoportal/scaffolds/create/alembic.ini.mako_tmpl
+++ b/c2cgeoportal/scaffolds/create/alembic.ini.mako_tmpl
@@ -20,6 +20,7 @@ script_location = CONST_alembic/main
 # versions/ directory
 # sourceless = false
 
+# overriden from the SQLALCHEMY_URL environment variable
 sqlalchemy.url = ${sqlalchemy["url"]}
 version_table = c2cgeoportal_version
 version_table_schema = ${schema}

--- a/c2cgeoportal/scaffolds/create/alembic_static.ini.mako_tmpl
+++ b/c2cgeoportal/scaffolds/create/alembic_static.ini.mako_tmpl
@@ -20,6 +20,7 @@ script_location = CONST_alembic/static
 # versions/ directory
 # sourceless = false
 
+# overriden from the SQLALCHEMY_URL environment variable
 sqlalchemy.url = ${sqlalchemy["url"]}
 version_table = c2cgeoportal_version
 version_table_schema = ${schema}_static

--- a/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -1214,11 +1214,11 @@ push_docker:
 .PHONY: testDB
 testDB: testDB/12-alembic.sql testDB/13-alembic-static.sql
 
-testDB/12-alembic.sql: $(VENV_BIN)/alembic$(PYTHON_BIN_POSTFIX) alembic.ini
+testDB/12-alembic.sql: $(VENV_BIN)/alembic$(PYTHON_BIN_POSTFIX) alembic.ini CONST_alembic/main/versions/*.py
 	$(PRERULE_CMD)
 	$(VENV_BIN)/alembic -c alembic.ini upgrade --sql head > $@
 
-testDB/13-alembic-static.sql: $(VENV_BIN)/alembic$(PYTHON_BIN_POSTFIX) alembic_static.ini
+testDB/13-alembic-static.sql: $(VENV_BIN)/alembic$(PYTHON_BIN_POSTFIX) alembic_static.ini CONST_alembic/static/versions/*.py
 	$(PRERULE_CMD)
 	$(VENV_BIN)/alembic -c alembic_static.ini upgrade --sql head > $@
 endif

--- a/c2cgeoportal/scaffolds/update/CONST_alembic/main/env.py
+++ b/c2cgeoportal/scaffolds/update/CONST_alembic/main/env.py
@@ -29,6 +29,7 @@ from __future__ import with_statement
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 from logging.config import fileConfig
+import os
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -37,6 +38,10 @@ config = context.config
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
 fileConfig(config.config_file_name)
+
+# Allow to define the DB URL from the environment
+if 'SQLALCHEMY_URL' in os.environ:  # pragma: nocover
+    config.set_main_option('sqlalchemy.url', os.environ['SQLALCHEMY_URL'])
 
 # add your model's MetaData object here
 # for 'autogenerate' support

--- a/c2cgeoportal/scaffolds/update/CONST_alembic/static/env.py
+++ b/c2cgeoportal/scaffolds/update/CONST_alembic/static/env.py
@@ -29,6 +29,7 @@ from __future__ import with_statement
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 from logging.config import fileConfig
+import os
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -37,6 +38,10 @@ config = context.config
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
 fileConfig(config.config_file_name)
+
+# Allow to define the DB URL from the environment
+if 'SQLALCHEMY_URL' in os.environ:  # pragma: nocover
+    config.set_main_option('sqlalchemy.url', os.environ['SQLALCHEMY_URL'])
 
 # add your model's MetaData object here
 # for 'autogenerate' support

--- a/c2cgeoportal/scaffolds/update/run_alembic.sh
+++ b/c2cgeoportal/scaffolds/update/run_alembic.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Upgrade the DB.
+#
+# Mostly useful in a Docker environment.
+
+set -e
+
+for ini in *alembic*.ini
+do
+    if [[ -f $ini ]]
+    then
+        echo "$ini ==========================="
+        alembic -c $ini upgrade head
+    fi
+done

--- a/doc/integrator/docker.rst
+++ b/doc/integrator/docker.rst
@@ -131,3 +131,25 @@ something like that:
 
     environment:
       DB_CONNECTION: user=www-data password=toto dbname=geoacordaDev host=db
+
+
+Keep your DB schema up to date
+------------------------------
+
+The WSGI image contains Alembic. You can use it as a start once container and
+add something like that in your composition:
+
+.. code:: yaml
+
+    alembic:
+      labels:
+        io.rancher.container.start_once: 'true'
+      image: company/prefix_wsgi:tag
+      environment:
+        SQLALCHEMY_URL: postgresql://postgres:${DB_PASSWORD}@db:5432/${DB_NAME}
+      links:
+        - db
+      command: ./run_alembic.sh
+
+When you do an upgrade, backup your DB and upgrade this container first. It will update your
+DB schema, if needed.


### PR DESCRIPTION
Now, the WSGI can be used as an Alembic container to upgrade the DB schema.

Fix the Makefile dependencies for Alembic generated SQL files.