### PR TITLE
Remove http URL for tx host on Windows

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -16,7 +16,6 @@ PYTHON_BIN_POSTFIX = .exe
 NODE_BIN_POSTFIX = .cmd
 FIND ?= $(CYGWIN_PATH)/bin/find.exe
 HOME_DIR ?= ""
-TX_HOST ?= http://www.transifex.com
 # TILECLOUD_CHAIN require Shapely but doesn't have a system specific setup.
 # You can still install it but you must install Shapely manualy inside
 # TILECLOUD_CHAIN virtualenv


### PR DESCRIPTION
See https://github.com/camptocamp/c2cgeoportal/issues/2188#issuecomment-216537865

This is actually also working via https on Windows....

But I think it is OK to keep the `TX_HOST` variable in `CONST_Makefile` so that the URL is only hard coded once (by defining the variable), thus not to completely revert https://github.com/camptocamp/c2cgeoportal/pull/2196

Please review and (eventually) merge