### PR TITLE
Be able to deploy the database the first time

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_alembic/static/versions/1da396a88908_move_user_table_to_static_schema.py
+++ b/c2cgeoportal/scaffolds/update/CONST_alembic/static/versions/1da396a88908_move_user_table_to_static_schema.py
@@ -34,6 +34,12 @@ Revises: 3f89a7d71a5e
 Create Date: 2015-02-20 14:09:04.875390
 """
 
+try:
+    from hashlib import sha1
+    sha1  # suppress pyflakes warning
+except ImportError:  # pragma: no cover
+    from sha import new as sha1
+
 from alembic import op, context
 from sqlalchemy import Column, ForeignKey
 from sqlalchemy.types import Integer, String, Unicode, Boolean
@@ -82,23 +88,31 @@ def upgrade():
             )
         )
 
-    op.execute(
-        'INSERT INTO %(staticschema)s.user '
-        '(type, username, password, email, is_password_changed, role_name%(parent_column)s) ('
-        'SELECT u.type, u.username, u.password, u.email, '
-        'u.is_password_changed, r.name%(parent_select)s '
-        'FROM %(schema)s.user AS u '
-        'LEFT OUTER JOIN %(schema)s.role AS r ON (r.id = u.role_id) %(parent_join)s'
-        ')' % {
-            'staticschema': staticschema,
-            'schema': schema,
-            'parent_select': parent_select,
-            'parent_column': parent_column,
-            'parent_join': parent_join,
-        }
-    )
-
-    op.drop_table('user', schema=schema)
+    try:
+        op.execute(
+            'INSERT INTO %(staticschema)s.user '
+            '(type, username, password, email, is_password_changed, role_name%(parent_column)s) ('
+            'SELECT u.type, u.username, u.password, u.email, '
+            'u.is_password_changed, r.name%(parent_select)s '
+            'FROM %(schema)s.user AS u '
+            'LEFT OUTER JOIN %(schema)s.role AS r ON (r.id = u.role_id) %(parent_join)s'
+            ')' % {
+                'staticschema': staticschema,
+                'schema': schema,
+                'parent_select': parent_select,
+                'parent_column': parent_column,
+                'parent_join': parent_join,
+            }
+        )
+        op.drop_table('user', schema=schema)
+    except:
+        op.execute(
+            "INSERT INTO %(staticschema)s.user (type, username, email, password, role) "
+            "VALUES ( 'user', 'admin', 'info@example.com', '%(pass)s', 'role_admin')" % {
+                'staticschema': staticschema,
+                'pass': sha1('admin').hexdigest()
+            }
+        )
 
 
 def downgrade():


### PR DESCRIPTION
Actually when we create a new project it will:
* Apply the main scripts who will create the user table in the main schema.
* Apply the static scripts who will move the user table from the main to the static schema.

And when we deploy the application on an empty database it will:
* Dump restore the main schema to the destination schema (that's don't have a user table)
* Apply the static scripts who will try to move the user table from the main to the static schema... => :-/