### PR TITLE
Add metadata 'opacity'

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_vars.yaml_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_vars.yaml_tmpl
@@ -171,6 +171,8 @@ vars:
           type: float
         - name: minResolution
           type: float
+        - name: opacity
+          type: float
         - name: thumbnail
           type: url
         - name: copyable


### PR DESCRIPTION
For: https://github.com/camptocamp/c2cgeoportal/wiki/Spec-%232804-Pre-defined-opacity-for-WMS-WMTS

(I'l do it manually in the demo)

We should add documentation about that... but where ?
(I add it this question in specs)