### PR TITLE
Disable geometry check per layer in 1.6

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_vars.yaml_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_vars.yaml_tmpl
@@ -130,6 +130,7 @@ vars:
         - copy_to
         - lastUpdateDateColumn
         - lastUpdateUserColumn
+        - geometry_validation
 
     # The list of functionalities that can be configured
     # through the admin interface.


### PR DESCRIPTION
Fix #2583

Added the `geometry_validation` UIMetadata to disable the check ST_IsValid and ST_IsSimple. Simply set it to False to disable it. Added tests and there's only one commit.