### PR TITLE
Less Windows requirements

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_requirements.txt
+++ b/c2cgeoportal/scaffolds/update/CONST_requirements.txt
@@ -3,9 +3,6 @@
 # missing dependency of formalchemy
 couchdbkit==0.6.5
 http-parser==0.8.3
-Pillow==3.4.2
-psycopg2==2.6.2
-pyproj==1.9.5.1
 restkit==4.2.2
 Shapely==1.5.17
 Pygments==2.1.3

--- a/c2cgeoportal/scaffolds/update/CONST_requirements_windows.txt
+++ b/c2cgeoportal/scaffolds/update/CONST_requirements_windows.txt
@@ -1,6 +1,3 @@
 -r CONST_versions_requirements.txt
-wheels/psycopg2-2.6.1-cp27-none-win32.whl
 wheels/Shapely-1.5.13-cp27-none-win32.whl
-wheels/Pillow-3.1.0-cp27-none-win32.whl
-wheels/pyproj-1.9.5-cp27-none-win32.whl
 -e .

--- a/c2cgeoportal/scaffolds/update/CONST_versions_requirements.txt
+++ b/c2cgeoportal/scaffolds/update/CONST_versions_requirements.txt
@@ -22,9 +22,12 @@ papyrus==2.2
 Paste==2.0.3
 PasteDeploy==1.5.2
 PasteScript==2.0.2
+Pillow==3.4.2
 polib==1.0.8
 postmarkup==1.2.2
+psycopg2==2.6.2
 pykwalify==1.5.2
+pyproj==1.9.5.1
 pyramid-chameleon==0.3
 pyramid-debugtoolbar==3.0.5
 pyramid-mako==1.0.2

--- a/doc/integrator/requirements.rst
+++ b/doc/integrator/requirements.rst
@@ -84,9 +84,7 @@ Python
 ^^^^^^
 
 * Install Microsoft Visual C++ Compiler for Python 2.7 (http://aka.ms/vcpython27)
-* Install pip, go to https://pip.pypa.io/en/latest/installing.html and download get-pip.py
-* Open a batch console (cmd), and run ``python get-pip.py``
-* Once done, run ``pip install virtualenv``
+* Be sure to have at least pip >= 9.x in your project . Using virtualenv >= 15 should resolve that.
 
 Cygwin
 ^^^^^^


### PR DESCRIPTION
Starting with pip >= 9, binary dependencies can now be installed through pip (as long as the wheel enables it...).

I removed the potential dependencies from the specific Linux/Windows requirement files and added their current "Linux" version to the common version file.

I tested all these packages in an independent virtual environment. I did not have any problem running the following commands:

```
Scripts\pip.exe --no-cache-dir install pillow==3.4.2
Scripts\pip.exe --no-cache-dir install psycopg2==2.6.2
Scripts\pip.exe --no-cache-dir install pyproj==1.9.5.1
```

I also updated the documentation.

only Shapely remains problematic...