### PR TITLE
Fix openlayers submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "c2cgeoportal/static/lib/openlayers"]
 	path = c2cgeoportal/static/lib/openlayers
-	url = https://github.com/openlayers/openlayers.git
+	url = https://github.com/openlayers/ol2.git


### PR DESCRIPTION
Openlayers v2 github repository has be renamed.
This update the submodule url.