### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/c2cgeoportal/forms.py
+++ b/c2cgeoportal/forms.py
@@ -96,7 +96,7 @@ def get_fanstatic_resources(request):  # pragma: no cover
     olimgpath = request.static_url("c2cgeoportal:static/lib/openlayers/img/")
 
     def olimgpath_renderer(url):
-        return '<script>OpenLayers.ImgPath="%s";</script>' % olimgpath
+        return '<script>OpenLayers.ImgPath="{0!s}";</script>'.format(olimgpath)
     if olimgpath_js is None:
         olimgpath_js = Resource(
             fanstatic_lib,
@@ -218,12 +218,12 @@ class CheckBoxTreeSet(CheckBoxSet):  # pragma: no cover
                 'descendants': false,
                 'ancestors': false }"""
         result = """<script lang="text/javascript" >
-            $(document).ready(function(){
-                $("#%(id)s").checkboxTree({%(opt)s});
-            });
+            $(document).ready(function(){{
+                $("#{id!s}").checkboxTree({{{opt!s}}});
+            }});
         </script>
-        <ul id="%(id)s" class="checkboxtree">
-        """ % {"id": self.dom_id, "opt": opt}
+        <ul id="{id!s}" class="checkboxtree">
+        """.format(**{"id": self.dom_id, "opt": opt})
         result += self.render_tree()
         result += "</ul>"
         return result
@@ -258,9 +258,9 @@ class SimpleLayerCheckBoxTreeSet(CheckBoxTreeSet):  # pragma: no cover
         result = "<li>"
         if self.auto_check:
             result += '<input type="checkbox"></input>'
-        result += "<label>%(label)s</label>" % {
+        result += "<label>{label!s}</label>".format(**{
             "label": item.name,
-        }
+        })
         result += self.render_children(item, depth)
         result += "</li>"
         return result
@@ -298,10 +298,10 @@ class SimpleLayerCheckBoxTreeSet(CheckBoxTreeSet):  # pragma: no cover
 
         result = """
         <li>
-            <input type="checkbox" id="%(id)s" name="%(name)s" value="%(value)s"%(add)s></input>
-            <label>%(type)s%(label)s</label>
-            """ % {
-            "id": "%s_%i" % (self.name, self.i),
+            <input type="checkbox" id="{id!s}" name="{name!s}" value="{value!s}"{add!s}></input>
+            <label>{type!s}{label!s}</label>
+            """.format(**{
+            "id": "{0!s}_{1:d}".format(self.name, self.i),
             # adds -second to fields (layer) that appears two time to
             # don"t save them twice (=> integrity error).
             "name": self.name + ("-second" if final_item.id in self._rendered_id else ""),
@@ -309,7 +309,7 @@ class SimpleLayerCheckBoxTreeSet(CheckBoxTreeSet):  # pragma: no cover
             "add": ' checked="checked"' if self.is_checked(item, final_item) else "",
             "type": prefixs.get(final_item.item_type, ""),
             "label": final_item.name,
-        }
+        })
         self._rendered_id.append(final_item.id)
         self.i += 1
         result += self.render_children(final_item, depth)
@@ -333,7 +333,7 @@ class SimpleLayerCheckBoxTreeSet(CheckBoxTreeSet):  # pragma: no cover
             result += "<li>"
             if self.auto_check:
                 result += '<input type="checkbox"></input>'
-            result += "<label>%(name)s</label>" % {"name": _("Unlinked layers")}
+            result += "<label>{name!s}</label>".format(**{"name": _("Unlinked layers")})
             result += "<ul>"
 
             while len(self.layer_group) > 0:
@@ -385,7 +385,7 @@ class FunctionalityCheckBoxTreeSet(CheckBoxTreeSet):  # pragma: no cover
             result += \
                 '<li><input type="checkbox" id="%s" name="%s" value="%i"%s>' \
                 '</input><label>%s</label></li>\n' % (
-                    "%s_%i" % (self.name, i),
+                    "{0!s}_{1:d}".format(self.name, i),
                     self.name,
                     functionality.id,
                     ' checked="checked"' if self._is_checked(functionality.id) else "",

--- a/c2cgeoportal/lib/__init__.py
+++ b/c2cgeoportal/lib/__init__.py
@@ -74,10 +74,10 @@ def get_url(url, request, default=None, errors=None):
         server = request.registry.settings.get("servers", {}).get(obj.netloc)
         if server is None:
             if default is None and errors is not None:
-                errors.add("The server '%s' isn't found in the config" % obj.netloc)
+                errors.add("The server '{0!s}' isn't found in the config".format(obj.netloc))
             return default
         else:
-            return "%s%s?%s" % (server, obj.path, obj.query)
+            return "{0!s}{1!s}?{2!s}".format(server, obj.path, obj.query)
 
     else:
         return url
@@ -347,7 +347,7 @@ class MultiDomainStaticURLInfo(StaticURLInfo):  # pragma: no cover
                 else:
                     subpath = quote(subpath)
                     return urljoin(url, subpath[1:])
-        raise ValueError("No static URL definition matching %s" % path)
+        raise ValueError("No static URL definition matching {0!s}".format(path))
 
     def add(self, config, name, spec, **extra):
         if "pregenerator" not in extra:

--- a/c2cgeoportal/lib/bashcolor.py
+++ b/c2cgeoportal/lib/bashcolor.py
@@ -39,4 +39,4 @@ WHITE = 7
 
 
 def colorize(text, color):   # pragma: no cover
-    return "\x1b[01;3%im%s\x1b[0m" % (color, text)
+    return "\x1b[01;3{0:d}m{1!s}\x1b[0m".format(color, text)

--- a/c2cgeoportal/lib/caching.py
+++ b/c2cgeoportal/lib/caching.py
@@ -48,9 +48,9 @@ def keygen_function(namespace, fn):
     """
 
     if namespace is None:
-        namespace = "%s:%s" % (fn.__module__, fn.__name__)
+        namespace = "{0!s}:{1!s}".format(fn.__module__, fn.__name__)
     else:  # pragma: no cover
-        namespace = "%s:%s|%s" % (fn.__module__, fn.__name__, namespace)
+        namespace = "{0!s}:{1!s}|{2!s}".format(fn.__module__, fn.__name__, namespace)
 
     args = inspect.getargspec(fn)
     has_self = args[0] and args[0][0] in ("self", "cls")

--- a/c2cgeoportal/lib/filter_capabilities.py
+++ b/c2cgeoportal/lib/filter_capabilities.py
@@ -80,7 +80,7 @@ def _wms_structure(wms_url, host):
         "REQUEST": "GetCapabilities",
     })
 
-    log.info("Get WMS GetCapabilities for URL: %s" % wms_url)
+    log.info("Get WMS GetCapabilities for URL: {0!s}".format(wms_url))
 
     # forward request to target (without Host Header)
     http = httplib2.Http()
@@ -90,12 +90,11 @@ def _wms_structure(wms_url, host):
     try:
         resp, content = http.request(wms_url, method="GET", headers=headers)
     except:  # pragma: no cover
-        raise HTTPBadGateway("Unable to GetCapabilities from wms_url %s" % wms_url)
+        raise HTTPBadGateway("Unable to GetCapabilities from wms_url {0!s}".format(wms_url))
 
     if resp.status < 200 or resp.status >= 300:  # pragma: no cover
         raise HTTPBadGateway(
-            "GetCapabilities from wms_url %s return the error: %i %s" %
-            (wms_url, resp.status, resp.reason)
+            "GetCapabilities from wms_url {0!s} return the error: {1:d} {2!s}".format(wms_url, resp.status, resp.reason)
         )
 
     try:
@@ -117,7 +116,7 @@ def _wms_structure(wms_url, host):
     except AttributeError:  # pragma: no cover
         error = "WARNING! an error occured while trying to " \
             "read the mapfile and recover the themes."
-        error = "%s\nurl: %s\nxml:\n%s" % (error, wms_url, content)
+        error = "{0!s}\nurl: {1!s}\nxml:\n{2!s}".format(error, wms_url, content)
         log.exception(error)
         raise HTTPBadGateway(error)
 

--- a/c2cgeoportal/lib/lingua_extractor.py
+++ b/c2cgeoportal/lib/lingua_extractor.py
@@ -161,7 +161,7 @@ class GeoMapfishConfigExtractor(Extractor):  # pragma: no cover
                 return [
                     Message(
                         None, raster_layer, None, [], u"", u"",
-                        (filename, u"raster/%s" % raster_layer)
+                        (filename, u"raster/{0!s}".format(raster_layer))
                     )
                     for raster_layer in config["vars"].get("raster", {}).keys()
                 ]
@@ -171,12 +171,12 @@ class GeoMapfishConfigExtractor(Extractor):  # pragma: no cover
                 for template_ in config.get("templates").keys():
                     result.append(Message(
                         None, template_, None, [], u"", u"",
-                        (filename, u"template/%s" % template_)
+                        (filename, u"template/{0!s}".format(template_))
                     ))
                     result += [
                         Message(
                             None, attribute, None, [], u"", u"",
-                            (filename, u"template/%s/%s" % (template_, attribute))
+                            (filename, u"template/{0!s}/{1!s}".format(template_, attribute))
                         )
                         for attribute in config.get("templates")[template_].attributes.keys()
                     ]
@@ -318,7 +318,7 @@ class GeoMapfishThemeExtractor(Extractor):  # pragma: no cover
         })
 
         if url not in self.featuretype_cache:
-            print("Get DescribeFeatureType for url: %s" % url)
+            print("Get DescribeFeatureType for url: {0!s}".format(url))
             self.featuretype_cache[url] = None
 
             # forward request to target (without Host Header)
@@ -329,14 +329,13 @@ class GeoMapfishThemeExtractor(Extractor):  # pragma: no cover
             try:
                 resp, content = http.request(url, method="GET", headers=h)
             except:  # pragma: no cover
-                print("Unable to DescribeFeatureType from URL %s" % url)
+                print("Unable to DescribeFeatureType from URL {0!s}".format(url))
                 self.featuretype_cache[url] = None
                 return []
 
             if resp.status < 200 or resp.status >= 300:  # pragma: no cover
                 print(
-                    "DescribeFeatureType from URL %s return the error: %i %s" %
-                    (url, resp.status, resp.reason)
+                    "DescribeFeatureType from URL {0!s} return the error: {1:d} {2!s}".format(url, resp.status, resp.reason)
                 )
                 self.featuretype_cache[url] = None
                 return []
@@ -349,7 +348,7 @@ class GeoMapfishThemeExtractor(Extractor):  # pragma: no cover
                     "WARNING! an error occured while trying to "
                     "read the Mapfile and recover the themes."
                 )
-                print("URL: %s\nxml:\n%s" % (url, content))
+                print("URL: {0!s}\nxml:\n{1!s}".format(url, content))
         else:
             describe = self.featuretype_cache[url]
 
@@ -361,7 +360,7 @@ class GeoMapfishThemeExtractor(Extractor):  # pragma: no cover
         for type_element in describe.getElementsByTagNameNS(
             "http://www.w3.org/2001/XMLSchema", "complexType"
         ):
-            if type_element.getAttribute("name") == "%sType" % layer:
+            if type_element.getAttribute("name") == "{0!s}Type".format(layer):
                 for element in type_element.getElementsByTagNameNS(
                     "http://www.w3.org/2001/XMLSchema", "element"
                 ):

--- a/c2cgeoportal/lib/raster/dbfutils.py
+++ b/c2cgeoportal/lib/raster/dbfutils.py
@@ -65,7 +65,7 @@ def dbfreader(f):
     assert terminator == "\r"
 
     fields.insert(0, ("DeletionFlag", "C", 1, 0))
-    fmt = "".join(["%ds" % fieldinfo[2] for fieldinfo in fields])
+    fmt = "".join(["{0:d}s".format(fieldinfo[2]) for fieldinfo in fields])
     fmtsiz = struct.calcsize(fmt)
     for i in xrange(numrec):
         record = struct.unpack(fmt, f.read(fmtsiz))

--- a/c2cgeoportal/lib/raster/georaster.py
+++ b/c2cgeoportal/lib/raster/georaster.py
@@ -45,7 +45,7 @@ class Tile:
         return self.min_x <= x and self.max_x > x and self.min_y <= y and self.max_y > y
 
     def __str__(self):
-        return "%f, %f, %f, %f: %s" % (
+        return "{0:f}, {1:f}, {2:f}, {3:f}: {4!s}".format(
             self.min_x, self.min_y, self.max_x, self.max_y, self.filename
         )
 

--- a/c2cgeoportal/lib/wmstparsing.py
+++ b/c2cgeoportal/lib/wmstparsing.py
@@ -74,8 +74,7 @@ class TimeInformation:
             if self.mode is not None:
                 if self.mode != mode:
                     raise ValueError(
-                        "Could not mix time mode '%s' and '%s'"
-                        % (mode, self.mode)
+                        "Could not mix time mode '{0!s}' and '{1!s}'".format(mode, self.mode)
                     )
             else:
                 self.mode = mode
@@ -86,8 +85,7 @@ class TimeInformation:
         if self.widget is not None:
             if self.widget != widget:
                 raise ValueError(
-                    "Could not mix time widget '%s' and '%s'"
-                    % (widget, self.widget)
+                    "Could not mix time widget '{0!s}' and '{1!s}'".format(widget, self.widget)
                 )
         else:
             self.widget = widget
@@ -220,8 +218,7 @@ def parse_extent(extent, default_values):
             # case "start/end/interval"
             if len(extent) > 1 or extent[0].count("/") != 2:
                 raise ValueError(
-                    "Unsupported time definition '%s'"
-                    % extent)
+                    "Unsupported time definition '{0!s}'".format(extent))
             s, e, i = extent[0].split("/")
             start = _parse_date(s)
             end = _parse_date(e)
@@ -290,7 +287,7 @@ def _parse_date(date):
             dt = dt.replace(tzinfo=isodate.UTC)
         return "second", dt
     except:
-        raise ValueError("Invalid date format '%s'" % date)
+        raise ValueError("Invalid date format '{0!s}'".format(date))
 
 
 def _format_date(date):

--- a/c2cgeoportal/models.py
+++ b/c2cgeoportal/models.py
@@ -171,7 +171,7 @@ class Functionality(Base):
         self.description = description
 
     def __unicode__(self):
-        return u"%s - %s" % (self.name or u"", self.value or u"")  # pragma: no cover
+        return u"{0!s} - {1!s}".format(self.name or u"", self.value or u"")  # pragma: no cover
 
 
 event.listen(Functionality, "after_update", cache_invalidate_cb)
@@ -979,7 +979,7 @@ class Metadata(Base):
         self.value = value
 
     def __unicode__(self):  # pragma: no cover
-        return u"%s: %s" % (self.name or u"", self.value or u"")
+        return u"{0!s}: {1!s}".format(self.name or u"", self.value or u"")
 
 
 event.listen(Metadata, "after_insert", cache_invalidate_cb, propagate=True)
@@ -1068,7 +1068,7 @@ def db_chooser_tween_factory(handler, registry):  # pragma: nocover
     def db_chooser_tween(request):
         session = DBSession()
         old = session.bind
-        method_path = "%s %s" % (request.method, request.path)
+        method_path = "{0!s} {1!s}".format(request.method, request.path)
         force_master = any(r.match(method_path) for r in master_paths)
         if not force_master and (request.method in ("GET", "OPTIONS") or
                                  any(r.match(method_path) for r in slave_paths)):

--- a/c2cgeoportal/pyramid_.py
+++ b/c2cgeoportal/pyramid_.py
@@ -73,10 +73,10 @@ class DecimalJSON:
                     request.response.content_type = "application/json"
                 else:
                     request.response.content_type = "text/javascript"
-                    ret = "%(callback)s(%(json)s);" % {
+                    ret = "{callback!s}({json!s});".format(**{
                         "callback": callback,
                         "json": ret
-                    }
+                    })
             return ret
         return _render
 
@@ -94,19 +94,19 @@ def add_interface(
             config,
             interface_name=interface_name,
             route_names=(interface_name, interface_name + ".js"),
-            routes=("/%s" % interface_name, "/%s.js" % interface_name),
-            renderers=("/%s.html" % interface_name, "/%s.js" % interface_name),
+            routes=("/{0!s}".format(interface_name), "/{0!s}.js".format(interface_name)),
+            renderers=("/{0!s}.html".format(interface_name), "/{0!s}.js".format(interface_name)),
         )
 
     elif interface_type == INTERFACE_TYPE_NGEO:
-        route = "/%s" % interface_name
+        route = "/{0!s}".format(interface_name)
 
         add_interface_ngeo(
             config,
             interface_name=interface_name,
             route_name=interface_name,
             route=route,
-            renderer="/%s.html" % interface_name,
+            renderer="/{0!s}.html".format(interface_name),
         )
 
 
@@ -130,14 +130,14 @@ def add_interface_cgxp(config, interface_name, route_names, routes, renderers): 
     )
     # permalink theme: recover the theme for generating custom viewer.js url
     config.add_route(
-        "%stheme" % route_names[0],
-        "%s%stheme/{themes}" % (routes[0], "" if routes[0][-1] == "/" else "/"),
+        "{0!s}theme".format(route_names[0]),
+        "{0!s}{1!s}theme/{{themes}}".format(routes[0], "" if routes[0][-1] == "/" else "/"),
     )
     config.add_view(
         Entry,
         decorator=add_interface,
         attr="get_cgxp_permalinktheme_vars",
-        route_name="%stheme" % route_names[0],
+        route_name="{0!s}theme".format(route_names[0]),
         renderer=renderers[0]
     )
     config.add_route(
@@ -177,15 +177,15 @@ def add_interface_ngeo(config, interface_name, route_name, route, renderer):  # 
     )
     # permalink theme: recover the theme for generating custom viewer.js url
     config.add_route(
-        "%stheme" % route_name,
-        "%s%stheme/{themes}" % (route, "" if route[-1] == "/" else "/"),
+        "{0!s}theme".format(route_name),
+        "{0!s}{1!s}theme/{{themes}}".format(route, "" if route[-1] == "/" else "/"),
         request_method="GET",
     )
     config.add_view(
         Entry,
         decorator=add_interface,
         attr="get_ngeo_permalinktheme_vars",
-        route_name="%stheme" % route_name,
+        route_name="{0!s}theme".format(route_name),
         renderer=renderer
     )
 
@@ -198,14 +198,14 @@ def add_interface_ngeo(config, interface_name, route_name, route, renderer):  # 
 def add_static_view_ngeo(config):  # pragma: no cover
     """ Add the project static view for ngeo """
     package = config.get_settings()["package"]
-    _add_static_view(config, "static-ngeo", "%s:static-ngeo" % package)
+    _add_static_view(config, "static-ngeo", "{0!s}:static-ngeo".format(package))
     config.override_asset(
         to_override="c2cgeoportal:project/",
-        override_with="%s:static-ngeo/" % package
+        override_with="{0!s}:static-ngeo/".format(package)
     )
     config.add_static_view(
         name=package,
-        path="%s:static" % package,
+        path="{0!s}:static".format(package),
         cache_max_age=int(config.get_settings()["default_max_age"])
     )
 
@@ -228,10 +228,10 @@ def add_admin_interface(config):
 def add_static_view(config):
     """ Add the project static view for CGXP """
     package = config.get_settings()["package"]
-    _add_static_view(config, "static-cgxp", "%s:static" % package)
+    _add_static_view(config, "static-cgxp", "{0!s}:static".format(package))
     config.override_asset(
         to_override="c2cgeoportal:project/",
-        override_with="%s:static/" % package
+        override_with="{0!s}:static/".format(package)
     )
 
 
@@ -360,7 +360,7 @@ class OgcproxyRoutePredicate:
         try:
             ip = IP(gethostbyname(parts.netloc))
         except gaierror as e:
-            log.info("Unable to get host name for %s: %s" % (url, e))
+            log.info("Unable to get host name for {0!s}: {1!s}".format(url, e))
             return False
         for net in self.private_networks:
             if ip in net:

--- a/c2cgeoportal/scaffolds/update/CONST_alembic/main/versions/5109242131ce_add_column_time_widget.py
+++ b/c2cgeoportal/scaffolds/update/CONST_alembic/main/versions/5109242131ce_add_column_time_widget.py
@@ -49,9 +49,9 @@ def upgrade():
     # Instructions
     for table in ['layerv1', 'layer_internal_wms', 'layer_external_wms']:
         op.add_column(table, Column('time_widget', Unicode(10), default=u'slider'), schema=schema)
-        op.execute("UPDATE %(schema)s.%(table)s SET time_widget = 'slider'" % {
+        op.execute("UPDATE {schema!s}.{table!s} SET time_widget = 'slider'".format(**{
             'schema': schema, 'table': table
-        })
+        }))
 
 
 def downgrade():

--- a/c2cgeoportal/scaffolds/update/CONST_alembic/static/versions/1da396a88908_move_user_table_to_static_schema.py
+++ b/c2cgeoportal/scaffolds/update/CONST_alembic/static/versions/1da396a88908_move_user_table_to_static_schema.py
@@ -77,9 +77,9 @@ def upgrade():
         parent_column = ', parent_role_name'
         parent_select = ', pr.name'
         parent_join = (
-            'LEFT OUTER JOIN %(parentschema)s.role AS pr ON (pr.id = u.parent_role_id)' % {
+            'LEFT OUTER JOIN {parentschema!s}.role AS pr ON (pr.id = u.parent_role_id)'.format(**{
                 'parentschema': parentschema,
-            }
+            })
         )
 
     op.execute(
@@ -129,9 +129,9 @@ def downgrade():
         parent_column = ', parent_role_id'
         parent_select = ', pr.id'
         parent_join = (
-            'LEFT OUTER JOIN %(parentschema)s.role AS pr ON (pr.name = u.parent_role_name)' % {
+            'LEFT OUTER JOIN {parentschema!s}.role AS pr ON (pr.name = u.parent_role_name)'.format(**{
                 'parentschema': parentschema,
-            }
+            })
         )
 
     op.execute(

--- a/c2cgeoportal/scaffolds/update/CONST_alembic/static/versions/3f89a7d71a5e_alter_column_url_to_remove_limitation.py
+++ b/c2cgeoportal/scaffolds/update/CONST_alembic/static/versions/3f89a7d71a5e_alter_column_url_to_remove_limitation.py
@@ -44,7 +44,7 @@ down_revision = None
 
 
 def upgrade():
-    schema = '%s_static' % context.get_context().config.get_main_option('schema')
+    schema = '{0!s}_static'.format(context.get_context().config.get_main_option('schema'))
     op.alter_column('shorturl', 'url', type_=types.Unicode, schema=schema)
 
 

--- a/c2cgeoportal/scripts/c2ctool.py
+++ b/c2cgeoportal/scripts/c2ctool.py
@@ -103,7 +103,7 @@ To have some help on a command type:
 
 
 def _fill_arguments(command):
-    parser = ArgumentParser(prog="%s %s" % (sys.argv[0], command), add_help=False)
+    parser = ArgumentParser(prog="{0!s} {1!s}".format(sys.argv[0], command), add_help=False)
     parser.add_argument(
         "--no-cleanall",
         help="Run clean instead of cleanall",
@@ -185,7 +185,7 @@ class C2cTool:
         http = httplib2.Http()
         for check_type in ("", "type=all"):
             resp, content = http.request(
-                "http://localhost%s%s" % (self.project["checker_path"], check_type),
+                "http://localhost{0!s}{1!s}".format(self.project["checker_path"], check_type),
                 method="GET",
                 headers={
                     "Host": self.project["host"]
@@ -194,7 +194,7 @@ class C2cTool:
             if resp.status < 200 or resp.status >= 300:
                 print(self.color_bar)
                 print("Checker error:")
-                print("Open `http://%s%s%s` for more informations." % (
+                print("Open `http://{0!s}{1!s}{2!s}` for more informations.".format(
                     self.project["host"], self.project["checker_path"], check_type
                 ))
                 return False
@@ -273,7 +273,7 @@ class C2cTool:
             print("")
             print(self.color_bar)
             print("Your project isn't in the right folder!")
-            print("It should be in folder '%s' instead of folder '%s'." % (
+            print("It should be in folder '{0!s}' instead of folder '{1!s}'.".format(
                 self.project["project_folder"], os.path.split(os.path.realpath("."))[1]
             ))
             print("")
@@ -308,7 +308,7 @@ class C2cTool:
         # remove all no more existing branches
         check_call(["git", "fetch", "origin", "--prune"])
         branches = check_output(["git", "branch", "--all"]).split("\n")
-        if "  remotes/origin/%s" % branch in branches:
+        if "  remotes/origin/{0!s}".format(branch) in branches:
             try:
                 check_call(["git", "pull", "--rebase", self.options.git_remote, branch])
             except CalledProcessError:
@@ -337,17 +337,17 @@ class C2cTool:
 
         if not self.options.windows:
             check_call(["make", "-f", self.options.file, ".build/requirements.timestamp"])
-            pip_cmd = ["%s/pip" % self.venv_bin, "install"]
+            pip_cmd = ["{0!s}/pip".format(self.venv_bin), "install"]
             if self.options.version == "master":
-                check_call(["%s/pip" % self.venv_bin, "uninstall", "--yes", "c2cgeoportal"])
+                check_call(["{0!s}/pip".format(self.venv_bin), "uninstall", "--yes", "c2cgeoportal"])
                 pip_cmd += ["--pre", "c2cgeoportal"]
             else:
-                pip_cmd += ["c2cgeoportal==%s" % (self.options.version)]
+                pip_cmd += ["c2cgeoportal=={0!s}".format((self.options.version))]
             check_call(pip_cmd)
 
         check_call([
-            "%s/pcreate" % self.venv_bin, "--ignore-conflicting-name", "--overwrite",
-            "--scaffold=c2cgeoportal_update", "../%s" % self.project["project_folder"]
+            "{0!s}/pcreate".format(self.venv_bin), "--ignore-conflicting-name", "--overwrite",
+            "--scaffold=c2cgeoportal_update", "../{0!s}".format(self.project["project_folder"])
         ])
         check_call(["make", "-f", self.options.file, self.options.clean])
 
@@ -494,7 +494,7 @@ class C2cTool:
         print(colorize("Congratulations your upgrade is a success.", GREEN))
         print("")
         branch = check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"]).strip()
-        print("Now all your files will be commited, you should do a git push %s %s." % (
+        print("Now all your files will be commited, you should do a git push {0!s} {1!s}.".format(
             self.options.git_remote, branch
         ))
 

--- a/c2cgeoportal/scripts/gen_version.py
+++ b/c2cgeoportal/scripts/gen_version.py
@@ -52,7 +52,7 @@ def _get_versions():
 def main():
     print "INFO = {"
     for key, value in _get_versions().iteritems():
-        print "    \"%s\": \"%s\"," % (key, str(value).replace("\\", "\\\\").replace("\"", "\\\""))
+        print "    \"{0!s}\": \"{1!s}\",".format(key, str(value).replace("\\", "\\\\").replace("\"", "\\\""))
     print "}"
 
 

--- a/c2cgeoportal/scripts/import_ngeo_apps.py
+++ b/c2cgeoportal/scripts/import_ngeo_apps.py
@@ -73,8 +73,8 @@ class _RouteDest:
         query_string = matches.group(1)
         query = ''
         if len(query_string) > 0:
-            query = ", _query=%s" % dumps(dict(parse_qsl(query_string)))
-        return r"module.constant('%s', '${request.route_url('%s'%s) | n}');" % (
+            query = ", _query={0!s}".format(dumps(dict(parse_qsl(query_string))))
+        return r"module.constant('{0!s}', '${{request.route_url('{1!s}'{2!s}) | n}}');".format(
             self.constant, self.route, query
         )
 

--- a/c2cgeoportal/scripts/l10nv1tov2.py
+++ b/c2cgeoportal/scripts/l10nv1tov2.py
@@ -81,17 +81,17 @@ and build your application to merge the old localisation with the new one.
     with open(options.po_v2, "w+") as destionation:
         destionation.write("""msgid ""
 msgstr ""
-"Last-Translator: Imported from %s\\n"
-"Language: %s\\n"
+"Last-Translator: Imported from {0!s}\\n"
+"Language: {1!s}\\n"
 "MIME-Version: 1.0\\n"
 "Content-Type: text/plain; charset=UTF-8\\n"
 "Content-Transfer-Encoding: 8bit\\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\\n"
-""" % (options.json_v1, options.lang))
+""".format(options.json_v1, options.lang))
         for key, value in source.items():
             if isinstance(value, basestring):
                 destionation.write(("""
-msgid "%s"
-msgstr "%s"
-""" % (key, value.replace('"', '\\"'))).encode("utf-8"),
+msgid "{0!s}"
+msgstr "{1!s}"
+""".format(key, value.replace('"', '\\"'))).encode("utf-8"),
                 )

--- a/c2cgeoportal/scripts/manage_users.py
+++ b/c2cgeoportal/scripts/manage_users.py
@@ -100,7 +100,7 @@ User can be created if it doesn't exist yet."""
     if app_name is None and "#" in app_config:
         app_config, app_name = app_config.split("#", 1)
     if not os.path.isfile(app_config):
-        parser.error("Can't find config file: %s" % app_config)
+        parser.error("Can't find config file: {0!s}".format(app_config))
 
     # loading schema name from config and setting its value to the
     # corresponding global variable from c2cgeoportal
@@ -121,19 +121,19 @@ User can be created if it doesn't exist yet."""
         try:
             getattr(models, model)
         except AttributeError:
-            print("models.%s not found" % model)
+            print("models.{0!s} not found".format(model))
 
     # check that user exists
     sess = models.DBSession()
-    query = sess.query(models.User).filter_by(username=u"%s" % username)
+    query = sess.query(models.User).filter_by(username=u"{0!s}".format(username))
 
     result = query.count()
     if result == 0:
         if not options.create:
             # if doesn"t exist and no -c option, throw error
-            raise Exception("User %s doesn't exist in database" % username)
+            raise Exception("User {0!s} doesn't exist in database".format(username))
         else:
-            print("User %s doesn't exist in database, creating" % username)
+            print("User {0!s} doesn't exist in database, creating".format(username))
             # if doesn't exist and -c option, create user
 
             password = options.password if options.password is not None else username
@@ -141,28 +141,27 @@ User can be created if it doesn't exist yet."""
 
             # get roles
             query_role = sess.query(models.Role).filter(
-                models.Role.name == u"%s" % options.rolename)
+                models.Role.name == u"{0!s}".format(options.rolename))
 
             if query_role.count() == 0:
                 # role not found in db?
                 raise Exception(
-                    "Role matching %s doesn't exist in database" %
-                    options.rolename)
+                    "Role matching {0!s} doesn't exist in database".format(
+                    options.rolename))
 
             role = query_role.first()
 
             user = models.User(
-                username=u"%s" % username,
-                password=u"%s" % password,
-                email=u"%s" % email,
+                username=u"{0!s}".format(username),
+                password=u"{0!s}".format(password),
+                email=u"{0!s}".format(email),
                 role=role
             )
             sess.add(user)
             transaction.commit()
 
             print(
-                "User %s created with password %s and role %s" %
-                (username, password, options.rolename)
+                "User {0!s} created with password {1!s} and role {2!s}".format(username, password, options.rolename)
             )
 
     else:
@@ -170,8 +169,8 @@ User can be created if it doesn't exist yet."""
         user = query.first()
 
         if options.password is not None:
-            print("Password set to: %s" % options.password)
-            user.password = u"%s" % options.password
+            print("Password set to: {0!s}".format(options.password))
+            user.password = u"{0!s}".format(options.password)
 
         if options.email is not None:
             user.email = options.email
@@ -179,7 +178,7 @@ User can be created if it doesn't exist yet."""
         sess.add(user)
         transaction.commit()
 
-        print("Password resetted for user %s" % username)
+        print("Password resetted for user {0!s}".format(username))
 
 
 if __name__ == "__main__":

--- a/c2cgeoportal/scripts/themev1tov2.py
+++ b/c2cgeoportal/scripts/themev1tov2.py
@@ -88,7 +88,7 @@ def main():
     if options.layers:
         table_list = [LayerWMTS, LayerWMS, OGCServer]
         for table in table_list:
-            print("Emptying table %s." % str(table.__table__))
+            print("Emptying table {0!s}.".format(str(table.__table__)))
             # must be done exactly this way othewise the cascade config in the
             # models are not used
             for t in session.query(table).all():

--- a/c2cgeoportal/stats.py
+++ b/c2cgeoportal/stats.py
@@ -139,7 +139,7 @@ class _StatsDBackend:  # pragma: no cover
 
     def timer(self, key, duration):
         the_key = self._key(key)
-        message = "%s:%s|ms" % (the_key, int(round(duration * 1000.0)))
+        message = "{0!s}:{1!s}|ms".format(the_key, int(round(duration * 1000.0)))
         try:
             self._socket.send(message)
         except:

--- a/c2cgeoportal/tests/functional/__init__.py
+++ b/c2cgeoportal/tests/functional/__init__.py
@@ -58,7 +58,7 @@ if os.path.exists(configfile):
         os.path.dirname(os.path.abspath(__file__)),
         "c2cgeoportal_test.map"
     )
-    mapserv = "%s?map=%s&" % (mapserv_url, mapfile)
+    mapserv = "{0!s}?map={1!s}&".format(mapserv_url, mapfile)
 
 caching.init_region({"backend": "dogpile.cache.memory"})
 

--- a/c2cgeoportal/tests/functional/test_dbreflection.py
+++ b/c2cgeoportal/tests/functional/test_dbreflection.py
@@ -83,7 +83,7 @@ class TestReflection(TestCase):
             self._tables = []
 
         ctable = Table(
-            "%s_child" % tablename, Base.metadata,
+            "{0!s}_child".format(tablename), Base.metadata,
             Column("id", types.Integer, primary_key=True),
             Column("name", types.Unicode),
             schema="public"
@@ -96,11 +96,11 @@ class TestReflection(TestCase):
             Column("id", types.Integer, primary_key=True),
             Column(
                 "child1_id", types.Integer,
-                ForeignKey("public.%s_child.id" % tablename)
+                ForeignKey("public.{0!s}_child.id".format(tablename))
             ),
             Column(
                 "child2_id", types.Integer,
-                ForeignKey("public.%s_child.id" % tablename)
+                ForeignKey("public.{0!s}_child.id".format(tablename))
             ),
             Column("point", Geometry("POINT", management=management)),
             Column("linestring", Geometry("LINESTRING", management=management)),

--- a/c2cgeoportal/tests/functional/test_entry.py
+++ b/c2cgeoportal/tests/functional/test_entry.py
@@ -683,7 +683,7 @@ class TestEntryView(TestCase):
         ]))
         self.assertEquals(
             result["queryer_attribute_urls"],
-            '{"layer_test": {"label": "%s"}}' % mapserv_url
+            '{{"layer_test": {{"label": "{0!s}"}}}}'.format(mapserv_url)
         )
 
         result = entry.get_ngeo_index_vars()
@@ -1134,7 +1134,7 @@ class TestEntryView(TestCase):
             ("VERSION", "1.1.1"),
             ("REQUEST", "GetCapabilities"),
         )
-        mapserv = "%s?map=%s&" % (mapserv_url, mapfile)
+        mapserv = "{0!s}?map={1!s}&".format(mapserv_url, mapfile)
         url = mapserv + "&".join(["=".join(p) for p in params])
         http = httplib2.Http()
         h = {"Host": host}
@@ -1387,7 +1387,7 @@ class TestEntryView(TestCase):
         self.assertIn(error, errors)
         self.assertEquals(
             len([e for e in errors if e == error]), 1,
-            "Error '%s' more than one time in errors:\n%r" % (error, errors),
+            "Error '{0!s}' more than one time in errors:\n{1!r}".format(error, errors),
         )
 
     def test_internalwms(self):

--- a/c2cgeoportal/tests/functional/test_layers.py
+++ b/c2cgeoportal/tests/functional/test_layers.py
@@ -129,10 +129,10 @@ class TestLayers(TestCase):
         if not self.metadata:
             self.metadata = declarative_base(bind=engine).metadata
 
-        tablename = "table_%d" % id
+        tablename = "table_{0:d}".format(id)
 
         table1 = Table(
-            "%s_child" % tablename, self.metadata,
+            "{0!s}_child".format(tablename), self.metadata,
             Column("id", types.Integer, primary_key=True),
             Column("name", types.Unicode),
             schema="public"
@@ -142,7 +142,7 @@ class TestLayers(TestCase):
             tablename, self.metadata,
             Column("id", types.Integer, primary_key=True),
             Column("child_id", types.Integer,
-                   ForeignKey("public.%s_child.id" % tablename)),
+                   ForeignKey("public.{0!s}_child.id".format(tablename))),
             Column("name", types.Unicode),
             Column("geom", Geometry("POINT", srid=21781, management=management)),
             schema="public"
@@ -274,7 +274,7 @@ class TestLayers(TestCase):
         layer_id2 = self._create_layer()
         layer_id3 = self._create_layer()
 
-        layer_ids = "%d,%d,%d" % (layer_id1, layer_id2, layer_id3)
+        layer_ids = "{0:d},{1:d},{2:d}".format(layer_id1, layer_id2, layer_id3)
         request = self._get_request(layer_ids, username=u"__test_user")
 
         layers = Layers(request)
@@ -579,7 +579,7 @@ class TestLayers(TestCase):
 
         layers = Layers(request)
         cls = layers.metadata()
-        self.assertEquals(cls.__table__.name, "table_%d" % layer_id)
+        self.assertEquals(cls.__table__.name, "table_{0:d}".format(layer_id))
         self.assertTrue(hasattr(cls, "name"))
         self.assertTrue("child" in cls.__dict__)
 
@@ -776,7 +776,7 @@ class TestLayers(TestCase):
         from c2cgeoportal.views.layers import Layers
 
         layer_id = self._create_layer(public=True)
-        tablename = "table_%d" % layer_id
+        tablename = "table_{0:d}".format(layer_id)
         settings = {
             "layers": {
                 "enum": {
@@ -812,7 +812,7 @@ class TestLayers(TestCase):
         from c2cgeoportal.views.layers import Layers
 
         layer_id = self._create_layer(public=True, attr_list=True)
-        tablename = "table_%d" % layer_id
+        tablename = "table_{0:d}".format(layer_id)
         settings = {
             "layers": {
                 "enum": {

--- a/c2cgeoportal/tests/functional/test_mapserverproxy.py
+++ b/c2cgeoportal/tests/functional/test_mapserverproxy.py
@@ -418,7 +418,7 @@ class TestMapserverproxyView(TestCase):
         expected_response = "".join(
             re.sub(pattern, "", l) for l in expected_response.splitlines()
         )
-        expected_response = "%s('%s');" % ("cb", expected_response)
+        expected_response = "{0!s}('{1!s}');".format("cb", expected_response)
         response_body = "".join(
             re.sub(pattern, "", l) for l in response.body.splitlines()
         )
@@ -741,11 +741,11 @@ class TestMapserverproxyView(TestCase):
 
         request = self._create_dummy_request()
 
-        featureid = "%(typename)s.%(fid1)s,%(typename)s.%(fid2)s" % {
+        featureid = "{typename!s}.{fid1!s},{typename!s}.{fid2!s}".format(**{
             "typename": "testpoint_unprotected",
             "fid1": self.id_lausanne,
             "fid2": self.id_paris
-        }
+        })
         request.params.update(dict(
             service="wfs", version="1.0.0",
             request="getfeature", typename="testpoint_unprotected",
@@ -763,11 +763,11 @@ class TestMapserverproxyView(TestCase):
 
         request = self._create_dummy_request()
 
-        featureid = "%(typename)s.%(fid1)s,%(typename)s.%(fid2)s" % {
+        featureid = "{typename!s}.{fid1!s},{typename!s}.{fid2!s}".format(**{
             "typename": "testpoint_unprotected",
             "fid1": self.id_lausanne,
             "fid2": self.id_paris
-        }
+        })
         request.params.update(dict(
             service="wfs", version="1.0.0",
             request="getfeature", typename="testpoint_unprotected",
@@ -785,11 +785,11 @@ class TestMapserverproxyView(TestCase):
 
         request = self._create_dummy_request()
 
-        featureid = "%(typename)s.%(fid1)s,%(typename)s.%(fid2)s" % {
+        featureid = "{typename!s}.{fid1!s},{typename!s}.{fid2!s}".format(**{
             "typename": "testpoint_unprotected",
             "fid1": self.id_lausanne,
             "fid2": self.id_paris
-        }
+        })
         request.params.update(dict(
             service="wfs", version="1.0.0",
             request="getfeature", typename="testpoint_unprotected",
@@ -805,11 +805,11 @@ class TestMapserverproxyView(TestCase):
 
         request = self._create_dummy_request()
 
-        featureid = "%(typename)s.%(fid1)s,%(typename)s.%(fid2)s" % {
+        featureid = "{typename!s}.{fid1!s},{typename!s}.{fid2!s}".format(**{
             "typename": "testpoint_unprotected",
             "fid1": self.id_lausanne,
             "fid2": self.id_paris
-        }
+        })
         request.params.update(dict(
             service="wfs", version="1.0.0",
             request="getfeature", typename="testpoint_unprotected",
@@ -825,11 +825,11 @@ class TestMapserverproxyView(TestCase):
 
         request = self._create_dummy_request()
 
-        featureid = "%(typename)s.%(fid1)s,%(typename)s.%(fid2)s" % {
+        featureid = "{typename!s}.{fid1!s},{typename!s}.{fid2!s}".format(**{
             "typename": "testpoint_unprotected",
             "fid1": self.id_lausanne,
             "fid2": self.id_paris
-        }
+        })
         request.params.update(dict(
             service="wfs", version="1.0.0",
             request="getfeature", typename="testpoint_unprotected",

--- a/c2cgeoportal/views/check_collector.py
+++ b/c2cgeoportal/views/check_collector.py
@@ -62,7 +62,7 @@ class CheckerCollector:  # pragma: no cover
                 check_type = params["type"] if "type" in params else \
                     host["type"] if "type" in host else "default"
                 checks = self.settings["check_type"][check_type]
-                body += "<h2>%s</h2>" % host["display"]
+                body += "<h2>{0!s}</h2>".format(host["display"])
 
                 start1 = time()
                 for check in checks:
@@ -72,12 +72,11 @@ class CheckerCollector:  # pragma: no cover
                     res, err = self._testurl("{}/{}?type={}".format(
                         host["url"], check["name"], check_type
                     ))
-                    body += "<p>%s: %s (%0.4fs)</p>" % \
-                        (check["display"], res, time() - start2)
+                    body += "<p>{0!s}: {1!s} ({2:0.4f}s)</p>".format(check["display"], res, time() - start2)
                     if err:
-                        body += "%s<hr/>" % err
-                body += "<p>Elapsed: %0.4f</p>" % (time() - start1)
-        body += "<p>Elapsed all: %0.4f</p>" % (time() - start0)
+                        body += "{0!s}<hr/>".format(err)
+                body += "<p>Elapsed: {0:0.4f}</p>".format((time() - start1))
+        body += "<p>Elapsed all: {0:0.4f}</p>".format((time() - start0))
         return Response(
             body=body, status_int=self.status_int, cache_control="no-cache"
         )
@@ -90,8 +89,8 @@ class CheckerCollector:  # pragma: no cover
 
         if resp.status != httplib.OK:
             self.status_int = max(self.status_int, resp.status)
-            return '<span style="color: red;">%i - %s</span>' % (
+            return '<span style="color: red;">{0:d} - {1!s}</span>'.format(
                 resp.status, resp.reason
             ), content
 
-        return '<span style="color: green;">%s</span>' % content, None
+        return '<span style="color: green;">{0!s}</span>'.format(content), None

--- a/c2cgeoportal/views/checker.py
+++ b/c2cgeoportal/views/checker.py
@@ -66,7 +66,7 @@ def build_url(name, url, request, headers=None):
         if value is not None:
             headers[header] = value
 
-    log.info("%s, URL: %s => %s" % (name, url, url_))
+    log.info("{0!s}, URL: {1!s} => {2!s}".format(name, url, url_))
     return url_, headers
 
 
@@ -89,7 +89,7 @@ class Checker:  # pragma: no cover
 
     def make_response(self, msg):
         return Response(
-            body=msg, status="%i %s" % (self.status_int, self.status), cache_control="no-cache"
+            body=msg, status="{0:d} {1!s}".format(self.status_int, self.status), cache_control="no-cache"
         )
 
     def testurl(self, url):
@@ -138,7 +138,7 @@ class Checker:  # pragma: no cover
             "comment": "Foobar",
             "title": "Bouchon",
             "units": "m",
-            "srs": "EPSG:%i" % self.request.registry.settings["srid"],
+            "srs": "EPSG:{0:d}".format(self.request.registry.settings["srid"]),
             "dpi": 254,
             "layers": [],
             "layout": self.settings["print_template"],
@@ -217,7 +217,7 @@ class Checker:  # pragma: no cover
             status = loads(content)
             if "error" in status:
                 self.set_status(500, status["error"])
-                return "Failed to do the printing: %s" % status["error"]
+                return "Failed to do the printing: {0!s}".format(status["error"])
             done = status["done"]
 
         url = self.request.route_url("printproxy_report_get", ref=job["ref"])
@@ -315,7 +315,7 @@ class Checker:  # pragma: no cover
             for lang in available_locale_names:
                 if _type == "cgxp":
                     named_urls.append((
-                        "%s-%s" % (_type, lang),
+                        "{0!s}-{1!s}".format(_type, lang),
                         self.request.static_url(
                             "{package}:static/build/lang-{lang}.js".format(
                                 package=self.request.registry.settings["package"], lang=lang
@@ -324,7 +324,7 @@ class Checker:  # pragma: no cover
                     ))
                 elif _type == "cgxp-api":
                     named_urls.append((
-                        "%s-%s" % (_type, lang),
+                        "{0!s}-{1!s}".format(_type, lang),
                         self.request.static_url(
                             "{package}:static/build/api-lang-{lang}.js".format(
                                 package=self.request.registry.settings["package"], lang=lang
@@ -333,7 +333,7 @@ class Checker:  # pragma: no cover
                     ))
                 elif _type == "ngeo":
                     named_urls.append((
-                        "%s-%s" % (_type, lang),
+                        "{0!s}-{1!s}".format(_type, lang),
                         self.request.static_url(
                             "{package}:static-ngeo/build/{lang}.json".format(
                                 package=self.request.registry.settings["package"], lang=lang

--- a/c2cgeoportal/views/echo.py
+++ b/c2cgeoportal/views/echo.py
@@ -42,7 +42,7 @@ def json_base64_encode(filename, file):
     Generate a JSON-wrapped base64-encoded string.
     See http://en.wikipedia.org/wiki/Base64
     """
-    yield '{"filename":%s,"data":"' % (json.dumps(filename),)
+    yield '{{"filename":{0!s},"data":"'.format(json.dumps(filename))
     yield b64encode(file.read())
     yield '","success":true}'
 

--- a/c2cgeoportal/views/entry.py
+++ b/c2cgeoportal/views/entry.py
@@ -211,7 +211,7 @@ class Entry:
             "REQUEST": "GetCapabilities",
         })
 
-        log.info("Get WMS GetCapabilities for url: %s" % url)
+        log.info("Get WMS GetCapabilities for url: {0!s}".format(url))
 
         # forward request to target (without Host Header)
         http = httplib2.Http()
@@ -229,12 +229,11 @@ class Entry:
         try:
             resp, content = http.request(url, method="GET", headers=headers)
         except:  # pragma: no cover
-            errors.add("Unable to GetCapabilities from url %s" % url)
+            errors.add("Unable to GetCapabilities from url {0!s}".format(url))
             return None, errors
 
         if resp.status < 200 or resp.status >= 300:  # pragma: no cover
-            error = "GetCapabilities from URL %s return the error: %i %s" % \
-                (url, resp.status, resp.reason)
+            error = "GetCapabilities from URL {0!s} return the error: {1:d} {2!s}".format(url, resp.status, resp.reason)
             errors.add(error)
             log.exception(error)
             return None, errors
@@ -242,8 +241,7 @@ class Entry:
         # With wms 1.3 it returns text/xml also in case of error :-(
         if resp.get("content-type").split(";")[0].strip() not in \
                 ["application/vnd.ogc.wms_xml", "text/xml"]:
-            error = "GetCapabilities from URL %s returns a wrong Content-Type: %s\n%s" % \
-                (url, resp.get("content-type"), content.encode("utf-8"))
+            error = "GetCapabilities from URL {0!s} returns a wrong Content-Type: {1!s}\n{2!s}".format(url, resp.get("content-type"), content.encode("utf-8"))
             errors.add(error)
             log.exception(error)
             return None, errors
@@ -255,7 +253,7 @@ class Entry:
                 "WARNING! an error occured while trying to "
                 "read the mapfile and recover the themes."
             )
-            error = "%s\nURL: %s\n%s" % (error, url, content.encode("utf-8"))
+            error = "{0!s}\nURL: {1!s}\n{2!s}".format(error, url, content.encode("utf-8"))
             errors.add(error)
             log.exception(error)
         return wms, errors
@@ -328,8 +326,8 @@ class Entry:
             resolution = self._get_layer_resolution_hint(child_layer)
             child_layer_info = {
                 "name": child_layer.name,
-                "minResolutionHint": float("%0.2f" % resolution[0]),
-                "maxResolutionHint": float("%0.2f" % resolution[1]),
+                "minResolutionHint": float("{0:0.2f}".format(resolution[0])),
+                "maxResolutionHint": float("{0:0.2f}".format(resolution[1])),
             }
             if hasattr(child_layer, "queryable"):
                 child_layer_info["queryable"] = child_layer.queryable
@@ -346,8 +344,8 @@ class Entry:
         resolution = self._get_layer_resolution_hint(layer)
         layer_info = {
             "name": layer.name,
-            "minResolutionHint": float("%0.2f" % resolution[0]),
-            "maxResolutionHint": float("%0.2f" % resolution[1]),
+            "minResolutionHint": float("{0:0.2f}".format(resolution[0])),
+            "maxResolutionHint": float("{0:0.2f}".format(resolution[1])),
         }
         layer_info["queryable"] = layer.queryable == 1 \
             if hasattr(layer, "queryable") else True
@@ -452,8 +450,7 @@ class Entry:
 
         except ValueError:  # pragma no cover
             errors.add(
-                "Error while handling time for layer '%s': %s"
-                % (layer.name, sys.exc_info()[1])
+                "Error while handling time for layer '{0!s}': {1!s}".format(layer.name, sys.exc_info()[1])
             )
 
         return errors
@@ -571,16 +568,16 @@ class Entry:
             resolutions = self._get_layer_resolution_hint(wms_layer_obj)
             if resolutions[0] <= resolutions[1]:
                 if "minResolutionHint" not in l:
-                    l["minResolutionHint"] = float("%0.2f" % resolutions[0])
+                    l["minResolutionHint"] = float("{0:0.2f}".format(resolutions[0]))
                 if "maxResolutionHint" not in l:
-                    l["maxResolutionHint"] = float("%0.2f" % resolutions[1])
+                    l["maxResolutionHint"] = float("{0:0.2f}".format(resolutions[1]))
             l["childLayers"] = self._get_child_layers_info_1(wms_layer_obj)
             if hasattr(wms_layer_obj, "queryable"):
                 l["queryable"] = wms_layer_obj.queryable
         else:
             if self.default_ogc_server.type != OGCSERVER_TYPE_GEOSERVER:
                 errors.add(
-                    "The layer '%s' is not defined in WMS capabilities" % wmslayer
+                    "The layer '{0!s}' is not defined in WMS capabilities".format(wmslayer)
                 )
 
     def _fill_external_wms(self, l, layer, errors):
@@ -624,8 +621,7 @@ class Entry:
                 l["dimensions"] = json.loads(layer.dimensions)
             except:  # pragma: no cover
                 errors.add(
-                    u"Unexpected error: '%s' while reading '%s' in layer '%s'" %
-                    (sys.exc_info()[0], layer.dimensions, layer.name))
+                    u"Unexpected error: '{0!s}' while reading '{1!s}' in layer '{2!s}'".format(sys.exc_info()[0], layer.dimensions, layer.name))
 
         mapserverproxy_url = self.request.route_url("mapserverproxy")
         wms, wms_layers, wms_errors = self._wms_layers(
@@ -669,10 +665,10 @@ class Entry:
 
                 if resolutions[0] != float("Inf"):
                     ql["minResolutionHint"] = float(
-                        "%0.2f" % resolutions[0])
+                        "{0:0.2f}".format(resolutions[0]))
                 if resolutions[1] != 0:
                     ql["maxResolutionHint"] = float(
-                        "%0.2f" % resolutions[1])
+                        "{0:0.2f}".format(resolutions[1]))
 
                 l["queryLayers"].append(ql)
 
@@ -696,7 +692,7 @@ class Entry:
 
         # escape loop
         if depth > 30:
-            log.error("Error: too many recursions with group '%s'" % group.name)
+            log.error("Error: too many recursions with group '{0!s}'".format(group.name))
             return ogc_servers
 
         # recurse on children
@@ -730,7 +726,7 @@ class Entry:
         # escape loop
         if depth > 30:
             errors.add(
-                "Too many recursions with group '%s'" % group.name
+                "Too many recursions with group '{0!s}'".format(group.name)
             )
             return None, errors
 
@@ -750,7 +746,7 @@ class Entry:
                 if type(group) == Theme or catalogue or \
                         group.is_internal_wms == tree_item.is_internal_wms:
                     gp, gp_errors = self._group(
-                        "%s/%s" % (path, tree_item.name),
+                        "{0!s}/{1!s}".format(path, tree_item.name),
                         tree_item, layers, depth=depth, min_levels=min_levels,
                         catalogue=catalogue, role_id=role_id, version=version, mixed=mixed,
                         time=time, dim=dim, wms_layers=wms_layers, layers_name=layers_name, **kwargs
@@ -760,8 +756,7 @@ class Entry:
                         children.append(gp)
                 else:
                     errors.add(
-                        "Group '%s' cannot be in group '%s' (internal/external mix)." %
-                        (tree_item.name, group.name)
+                        "Group '{0!s}' cannot be in group '{1!s}' (internal/external mix).".format(tree_item.name, group.name)
                     )
             elif self._layer_included(tree_item, version):
                 if (tree_item.name in layers):
@@ -779,15 +774,14 @@ class Entry:
                         errors |= l_errors
                         if l is not None:
                             if depth < min_levels:
-                                errors.add("The Layer '%s' is under indented (%i/%i)." % (
+                                errors.add("The Layer '{0!s}' is under indented ({1:d}/{2:d}).".format(
                                     path + "/" + tree_item.name, depth, min_levels
                                 ))
                             else:
                                 children.append(l)
                     else:
                         errors.add(
-                            "Layer '%s' cannot be in the group '%s' (internal/external mix)." %
-                            (tree_item.name, group.name)
+                            "Layer '{0!s}' cannot be in the group '{1!s}' (internal/external mix).".format(tree_item.name, group.name)
                         )
 
         if len(children) > 0:
@@ -938,7 +932,7 @@ class Entry:
         for item in theme.children:
             if type(item) == LayerGroup:
                 gp, gp_errors = self._group(
-                    "%s/%s" % (theme.name, item.name),
+                    "{0!s}/{1!s}".format(theme.name, item.name),
                     item, layers,
                     role_id=role_id, version=version, catalogue=catalogue,
                     min_levels=min_levels
@@ -948,7 +942,7 @@ class Entry:
                     children.append(gp)
             elif self._layer_included(item, version):
                 if min_levels > 0:
-                    errors.add("The Layer '%s' cannot be directly in the theme '%s' (0/%i)." % (
+                    errors.add("The Layer '{0!s}' cannot be directly in the theme '{1!s}' (0/{2:d}).".format(
                         item.name, theme.name, min_levels
                     ))
                 elif item.name in layers:
@@ -1014,7 +1008,7 @@ class Entry:
         }
         wfsgc_url = add_url_params(wfs_url, params)
 
-        log.info("WFS GetCapabilities for base url: %s" % wfsgc_url)
+        log.info("WFS GetCapabilities for base url: {0!s}".format(wfsgc_url))
 
         # forward request to target (without Host Header)
         http = httplib2.Http()
@@ -1024,13 +1018,12 @@ class Entry:
         try:
             resp, get_capabilities_xml = http.request(wfsgc_url, method="GET", headers=h)
         except:  # pragma: no cover
-            errors.add("Unable to GetCapabilities from url %s" % wfsgc_url)
+            errors.add("Unable to GetCapabilities from url {0!s}".format(wfsgc_url))
             return None, errors
 
         if resp.status < 200 or resp.status >= 300:  # pragma: no cover
             errors.add(
-                "GetCapabilities from url %s return the error: %i %s" %
-                (wfsgc_url, resp.status, resp.reason)
+                "GetCapabilities from url {0!s} return the error: {1:d} {2!s}".format(wfsgc_url, resp.status, resp.reason)
             )
             return None, errors
 
@@ -1049,7 +1042,7 @@ class Entry:
                         name_value = name_value.split(":")[1]
                     featuretypes.append(name_value)
                 else:  # pragma nocover
-                    log.warn("Feature type without name: %s" % featureType.toxml())
+                    log.warn("Feature type without name: {0!s}".format(featureType.toxml()))
             return featuretypes, errors
         except:  # pragma: no cover
             return get_capabilities_xml, errors
@@ -1093,14 +1086,13 @@ class Entry:
             resp, content = http.request(ext_url, method="GET", headers=h)
         except:
             errors.add(
-                "Unable to get external themes from url %s" % ext_url
+                "Unable to get external themes from url {0!s}".format(ext_url)
             )
             return None, errors
 
         if resp.status < 200 or resp.status >= 300:
             errors.add(
-                "Get external themes from url %s return the error: %i %s" %
-                (ext_url, resp.status, resp.reason)
+                "Get external themes from url {0!s} return the error: {1:d} {2!s}".format(ext_url, resp.status, resp.reason)
             )
             return None, errors
 
@@ -1452,7 +1444,7 @@ class Entry:
         user = self.request.registry.validate_user(self.request, login, password)
         if user is not None:
             headers = remember(self.request, user)
-            log.info("User '%s' logged in." % login)
+            log.info("User '{0!s}' logged in.".format(login))
 
             came_from = self.request.params.get("came_from")
             if came_from:
@@ -1466,7 +1458,7 @@ class Entry:
                     )), headers=headers),
                 )
         else:
-            log.info("bad credentials for login '%s'." % login)
+            log.info("bad credentials for login '{0!s}'.".format(login))
             raise HTTPBadRequest("See server logs for details")
 
     @view_config(route_name="logout")
@@ -1479,7 +1471,7 @@ class Entry:
             log.info("Logout on non login user.")
             raise HTTPBadRequest("See server logs for details")
 
-        log.info("User '%s' (%i) logging out." % (
+        log.info("User '{0!s}' ({1:d}) logging out.".format(
             self.request.user.username,
             self.request.user.id
         ))
@@ -1533,7 +1525,7 @@ class Entry:
             self.request, self.request.user.username, old_password
         )
         if user is None:
-            log.info("The old password is wrong for user '%s'." % user)
+            log.info("The old password is wrong for user '{0!s}'.".format(user))
             raise HTTPBadRequest("See server logs for details")
 
         if new_password != new_password_confirm:
@@ -1547,7 +1539,7 @@ class Entry:
         u._set_password(new_password)
         u.is_password_changed = True
         DBSession.flush()
-        log.info("Password changed for user '%s'" % self.request.user.username)
+        log.info("Password changed for user '{0!s}'".format(self.request.user.username))
 
         return {
             "success": "true"
@@ -1568,12 +1560,12 @@ class Entry:
         try:
             user = DBSession.query(User).filter(User.username == username).one()
         except NoResultFound:  # pragma: no cover
-            return None, None, None, "The login '%s' doesn't exist." % username
+            return None, None, None, "The login '{0!s}' doesn't exist.".format(username)
 
         if user.email is None or user.email == "":  # pragma: no cover
             return \
                 None, None, None, \
-                "The user '%s' has no registered email address." % user.username,
+                "The user '{0!s}' has no registered email address.".format(user.username),
 
         password = self.generate_password()
         user.set_temp_password(password)

--- a/c2cgeoportal/views/export.py
+++ b/c2cgeoportal/views/export.py
@@ -58,7 +58,7 @@ def exportcsv(request):
     content += csv.encode(csv_encoding)
     request.response.body = content
     response.charset = csv_encoding.encode(csv_encoding)
-    response.content_disposition = "attachment; filename=%s.%s" % (
+    response.content_disposition = "attachment; filename={0!s}.{1!s}".format(
         name.replace(" ", "_"), csv_extension
     )
     return set_common_headers(
@@ -97,8 +97,7 @@ def exportgpxkml(request):
     response = request.response
     response.body = doc.encode(charset)
     response.charset = charset
-    response.content_disposition = ("attachment; filename=%s.%s"
-                                    % (name.replace(" ", "_"), fmt))
+    response.content_disposition = ("attachment; filename={0!s}.{1!s}".format(name.replace(" ", "_"), fmt))
     return set_common_headers(
         request, "exportgpxkml", NO_CACHE,
         content_type=_CONTENT_TYPES[fmt]

--- a/c2cgeoportal/views/fulltextsearch.py
+++ b/c2cgeoportal/views/fulltextsearch.py
@@ -65,7 +65,7 @@ class FullTextSearchView:
             language = self.languages[lang]
         except KeyError:
             return HTTPInternalServerError(
-                detail="%s not defined in languages" % lang)
+                detail="{0!s} not defined in languages".format(lang))
 
         if "query" not in self.request.params:
             return HTTPBadRequest(detail="no query")

--- a/c2cgeoportal/views/layers.py
+++ b/c2cgeoportal/views/layers.py
@@ -82,8 +82,8 @@ class Layers:
             if isinstance(col.type, Geometry):
                 return col.name, col.type.srid
         raise HTTPInternalServerError(
-            'Failed getting geometry column info for table "%s".' %
-            layer.geo_table
+            'Failed getting geometry column info for table "{0!s}".'.format(
+            layer.geo_table)
         )  # pragma: no cover
 
     def _get_layer(self, layer_id):
@@ -94,13 +94,13 @@ class Layers:
             query = query.filter(Layer.id == layer_id)
             layer, geo_table = query.one()
         except NoResultFound:
-            raise HTTPNotFound("Layer %d not found" % layer_id)
+            raise HTTPNotFound("Layer {0:d} not found".format(layer_id))
         except MultipleResultsFound:  # pragma: no cover
             raise HTTPInternalServerError(
-                "Too many layers found with id %i" % layer_id
+                "Too many layers found with id {0:d}".format(layer_id)
             )
         if not geo_table:  # pragma: no cover
-            raise HTTPNotFound("Layer %d has no geo table" % layer_id)
+            raise HTTPNotFound("Layer {0:d} has no geo table".format(layer_id))
         return layer
 
     def _get_layers_for_request(self):
@@ -114,8 +114,8 @@ class Layers:
                 yield self._get_layer(layer_id)
         except ValueError:
             raise HTTPBadRequest(
-                "A Layer id in '%s' is not an integer" %
-                self.request.matchdict["layer_id"]
+                "A Layer id in '{0!s}' is not an integer".format(
+                self.request.matchdict["layer_id"])
             )  # pragma: no cover
 
     def _get_layer_for_request(self):
@@ -416,17 +416,17 @@ class Layers:
     @cache_region.cache_on_arguments()
     def _enumerate_attribute_values(self, general_dbsession_name, layername, fieldname):
         if layername not in self.layers_enum_config:  # pragma: no cover
-            raise HTTPBadRequest("Unknown layer: %s" % layername)
+            raise HTTPBadRequest("Unknown layer: {0!s}".format(layername))
 
         layerinfos = self.layers_enum_config[layername]
         if fieldname not in layerinfos["attributes"]:  # pragma: no cover
-            raise HTTPBadRequest("Unknown attribute: %s" % fieldname)
+            raise HTTPBadRequest("Unknown attribute: {0!s}".format(fieldname))
         dbsession = DBSessions.get(
             layerinfos.get("dbsession", general_dbsession_name),
         )
         if dbsession is None:  # pragma: no cover
             raise HTTPInternalServerError(
-                "No dbsession found for layer '%s'" % layername
+                "No dbsession found for layer '{0!s}'".format(layername)
             )
 
         layer_table = layerinfos.get("table")
@@ -436,7 +436,7 @@ class Layers:
         table = attrinfos.get("table", layer_table)
         if table is None:  # pragma: no cover
             raise HTTPInternalServerError(
-                "No config table found for layer '%s'" % layername
+                "No config table found for layer '{0!s}'".format(layername)
             )
         layertable = get_table(table, session=dbsession)
 

--- a/c2cgeoportal/views/mapserverproxy.py
+++ b/c2cgeoportal/views/mapserverproxy.py
@@ -129,8 +129,7 @@ class MapservProxy(Proxy):
         # don't allows direct variable substitution
         for k in params.keys():
             if k[:2].capitalize() == "S_":
-                log.warning("Direct substitution not allowed (%s=%s)." %
-                            (k, params[k]))
+                log.warning("Direct substitution not allowed ({0!s}={1!s}).".format(k, params[k]))
                 del params[k]
 
         # add functionalities params
@@ -224,7 +223,7 @@ class MapservProxy(Proxy):
             # escape single quotes in the JavaScript string
             content = unicode(content.decode("utf8"))
             content = content.replace(u"'", u"\\'")
-            content = u"%s('%s');" % (callback, u" ".join(content.splitlines()))
+            content = u"{0!s}('{1!s}');".format(callback, u" ".join(content.splitlines()))
         else:
             content_type = resp["content-type"]
 

--- a/c2cgeoportal/views/pdfreport.py
+++ b/c2cgeoportal/views/pdfreport.py
@@ -54,9 +54,9 @@ class PdfReport(Proxy):  # pragma: no cover
         headers = dict(self.request.headers)
         headers["Content-Type"] = "application/json"
         resp, content = self._proxy(
-            "%s/buildreport.%s" % (
+            "{0!s}/buildreport.{1!s}".format(
                 self.config["print_url"],
-                spec["outputFormat"],
+                spec["outputFormat"]
             ),
             method="POST",
             body=dumps(spec),
@@ -148,9 +148,9 @@ class PdfReport(Proxy):  # pragma: no cover
             )
 
         mapserv_url = self.request.route_url("mapserverproxy")
-        vector_request_url = "%s?%s" % (
+        vector_request_url = "{0!s}?{1!s}".format(
             mapserv_url,
-            "&".join(["%s=%s" % i for i in {
+            "&".join(["{0!s}={1!s}".format(*i) for i in {
                 "service": "WFS",
                 "version": "1.1.0",
                 "outputformat": "gml3",

--- a/c2cgeoportal/views/printproxy.py
+++ b/c2cgeoportal/views/printproxy.py
@@ -119,16 +119,16 @@ class PrintProxy(Proxy):  # pragma: no cover
         """ Create PDF. """
         return self._proxy_response(
             "print",
-            "%screate.json" % (
+            "{0!s}create.json".format((
                 self.config["print_url"]
-            )
+            ))
         )
 
     @view_config(route_name="printproxy_get")
     def get(self):
         """ Get created PDF. """
 
-        resp, content = self._proxy("%s%s.printout" % (
+        resp, content = self._proxy("{0!s}{1!s}.printout".format(
             self.config["print_url"],
             self.request.matchdict.get("file")
         ))
@@ -209,7 +209,7 @@ class PrintProxy(Proxy):  # pragma: no cover
         """ Create PDF. """
         return self._proxy_response(
             "print",
-            "%s/report.%s" % (
+            "{0!s}/report.{1!s}".format(
                 self.config["print_url"],
                 self.request.matchdict.get("format")
             ),
@@ -220,7 +220,7 @@ class PrintProxy(Proxy):  # pragma: no cover
         """ PDF status. """
         return self._proxy_response(
             "print",
-            "%s/status/%s.json" % (
+            "{0!s}/status/{1!s}.json".format(
                 self.config["print_url"],
                 self.request.matchdict.get("ref")
             ),
@@ -231,7 +231,7 @@ class PrintProxy(Proxy):  # pragma: no cover
         """ PDF cancel. """
         return self._proxy_response(
             "print",
-            "%s/cancel/%s" % (
+            "{0!s}/cancel/{1!s}".format(
                 self.config["print_url"],
                 self.request.matchdict.get("ref")
             ),
@@ -242,7 +242,7 @@ class PrintProxy(Proxy):  # pragma: no cover
         """ Get the PDF. """
         return self._proxy_response(
             "print",
-            "%s/report/%s" % (
+            "{0!s}/report/{1!s}".format(
                 self.config["print_url"],
                 self.request.matchdict.get("ref")
             ),

--- a/c2cgeoportal/views/profile.py
+++ b/c2cgeoportal/views/profile.py
@@ -74,7 +74,7 @@ class Profile(Raster):
                     point["values"][l] = -9999
 
             r = template % tuple((str(point["values"][l]) for l in layers))
-            result += "\n%s,%s,%d,%d" % (str(point["dist"]), r, point["x"], point["y"])
+            result += "\n{0!s},{1!s},{2:d},{3:d}".format(str(point["dist"]), r, point["x"], point["y"])
 
         return set_common_headers(
             self.request, "profile", NO_CACHE,
@@ -94,7 +94,7 @@ class Profile(Raster):
                 if layer in self.rasters:
                     rasters[layer] = self.rasters[layer]
                 else:
-                    raise HTTPNotFound("Layer %s not found" % layer)
+                    raise HTTPNotFound("Layer {0!s} not found".format(layer))
         else:
             rasters = self.rasters
 

--- a/c2cgeoportal/views/proxy.py
+++ b/c2cgeoportal/views/proxy.py
@@ -65,17 +65,17 @@ class Proxy:
         query_string = urllib.urlencode(params_encoded)
 
         if parsed_url.port is None:
-            url = "%s://%s%s?%s" % (
+            url = "{0!s}://{1!s}{2!s}?{3!s}".format(
                 parsed_url.scheme, parsed_url.hostname,
                 parsed_url.path, query_string
             )
         else:  # pragma: no cover
-            url = "%s://%s:%i%s?%s" % (
+            url = "{0!s}://{1!s}:{2:d}{3!s}?{4!s}".format(
                 parsed_url.scheme, parsed_url.hostname, parsed_url.port,
                 parsed_url.path, query_string
             )
 
-        log.info("Send query to URL:\n%s." % url)
+        log.info("Send query to URL:\n{0!s}.".format(url))
 
         if method is None:
             method = self.request.method
@@ -108,13 +108,12 @@ class Proxy:
                 )
         except Exception as e:  # pragma: no cover
             log.error(
-                "Error '%s' while getting the URL:\n%s\nMethod: %s." %
-                (sys.exc_info()[0], url, method)
+                "Error '{0!s}' while getting the URL:\n{1!s}\nMethod: {2!s}.".format(sys.exc_info()[0], url, method)
             )
 
             log.error(
-                "--- With headers ---\n%s" %
-                "\n".join(["%s: %s" % h for h in headers.items()])
+                "--- With headers ---\n{0!s}".format(
+                "\n".join(["{0!s}: {1!s}".format(*h) for h in headers.items()]))
             )
 
             log.error("--- Exception ---")
@@ -132,16 +131,15 @@ class Proxy:
 
         if resp.status < 200 or resp.status >= 300:  # pragma: no cover
             log.error(
-                "Error '%s' in response of URL:\n%s." %
-                (resp.reason, url)
+                "Error '{0!s}' in response of URL:\n{1!s}.".format(resp.reason, url)
             )
 
-            log.error("Status: %i" % resp.status)
-            log.error("Method: %s" % method)
+            log.error("Status: {0:d}".format(resp.status))
+            log.error("Method: {0!s}".format(method))
 
             log.error(
-                "--- With headers ---\n%s" %
-                "\n".join(["%s: %s" % h for h in headers.items()])
+                "--- With headers ---\n{0!s}".format(
+                "\n".join(["{0!s}: {1!s}".format(*h) for h in headers.items()]))
             )
 
             if method == "POST":

--- a/c2cgeoportal/views/raster.py
+++ b/c2cgeoportal/views/raster.py
@@ -60,7 +60,7 @@ class Raster:
                 if layer in self.rasters:
                     rasters[layer] = self.rasters[layer]
                 else:
-                    raise HTTPNotFound("Layer %s not found" % layer)
+                    raise HTTPNotFound("Layer {0!s} not found".format(layer))
         else:
             rasters = self.rasters
 
@@ -82,8 +82,7 @@ class Raster:
             self._rasters[ref] = raster
         else:
             raise HTTPInternalServerError(
-                'Bad raster type "%s" for raster layer "%s"'
-                % (layer["type"], ref))  # pragma: no cover
+                'Bad raster type "{0!s}" for raster layer "{1!s}"'.format(layer["type"], ref))  # pragma: no cover
 
         result = raster.get_value(lon, lat)
         if "round" in layer:

--- a/c2cgeoportal/views/resourceproxy.py
+++ b/c2cgeoportal/views/resourceproxy.py
@@ -66,5 +66,5 @@ class ResourceProxy(Proxy):
                 content_type=content_type
             )
         else:  # pragma: no cover
-            log.warning("target url not found: %s" % target)
+            log.warning("target url not found: {0!s}".format(target))
             return HTTPBadRequest("url not allowed")

--- a/c2cgeoportal/views/shortener.py
+++ b/c2cgeoportal/views/shortener.py
@@ -63,7 +63,7 @@ class Shortener:
         short_urls = DBSession.query(Shorturl).filter(Shorturl.ref == ref).all()
 
         if len(short_urls) != 1:
-            raise HTTPNotFound("Ref '%s' not found" % ref)
+            raise HTTPNotFound("Ref '{0!s}' not found".format(ref))
 
         short_urls[0].nb_hits += 1
         short_urls[0].last_hit = datetime.now()
@@ -93,7 +93,7 @@ class Shortener:
                 raise HTTPBadRequest("The requested host is not allowed.")
         else:
             if hostname != self.request.server_name:
-                raise HTTPBadRequest("The requested host '%s' should be '%s'" % (
+                raise HTTPBadRequest("The requested host '{0!s}' should be '{1!s}'".format(
                     hostname, self.request.server_name
                 ))
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:camptocamp:c2cgeoportal?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:camptocamp:c2cgeoportal?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)