### PR TITLE
Fix unicode theme error when logged in

### DIFF
--- a/c2cgeoportal/lib/__init__.py
+++ b/c2cgeoportal/lib/__init__.py
@@ -211,7 +211,14 @@ def add_spliturl_params(spliturl, params):
     query = []
     if spliturl.query != "":
         query.append(spliturl.query)
-    query.extend([urllib.urlencode(dict([param])) for param in params.items()])
+    prepared_params = []
+    for param in params.items():
+        if isinstance(param[1], unicode):
+            prepared_params.append({param[0], param[1].encode("utf-8")})
+        else:
+            prepared_params.append(param)
+
+    query.extend([urllib.urlencode(dict([param])) for param in prepared_params])
 
     return urlunsplit((
         spliturl.scheme, spliturl.netloc, spliturl.path,

--- a/c2cgeoportal/tests/test_init.py
+++ b/c2cgeoportal/tests/test_init.py
@@ -160,3 +160,11 @@ class TestHooks(TestCase):
 
     def test_bad_hook(self):
         self.assertRaises(AttributeError, call_hook, self.settings, "bad")
+
+
+class TestInit(TestCase):
+    def test_add_url_params(self):
+        from c2cgeoportal.lib import add_url_params
+        params = {"Name": "Bob", "Age": 18, "Nationality": u"Việt Nam"}
+        result = add_url_params("http://test/", params)
+        self.assertEqual(result, "http://test/?Nationality=Vi%E1%BB%87t+Nam&Age=18&Name=Bob")

--- a/c2cgeoportal/views/entry.py
+++ b/c2cgeoportal/views/entry.py
@@ -893,7 +893,7 @@ class Entry:
             # test if the theme is visible for the current user
             if len(children) > 0:
                 icon = get_url2(
-                    "The Theme '{}'".format(theme.name),
+                    u"The Theme '{}'".format(theme.name),
                     theme.icon, self.request, errors,
                 ) if theme.icon is not None and len(theme.icon) > 0 else self.request.static_url(
                     "c2cgeoportal:static/images/blank.gif"


### PR DESCRIPTION
Parameters like 'Détecteur de feu' need to be encoded before url escape.