### PR TITLE
Use unicode to format the returned page

### DIFF
--- a/c2cgeoportal/forms.py
+++ b/c2cgeoportal/forms.py
@@ -297,7 +297,7 @@ class SimpleLayerCheckBoxTreeSet(CheckBoxTreeSet):  # pragma: no cover
             "l_wmts": "WMTS Layer: ",
         }
 
-        result = """
+        result = u"""
         <li>
             <input type="checkbox" id="{id!s}" name="{name!s}" value="{value!s}"{add!s}></input>
             <label>{type!s}{label!s}</label>

--- a/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -752,6 +752,7 @@ $(TX_RC):
 .build/locale/%/LC_MESSAGES/gmf.po: $(TX_DEPENDENCIES)
 	$(PRERULE_CMD)
 	mkdir -p $(dir $@)
+	sleep 1 # To be sure that the the creation date should be after the .transifexrc file. (the $(TOUCHBACK_TXRC) lost the ms)
 	$(VENV_BIN)/tx pull -l $* --force
 	$(TOUCHBACK_TXRC)
 	test -s $@


### PR DESCRIPTION
Fix : https://github.com/camptocamp/c2cgeoportal/issues/2725