### PR TITLE
Set const vars layers to empty dict

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_vars.yaml_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_vars.yaml_tmpl
@@ -219,7 +219,7 @@ vars:
     raster:
 
     # Used by enumeration in the query builder
-    layers:
+    layers: {}
 
     # Used to send an email on password reset
     reset_password:


### PR DESCRIPTION
Avoid "NoneType is not iterable" error in : 
```
def _get_layers_enum(self):
        layers_enum = {}
        if "enum" in self.settings.get("layers", {}):
```
