### PR TITLE
Docker: better logging configurability

### DIFF
--- a/c2cgeoportal/scaffolds/create/apache/application.wsgi.mako
+++ b/c2cgeoportal/scaffolds/create/apache/application.wsgi.mako
@@ -1,15 +1,28 @@
 import site
 import sys
 import re
+import os
+from logging.config import fileConfig
 
+% if docker == 'TRUE':
+root = "/app"
+% else:
 site.addsitedir("${python_path}")
+root = "${directory}"
+% endif
+
 
 # Remove site packages
 regex = re.compile("^/usr/lib/python.\../dist-packages$")
 sys.path = [p for p in sys.path if regex.match(p) is None]
 
-from pyramid.paster import get_app, setup_logging
+from pyramid.paster import get_app
 
-configfile = "${directory}/${'development' if development == 'TRUE' else 'production'}.ini"
-setup_logging(configfile)
+configfile = os.path.join(root, "${'development' if development == 'TRUE' else 'production'}.ini")
+
+# Load the logging config without using pyramid to be able to use environment variables in there.
+vars = dict(__file__=configfile, here=os.path.dirname(configfile))
+vars.update(os.environ)
+fileConfig(configfile, defaults=vars)
+
 application = get_app(configfile, 'main')

--- a/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -448,6 +448,7 @@ CONFIG_VARS += sqlalchemy.url schema parentschema enable_admin_interface pyramid
 	reset_password fulltextsearch headers authorized_referers hooks stats db_chooser
 ENVIRONMENT_VARS += INSTANCE_ID=$(INSTANCE_ID) \
 	APACHE_ENTRY_POINT=$(APACHE_ENTRY_POINT) \
+	DOCKER=$(DOCKER) \
 	DOCKER_BASE=$(DOCKER_BASE) \
 	DEVELOPMENT=$(DEVELOPMENT) \
 	PACKAGE=$(PACKAGE)

--- a/c2cgeoportal/scaffolds/update/CONST_vars.yaml_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_vars.yaml_tmpl
@@ -14,6 +14,7 @@ vars:
     apache_entry_point: APACHE_ENTRY_POINT
     # Docker base image name (comes from the makefile).
     docker_base: DOCKER_BASE
+    docker: DOCKER
     # database user
     dbuser: www-data
     # database password
@@ -396,6 +397,7 @@ interpreted:
     environment:
     - instanceid
     - apache_entry_point
+    - docker
     - docker_base
     - development
     - wmtscapabilities_path

--- a/doc/integrator/docker.rst
+++ b/doc/integrator/docker.rst
@@ -120,6 +120,66 @@ Then, in your ``<package>/__init__.py`` file, add this function:
 By setting the ``SQLALCHEMY_URL`` environment variable in your composition
 for the wsgi image, you'll be able to change the DB connection used.
 
+You can change your ``production.ini`` and ``development.ini`` files to use
+environment variables for configuring the loggers. Here is an example for
+the part about the logging:
+
+.. code::
+
+    [loggers]
+    keys = root, sqlalchemy, c2cgeoportal
+
+    [handlers]
+    keys = console, logstash
+
+    [formatters]
+    keys = generic
+
+    [logger_root]
+    level = %(OTHER_LOG_LEVEL)s
+    handlers = %(LOG_TYPE)s
+
+    [logger_c2cgeoportal]
+    level = %(C2C_LOG_LEVEL)s
+    handlers =
+    qualname = c2cgeoportal
+
+    [logger_sqlalchemy]
+    level = %(SQL_LOG_LEVEL)s
+    handlers =
+    qualname = sqlalchemy.engine
+
+    [handler_console]
+    class = StreamHandler
+    args = (sys.stdout,)
+    level = NOTSET
+    formatter = generic
+
+    [formatter_generic]
+    format = %(levelname)-5.5s %(message)s
+
+    [handler_logstash]
+    class = cee_syslog_handler.CeeSysLogHandler
+    args = [("%(LOG_HOST)s", %(LOG_PORT)s)]
+    level = NOTSET
+
+Please note that to use
+``CeeSysLogHandler`` you need to add ``cee_syslog_handler>=0.3.3`` to your
+dependencies.
+
+Define default values for all those environment variables in your
+``Dockerfile`` and then you can change them in your composition. For example
+add the following at the end of your ``Dockerfile``:
+
+ .. code::
+
+    ENV LOG_TYPE console
+    ENV LOG_HOST localhost
+    ENV LOG_PORT 514
+    ENV C2C_LOG_LEVEL WARN
+    ENV SQL_LOG_LEVEL WARN
+    ENV OTHER_LOG_LEVEL WARN
+
 Mapserver
 .........
 


### PR DESCRIPTION
Add a way to configure the logging from the composition.

Fixed the production.ini file loading. I have a feeling it
was silently not working before.