### PR TITLE
Filter WMS capabilities with correct OGC server

### DIFF
--- a/c2cgeoportal/lib/__init__.py
+++ b/c2cgeoportal/lib/__init__.py
@@ -261,16 +261,22 @@ ogc_server_wms_url_ids = None
 
 def get_ogc_server_wms_url_ids(request):
     from c2cgeoportal.models import DBSession, OGCServer
+    from c2cgeoportal.lib.cacheversion import VersionCache
     global ogc_server_wms_url_ids
-    errors = set()
     if ogc_server_wms_url_ids is None:
-        ogc_server_wms_url_ids = dict()
+        ogc_server_wms_url_ids = VersionCache()
+
+    errors = set()
+    servers = ogc_server_wms_url_ids.get()
+    if servers is None:
+        servers = dict()
+        ogc_server_wms_url_ids.set(servers)
         for ogc_server in DBSession.query(OGCServer).all():
             url = get_url2(ogc_server.name, ogc_server.url, request, errors)
-            if ogc_server_wms_url_ids.get(url) is None:
-                ogc_server_wms_url_ids[url] = []
-            ogc_server_wms_url_ids.get(url).append(ogc_server.id)
-    return ogc_server_wms_url_ids
+            if servers.get(url) is None:
+                servers[url] = []
+            servers.get(url).append(ogc_server.id)
+    return servers
 
 
 ogc_server_wfs_url_ids = None
@@ -278,16 +284,22 @@ ogc_server_wfs_url_ids = None
 
 def get_ogc_server_wfs_url_ids(request):
     from c2cgeoportal.models import DBSession, OGCServer
+    from c2cgeoportal.lib.cacheversion import VersionCache
     global ogc_server_wfs_url_ids
-    errors = set()
     if ogc_server_wfs_url_ids is None:
-        ogc_server_wfs_url_ids = dict()
+        ogc_server_wfs_url_ids = VersionCache()
+
+    errors = set()
+    servers = ogc_server_wfs_url_ids.get()
+    if servers is None:
+        servers = dict()
+        ogc_server_wfs_url_ids.set(servers)
         for ogc_server in DBSession.query(OGCServer).all():
             url = get_url2(ogc_server.name, ogc_server.url_wfs, request, errors)
-            if ogc_server_wfs_url_ids.get(url) is None:
-                ogc_server_wfs_url_ids[url] = []
-            ogc_server_wfs_url_ids.get(url).append(ogc_server.id)
-    return ogc_server_wfs_url_ids
+            if servers.get(url) is None:
+                servers[url] = []
+            servers.get(url).append(ogc_server.id)
+    return servers
 
 
 def _get_layers_query(role_id, what):

--- a/c2cgeoportal/lib/__init__.py
+++ b/c2cgeoportal/lib/__init__.py
@@ -295,7 +295,7 @@ def get_ogc_server_wfs_url_ids(request):
         servers = dict()
         ogc_server_wfs_url_ids.set(servers)
         for ogc_server in DBSession.query(OGCServer).all():
-            url = get_url2(ogc_server.name, ogc_server.url_wfs, request, errors)
+            url = get_url2(ogc_server.name, ogc_server.url_wfs or ogc_server.url, request, errors)
             if servers.get(url) is None:
                 servers[url] = []
             servers.get(url).append(ogc_server.id)

--- a/c2cgeoportal/lib/cacheversion.py
+++ b/c2cgeoportal/lib/cacheversion.py
@@ -66,3 +66,18 @@ class CachebusterTween:
             response.headers["Access-Control-Allow-Headers"] = "X-Requested-With, Content-Type"
 
         return response
+
+
+class VersionCache:
+    _value = None
+    _cache = None
+
+    def uptodate(self):
+        return self._cache == get_cache_version()
+
+    def get(self):
+        return self._value if self.uptodate() else None
+
+    def set(self, value):
+        self._value = value
+        self._cache = get_cache_version()

--- a/c2cgeoportal/lib/filter_capabilities.py
+++ b/c2cgeoportal/lib/filter_capabilities.py
@@ -123,6 +123,13 @@ def wms_structure(wms_url, host):
         log.exception(error)
         raise HTTPBadGateway(error)
 
+    except SyntaxError:  # pragma: no cover
+        error = "WARNING! an error occured while trying to " \
+            "read the mapfile and recover the themes."
+        error = "{0!s}\nurl: {1!s}\nxml:\n{2!s}".format(error, wms_url, content)
+        log.exception(error)
+        raise HTTPBadGateway(error)
+
 
 def enable_proxies(proxies):  # pragma: no cover
     old_prepare_input_source = saxutils.prepare_input_source

--- a/c2cgeoportal/lib/filter_capabilities.py
+++ b/c2cgeoportal/lib/filter_capabilities.py
@@ -161,14 +161,17 @@ def enable_proxies(proxies):  # pragma: no cover
     saxutils.prepare_input_source = caching_prepare_input_source
 
 
-def filter_capabilities(content, role_id, wms, wms_url, headers, proxies, request):
+def filter_capabilities(content, role_id, wms, url, headers, proxies, request):
 
     if proxies:  # pragma: no cover
         enable_proxies(proxies)
 
-    wms_structure_ = wms_structure(wms_url, headers.get("Host"))
+    wms_structure_ = wms_structure(url, headers.get("Host"))
 
-    ogc_server_ids = get_ogc_server_wms_url_ids(request).get(wms_url)
+    ogc_server_ids = (
+        get_ogc_server_wms_url_ids(request) if wms else
+        get_ogc_server_wfs_url_ids(request)
+    ).get(url)
     gmf_private_layers = copy.copy(get_private_layers(ogc_server_ids))
     for id_ in get_protected_layers(role_id, ogc_server_ids).keys():
         if id_ in gmf_private_layers:

--- a/c2cgeoportal/lib/functionality.py
+++ b/c2cgeoportal/lib/functionality.py
@@ -66,9 +66,10 @@ FUNCTIONALITIES_TYPES = None
 
 
 def get_functionality(name, request):
+    global FUNCTIONALITIES_TYPES
+
     result = []
     errors = set()
-    global FUNCTIONALITIES_TYPES
     if FUNCTIONALITIES_TYPES is None:
         FUNCTIONALITIES_TYPES = get_types_map(
             request.registry.settings.get("admin_interface", {})

--- a/c2cgeoportal/tests/functional/__init__.py
+++ b/c2cgeoportal/tests/functional/__init__.py
@@ -87,6 +87,8 @@ def cleanup_db():
     DBSession.query(Shorturl).delete()
     transaction.commit()
 
+    caching.invalidate_region()
+
 
 def set_up_common():
     c2cgeoportal.schema = "main"
@@ -109,8 +111,6 @@ def tear_down_common():
 
     import sqlahelper
     sqlahelper.reset()
-
-    caching.invalidate_region()
 
 
 def create_default_ogcserver():

--- a/c2cgeoportal/tests/functional/__init__.py
+++ b/c2cgeoportal/tests/functional/__init__.py
@@ -28,7 +28,8 @@
 # either expressed or implied, of the FreeBSD Project.
 
 
-"""Pyramid application test package
+"""
+Pyramid application test package
 """
 
 import os
@@ -63,65 +64,67 @@ if os.path.exists(configfile):
 caching.init_region({"backend": "dogpile.cache.memory"})
 
 
+def cleanup_db():
+    """ Cleanup the database """
+    import transaction
+    from c2cgeoportal.models import DBSession, OGCServer, TreeItem, Role, User, RestrictionArea, \
+        Interface, Functionality, FullTextSearch, Shorturl
+
+    transaction.commit()
+    for ra in DBSession.query(RestrictionArea).all():
+        ra.roles = []
+        DBSession.delete(ra)
+    for ti in DBSession.query(TreeItem).all():
+        DBSession.delete(ti)
+    DBSession.query(OGCServer).delete()
+    DBSession.query(Interface).delete()
+    for r in DBSession.query(Role).all():
+        r.functionnalities = []
+        DBSession.delete(r)
+    DBSession.query(User).delete()
+    DBSession.query(Functionality).delete()
+    DBSession.query(FullTextSearch).delete()
+    DBSession.query(Shorturl).delete()
+    transaction.commit()
+
+
 def set_up_common():
     c2cgeoportal.schema = "main"
     c2cgeoportal.srid = 21781
     functionality.FUNCTIONALITIES_TYPES = None
 
-    # if test.in does not exist (because the z3c.recipe.filetemplate
-    # part hasn"t been executed) then db_url is None
-    if db_url is None:  # pragma: no cover
-        return
-
-    # verify that we have a working database connection before going
-    # forward
+    # verify that we have a working database connection before going forward
     from sqlalchemy import create_engine
-    from sqlalchemy.exc import OperationalError
     engine = create_engine(db_url)
-    try:
-        engine.connect()
-    except OperationalError:  # pragma: no cover
-        return
+    engine.connect()
 
     import sqlahelper
     sqlahelper.add_engine(engine)
 
+    cleanup_db()
+
 
 def tear_down_common():
-
-    functionality.FUNCTIONALITIES_TYPES = None
-
-    # if test.in does not exist (because the z3c.recipe.filetemplate
-    # part hasn't been executed) then db_url is None
-    if db_url is None:  # pragma: no cover
-        return
+    cleanup_db()
 
     import sqlahelper
     sqlahelper.reset()
-
-    # verify that we have a working database connection before going
-    # forward
-    from sqlalchemy import create_engine
-    from sqlalchemy.exc import OperationalError
-    engine = create_engine(db_url)
-    try:
-        engine.connect()
-    except OperationalError:  # pragma: no cover
-        return
 
     caching.invalidate_region()
 
 
 def create_default_ogcserver():
-    from c2cgeoportal.models import DBSession, OGCServer
-    DBSession.query(OGCServer).delete()
     import transaction
+    from c2cgeoportal.models import DBSession, OGCServer
+
     transaction.commit()
     ogcserver = OGCServer(name="__test_ogc_server")
     ogcserver.url = mapserv
     ogcserver_external = OGCServer(name="__test_external_ogc_server")
     ogcserver_external.url = mapserv + "external=true&"
     DBSession.add_all([ogcserver, ogcserver_external])
+    transaction.commit()
+
     return ogcserver, ogcserver_external
 
 

--- a/c2cgeoportal/tests/functional/c2cgeoportal_test.map.mako
+++ b/c2cgeoportal/tests/functional/c2cgeoportal_test.map.mako
@@ -430,6 +430,21 @@ MAP
         END
     END
 
+% for n in range(10):
+    LAYER
+        NAME "__test_private_layer${n}"
+        EXTENT 420000 40500 839000 306400
+        TYPE POINT
+        STATUS ON
+        CONNECTIONTYPE postgis
+        CONNECTION "user=${dbuser} password=${dbpassword} dbname=${db} host=${dbhost}"
+        DATA "the_geom from main.testpoint using unique id using srid=21781"
+        PROJECTION
+           "init=epsg:21781"
+        END
+    END
+% endfor
+
     LAYER
         NAME "__test_public_layer_bis"
         EXTENT 420000 40500 839000 306400

--- a/c2cgeoportal/tests/functional/test_entry.py
+++ b/c2cgeoportal/tests/functional/test_entry.py
@@ -38,12 +38,11 @@ import json
 from geoalchemy2 import WKTElement
 from pyramid import testing
 
-from c2cgeoportal.lib import functionality
 from c2cgeoportal.tests.functional import (  # noqa
     tear_down_common as tearDownModule,
     set_up_common as setUpModule,
     mapserv_url, mapserv, host, create_dummy_request,
-    create_default_ogcserver,
+    create_default_ogcserver, cleanup_db
 )
 
 import logging
@@ -58,15 +57,14 @@ class TestEntryView(TestCase):
         # https://docs.python.org/2/library/unittest.html#unittest.TestCase.maxDiff
         self.maxDiff = None
 
-        functionality.FUNCTIONALITIES_TYPES = None
-
         from c2cgeoportal.models import DBSession, User, Role, LayerV1, \
             RestrictionArea, Theme, LayerGroup, Functionality, Interface, \
             LayerWMS, OGCServer, FullTextSearch, OGCSERVER_TYPE_GEOSERVER, OGCSERVER_AUTH_GEOSERVER
         from sqlalchemy import func
 
+        cleanup_db()
+
         role1 = Role(name=u"__test_role1")
-        role1.id = 999
         user1 = User(username=u"__test_user1", password=u"__test_user1", role=role1)
         user1.email = "__test_user1@example.com"
 
@@ -184,42 +182,17 @@ class TestEntryView(TestCase):
             entry1, entry2, entry3,
         ])
 
+        DBSession.flush()
+
+        self.role1_id = role1.id
+
         transaction.commit()
 
     @staticmethod
     def tearDown():  # noqa
         testing.tearDown()
 
-        functionality.FUNCTIONALITIES_TYPES = None
-
-        from c2cgeoportal.models import DBSession, User, Role, TreeItem, \
-            RestrictionArea, Interface, OGCServer
-
-        DBSession.query(User).filter(User.username == "__test_user1").delete()
-        DBSession.query(User).filter(User.username == "__test_user2").delete()
-
-        ra = DBSession.query(RestrictionArea).filter(
-            RestrictionArea.name == "__test_ra1"
-        ).one()
-        ra.roles = []
-        DBSession.delete(ra)
-        ra = DBSession.query(RestrictionArea).filter(
-            RestrictionArea.name == "__test_ra2"
-        ).one()
-        ra.roles = []
-        DBSession.delete(ra)
-
-        DBSession.query(Role).filter(Role.name == "__test_role1").delete()
-        DBSession.query(Role).filter(Role.name == "__test_role2").delete()
-
-        for item in DBSession.query(TreeItem).all():
-            DBSession.delete(item)
-        DBSession.query(Interface).filter(
-            Interface.name == "desktop"
-        ).delete()
-        DBSession.query(OGCServer).delete()
-
-        transaction.commit()
+        cleanup_db()
 
     #
     # login/logout tests
@@ -250,7 +223,7 @@ class TestEntryView(TestCase):
             "username": "__test_user1",
             "is_password_changed": False,
             "role_name": "__test_role1",
-            "role_id": 999,
+            "role_id": self.role1_id,
             "functionalities": {},
         })
 
@@ -308,12 +281,12 @@ class TestEntryView(TestCase):
         response = Entry(request).login()
         self.assertEquals(response.status_int, 200)
         self.assertEquals(json.loads(response.body), {
-            "success": True,
-            "username": "__test_user1",
-            "is_password_changed": True,
-            "role_name": "__test_role1",
-            "role_id": 999,
-            "functionalities": {},
+            u"success": True,
+            u"username": u"__test_user1",
+            u"is_password_changed": True,
+            u"role_name": u"__test_role1",
+            u"role_id": self.role1_id,
+            u"functionalities": {},
         })
 
     #

--- a/c2cgeoportal/tests/functional/test_entry.py
+++ b/c2cgeoportal/tests/functional/test_entry.py
@@ -637,6 +637,16 @@ class TestEntryView(TestCase):
             "test_minscale",
             "test_maxscale",
             "test_boothscale",
+            "__test_private_layer0",
+            "__test_private_layer1",
+            "__test_private_layer2",
+            "__test_private_layer3",
+            "__test_private_layer4",
+            "__test_private_layer5",
+            "__test_private_layer6",
+            "__test_private_layer7",
+            "__test_private_layer8",
+            "__test_private_layer9",
         }
 
         self.assertEquals(set(json.loads(response["WFSTypes"])), result)

--- a/c2cgeoportal/tests/functional/test_layers.py
+++ b/c2cgeoportal/tests/functional/test_layers.py
@@ -34,7 +34,7 @@ from unittest import TestCase
 from c2cgeoportal.tests.functional import (  # noqa
     tear_down_common as tearDownModule,
     set_up_common as setUpModule,
-    create_dummy_request
+    create_dummy_request, cleanup_db
 )
 
 
@@ -47,11 +47,10 @@ class TestLayers(TestCase):
     def setUp(self):  # noqa
         import sqlahelper
         import transaction
-        from c2cgeoportal.models import DBSession, Role, User, Interface, TreeItem
+        from c2cgeoportal.models import DBSession, Role, User, Interface
         from c2cgeoportal.lib.dbreflection import init
 
-        for treeitem in DBSession.query(TreeItem).all():
-            DBSession.delete(treeitem)
+        cleanup_db()
 
         self.metadata = None
         self.layer_ids = []
@@ -78,29 +77,8 @@ class TestLayers(TestCase):
 
     def tearDown(self):  # noqa
         import transaction
-        from c2cgeoportal.models import DBSession, Role, User,  \
-            TreeItem, RestrictionArea, Interface
 
-        transaction.commit()
-
-        for treeitem in DBSession.query(TreeItem).all():
-            DBSession.delete(treeitem)
-
-        DBSession.query(User).filter(
-            User.username == u"__test_user"
-        ).delete()
-        r = DBSession.query(Role).filter(
-            Role.name == u"__test_role"
-        ).one()
-        r.restrictionareas = []
-        DBSession.delete(r)
-        DBSession.query(RestrictionArea).filter(
-            RestrictionArea.name == u"__test_ra"
-        ).delete()
-
-        DBSession.query(Interface).filter(
-            Interface.name == u"main"
-        ).delete()
+        cleanup_db()
 
         if self._tables is not None:
             for table in self._tables[::-1]:
@@ -425,7 +403,7 @@ class TestLayers(TestCase):
 
         from c2cgeoportal.models import DBSession, User
 
-        self.assertEquals(DBSession.query(User.username).all(), [(u"admin",), (u"__test_user",)])
+        self.assertEquals(DBSession.query(User.username).all(), [(u"__test_user",)])
 
         metadatas = [
             Metadata("lastUpdateDateColumn", "last_update_date"),

--- a/c2cgeoportal/tests/functional/test_mapserverproxy.py
+++ b/c2cgeoportal/tests/functional/test_mapserverproxy.py
@@ -200,6 +200,10 @@ class TestMapserverproxyView(TestCase):
 
         self.id_lausanne = p1.id
         self.id_paris = p3.id
+        self.ogc_server_id = ogc_server_internal.id
+        self.role1_id = role1.id
+        self.role2_id = role2.id
+        self.role3_id = role3.id
 
         transaction.commit()
 
@@ -557,6 +561,67 @@ class TestMapserverproxyView(TestCase):
         request.user = None if username is None else \
             DBSession.query(User).filter_by(username=username).one()
         return request
+
+    def test_private_layer(self):
+        from c2cgeoportal.lib.filter_capabilities import get_private_layers
+
+        pl = get_private_layers([self.ogc_server_id])
+        self.assertEquals(
+            {pl[l].name for l in pl},
+            {"testpoint_protected", "testpoint_protected_query_with_collect"}
+        )
+
+    def test_protected_layers1(self):
+        from c2cgeoportal.lib.filter_capabilities import get_protected_layers
+
+        pl = get_protected_layers(self.role1_id, [self.ogc_server_id])
+        self.assertEquals(
+            {pl[l].name for l in pl},
+            {"testpoint_protected", "testpoint_protected_query_with_collect"}
+        )
+
+    def test_protected_layers2(self):
+        from c2cgeoportal.lib.filter_capabilities import get_protected_layers
+
+        pl = get_protected_layers(self.role2_id, [self.ogc_server_id])
+        self.assertEquals(
+            {pl[l].name for l in pl},
+            {"testpoint_protected", "testpoint_protected_query_with_collect"}
+        )
+
+    def test_protected_layers3(self):
+        from c2cgeoportal.lib.filter_capabilities import get_protected_layers
+
+        pl = get_protected_layers(self.role3_id, [self.ogc_server_id])
+        self.assertEquals(
+            {pl[l].name for l in pl},
+            {"testpoint_protected", "testpoint_protected_query_with_collect"}
+        )
+
+    def test_writable_layers1(self):
+        from c2cgeoportal.lib.filter_capabilities import get_writable_layers
+
+        pl = get_writable_layers(self.role1_id, [self.ogc_server_id])
+        self.assertEquals(
+            {pl[l].name for l in pl}, set()
+        )
+
+    def test_writable_layers2(self):
+        from c2cgeoportal.lib.filter_capabilities import get_writable_layers
+
+        pl = get_writable_layers(self.role2_id, [self.ogc_server_id])
+        self.assertEquals(
+            {pl[l].name for l in pl}, set()
+        )
+
+    def test_writable_layers3(self):
+        from c2cgeoportal.lib.filter_capabilities import get_writable_layers
+
+        pl = get_writable_layers(self.role3_id, [self.ogc_server_id])
+        self.assertEquals(
+            {pl[l].name for l in pl},
+            {"testpoint_protected_query_with_collect"}
+        )
 
     def test_wms_get_capabilities(self):
         from c2cgeoportal.views.mapserverproxy import MapservProxy

--- a/c2cgeoportal/tests/functional/test_mapserverproxy_capabilities.py
+++ b/c2cgeoportal/tests/functional/test_mapserverproxy_capabilities.py
@@ -1,0 +1,346 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2013-2017, Camptocamp SA
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# The views and conclusions contained in the software and documentation are those
+# of the authors and should not be interpreted as representing official policies,
+# either expressed or implied, of the FreeBSD Project.
+
+
+import os
+from unittest2 import TestCase
+import transaction
+from c2cgeoportal.tests.functional import (  # noqa
+    tear_down_common as tearDownModule,
+    set_up_common as setUpModule,
+    create_dummy_request, mapserv, create_default_ogcserver, cleanup_db,
+)
+
+
+class TestMapserverproxyCapabilities(TestCase):
+
+    def setUp(self):  # noqa
+        self.maxDiff = None
+
+        from c2cgeoportal.models import User, Role, LayerWMS, RestrictionArea, \
+            Interface, DBSession, OGCServer, \
+            OGCSERVER_TYPE_MAPSERVER, OGCSERVER_AUTH_STANDARD
+
+        cleanup_db()
+        create_default_ogcserver()
+
+        ogcserver_jpeg = OGCServer(name="__test_ogc_server_jpeg")
+        ogcserver_jpeg.url = mapserv
+        ogcserver_jpeg.image_type = "image/jpeg"
+        ogcserver_jpeg.type = OGCSERVER_TYPE_MAPSERVER
+        ogcserver_jpeg.auth = OGCSERVER_AUTH_STANDARD
+
+        ogcserver_png = OGCServer(name="__test_ogc_server_png")
+        ogcserver_png.url = mapserv
+        ogcserver_png.image_type = "image/png"
+        ogcserver_png.type = OGCSERVER_TYPE_MAPSERVER
+        ogcserver_png.auth = OGCSERVER_AUTH_STANDARD
+
+        ogcserver_wfs1 = OGCServer(name="__test_ogc_server_wfs1")
+        ogcserver_wfs1.url = mapserv
+        ogcserver_wfs1.url_wfs = "config://srv"
+        ogcserver_wfs1.image_type = "image/png"
+        ogcserver_wfs1.type = OGCSERVER_TYPE_MAPSERVER
+        ogcserver_wfs1.auth = OGCSERVER_AUTH_STANDARD
+
+        ogcserver_wfs2 = OGCServer(name="__test_ogc_server_wfs2")
+        ogcserver_wfs2.url = "config://srv"
+        ogcserver_wfs2.url_wfs = mapserv
+        ogcserver_wfs2.image_type = "image/png"
+        ogcserver_wfs2.type = OGCSERVER_TYPE_MAPSERVER
+        ogcserver_wfs2.auth = OGCSERVER_AUTH_STANDARD
+
+        role = Role(name=u"__test_role", description=u"__test_role")
+        user = User(username=u"__test_user", password=u"__test_user")
+        user.role_name = u"__test_role"
+
+        main = Interface(name=u"main")
+
+        layer1 = LayerWMS(u"__test_layer1", public=False)
+        layer1.layer = u"__test_private_layer1"
+        layer1.ogc_server = ogcserver_jpeg
+        layer1.interfaces = [main]
+
+        layer2 = LayerWMS(u"__test_layer2", public=False)
+        layer2.layer = u"__test_private_layer2"
+        layer2.ogc_server = ogcserver_png
+        layer2.interfaces = [main]
+
+        layer3 = LayerWMS(u"__test_layer3", public=False)
+        layer3.layer = u"__test_private_layer3"
+        layer3.ogc_server = ogcserver_wfs1
+        layer3.interfaces = [main]
+
+        layer4 = LayerWMS(u"__test_layer4", public=False)
+        layer4.layer = u"__test_private_layer4"
+        layer4.ogc_server = ogcserver_wfs2
+        layer4.interfaces = [main]
+
+        restricted_area = RestrictionArea(u"__test_ra", u"", [layer1, layer2, layer3, layer4], [role])
+
+        DBSession.add_all([
+            user, restricted_area
+        ])
+        transaction.commit()
+
+    @staticmethod
+    def tearDown():  # noqa
+        cleanup_db()
+
+    @staticmethod
+    def _wms_get_capabilities(ogcserver, service="wms", username=None):
+        from c2cgeoportal.models import DBSession, User
+        from c2cgeoportal.views.mapserverproxy import MapservProxy
+
+        request = create_dummy_request({
+            "admin_interface": {
+                "available_functionalities": [
+                    "mapserver_substitution",
+                    "print_template",
+                ]
+            },
+            "servers": {
+                "srv": "http://example.com"
+            }
+        })
+        request.params = {"map": os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "c2cgeoportal_test.map"
+        )}
+        request.user = None if username is None else \
+            DBSession.query(User).filter_by(username=username).one()
+        request.params.update(dict(
+            service=service,
+            version="1.1.1",
+            request="getcapabilities",
+            ogcserver=ogcserver
+        ))
+        return MapservProxy(request).proxy()
+
+    @staticmethod
+    def _wms_get_capabilities_config(ogcserver, service="wms", username=None):
+        from c2cgeoportal.models import DBSession, User
+        from c2cgeoportal.views.mapserverproxy import MapservProxy
+
+        request = create_dummy_request({
+            "admin_interface": {
+                "available_functionalities": [
+                    "mapserver_substitution",
+                    "print_template",
+                ]
+            },
+            "servers": {
+                "srv": "http://example.com"
+            },
+            "mapserverproxy": {
+                "default_ogc_server": ogcserver,
+            },
+        })
+        request.params = {"map": os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "c2cgeoportal_test.map"
+        )}
+        request.user = None if username is None else \
+            DBSession.query(User).filter_by(username=username).one()
+        request.params.update(dict(
+            service=service,
+            version="1.1.1",
+            request="getcapabilities",
+        ))
+        return MapservProxy(request).proxy()
+
+    def test_wms_osjpeg(self):
+        response = self._wms_get_capabilities("__test_ogc_server_jpeg")
+        self.assertTrue(response.body.find("<Name>__test_private_layer1</Name>") < 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer2</Name>") < 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer3</Name>") < 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer4</Name>") > 0)
+
+    def test_wms_osjpeg_auth(self):
+        response = self._wms_get_capabilities("__test_ogc_server_jpeg", username="__test_user")
+        self.assertTrue(response.body.find("<Name>__test_private_layer1</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer2</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer3</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer4</Name>") > 0)
+
+    def test_wfs_osjpeg(self):
+        response = self._wms_get_capabilities("__test_ogc_server_jpeg", "wfs")
+        self.assertTrue(response.body.find("<Name>__test_private_layer1</Name>") < 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer2</Name>") < 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer3</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer4</Name>") < 0)
+
+    def test_wfs_osjpeg_auth(self):
+        response = self._wms_get_capabilities("__test_ogc_server_jpeg", "wfs", username="__test_user")
+        self.assertTrue(response.body.find("<Name>__test_private_layer1</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer2</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer3</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer4</Name>") > 0)
+
+    def test_wms_ospng(self):
+        response = self._wms_get_capabilities("__test_ogc_server_png")
+        self.assertTrue(response.body.find("<Name>__test_private_layer1</Name>") < 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer2</Name>") < 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer3</Name>") < 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer4</Name>") > 0)
+
+    def test_wms_ospng_auth(self):
+        response = self._wms_get_capabilities("__test_ogc_server_png", username="__test_user")
+        self.assertTrue(response.body.find("<Name>__test_private_layer1</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer2</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer3</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer4</Name>") > 0)
+
+    def test_wfs_ospng(self):
+        response = self._wms_get_capabilities("__test_ogc_server_png", "wfs")
+        self.assertTrue(response.body.find("<Name>__test_private_layer1</Name>") < 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer2</Name>") < 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer3</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer4</Name>") < 0)
+
+    def test_wfs_ospng_auth(self):
+        response = self._wms_get_capabilities("__test_ogc_server_png", "wfs", username="__test_user")
+        self.assertTrue(response.body.find("<Name>__test_private_layer1</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer2</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer3</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer4</Name>") > 0)
+
+    def test_wms_oswfs1(self):
+        response = self._wms_get_capabilities("__test_ogc_server_wfs1")
+        self.assertTrue(response.body.find("<Name>__test_private_layer1</Name>") < 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer2</Name>") < 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer3</Name>") < 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer4</Name>") > 0)
+
+    def test_wms_oswfs1_auth(self):
+        response = self._wms_get_capabilities("__test_ogc_server_wfs1", username="__test_user")
+        self.assertTrue(response.body.find("<Name>__test_private_layer1</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer2</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer3</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer4</Name>") > 0)
+
+    def test_wfs_oswfs2(self):
+        response = self._wms_get_capabilities("__test_ogc_server_wfs2", "wfs")
+        self.assertTrue(response.body.find("<Name>__test_private_layer1</Name>") < 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer2</Name>") < 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer3</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer4</Name>") < 0)
+
+    def test_wfs_oswfs2_auth(self):
+        response = self._wms_get_capabilities("__test_ogc_server_wfs2", "wfs", username="__test_user")
+        self.assertTrue(response.body.find("<Name>__test_private_layer1</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer2</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer3</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer4</Name>") > 0)
+
+    # # # CONFIG # # #
+
+    def test_wms_osjpeg_config(self):
+        response = self._wms_get_capabilities_config("__test_ogc_server_jpeg")
+        self.assertTrue(response.body.find("<Name>__test_private_layer1</Name>") < 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer2</Name>") < 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer3</Name>") < 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer4</Name>") > 0)
+
+    def test_wms_osjpeg_auth_config(self):
+        response = self._wms_get_capabilities_config("__test_ogc_server_jpeg", username="__test_user")
+        self.assertTrue(response.body.find("<Name>__test_private_layer1</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer2</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer3</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer4</Name>") > 0)
+
+    def test_wfs_osjpeg_config(self):
+        response = self._wms_get_capabilities_config("__test_ogc_server_jpeg", "wfs")
+        self.assertTrue(response.body.find("<Name>__test_private_layer1</Name>") < 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer2</Name>") < 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer3</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer4</Name>") < 0)
+
+    def test_wfs_osjpeg_auth_config(self):
+        response = self._wms_get_capabilities_config("__test_ogc_server_jpeg", "wfs", username="__test_user")
+        self.assertTrue(response.body.find("<Name>__test_private_layer1</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer2</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer3</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer4</Name>") > 0)
+
+    def test_wms_ospng_config(self):
+        response = self._wms_get_capabilities_config("__test_ogc_server_png")
+        self.assertTrue(response.body.find("<Name>__test_private_layer1</Name>") < 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer2</Name>") < 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer3</Name>") < 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer4</Name>") > 0)
+
+    def test_wms_ospng_auth_config(self):
+        response = self._wms_get_capabilities_config("__test_ogc_server_png", username="__test_user")
+        self.assertTrue(response.body.find("<Name>__test_private_layer1</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer2</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer3</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer4</Name>") > 0)
+
+    def test_wfs_ospng_config(self):
+        response = self._wms_get_capabilities_config("__test_ogc_server_png", "wfs")
+        self.assertTrue(response.body.find("<Name>__test_private_layer1</Name>") < 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer2</Name>") < 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer3</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer4</Name>") < 0)
+
+    def test_wfs_ospng_auth_config(self):
+        response = self._wms_get_capabilities_config("__test_ogc_server_png", "wfs", username="__test_user")
+        self.assertTrue(response.body.find("<Name>__test_private_layer1</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer2</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer3</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer4</Name>") > 0)
+
+    def test_wms_oswfs1_config(self):
+        response = self._wms_get_capabilities_config("__test_ogc_server_wfs1")
+        self.assertTrue(response.body.find("<Name>__test_private_layer1</Name>") < 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer2</Name>") < 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer3</Name>") < 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer4</Name>") > 0)
+
+    def test_wms_oswfs1_auth_config(self):
+        response = self._wms_get_capabilities_config("__test_ogc_server_wfs1", username="__test_user")
+        self.assertTrue(response.body.find("<Name>__test_private_layer1</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer2</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer3</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer4</Name>") > 0)
+
+    def test_wfs_oswfs2_config(self):
+        response = self._wms_get_capabilities_config("__test_ogc_server_wfs2", "wfs")
+        self.assertTrue(response.body.find("<Name>__test_private_layer1</Name>") < 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer2</Name>") < 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer3</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer4</Name>") < 0)
+
+    def test_wfs_oswfs2_auth_config(self):
+        response = self._wms_get_capabilities_config("__test_ogc_server_wfs2", "wfs", username="__test_user")
+        self.assertTrue(response.body.find("<Name>__test_private_layer1</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer2</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer3</Name>") > 0)
+        self.assertTrue(response.body.find("<Name>__test_private_layer4</Name>") > 0)

--- a/c2cgeoportal/views/entry.py
+++ b/c2cgeoportal/views/entry.py
@@ -289,7 +289,7 @@ class Entry:
 
         if role_id is not None:
             query2 = get_protected_layers_query(
-                role_id, self.default_ogc_server.url,
+                role_id, None,
                 what=LayerV1.name if version == 1 else LayerWMS.name,
                 version=version
             )

--- a/c2cgeoportal/views/mapserverproxy.py
+++ b/c2cgeoportal/views/mapserverproxy.py
@@ -103,12 +103,17 @@ class MapservProxy(OGCProxy):
             # send layer_name, but MapServer should not use the DATA
             # string for GetLegendGraphic.
 
-            params["role_id"] = self.user.parent_role.id if self.external else self.user.role.id
+            role = self.user.parent_role if self.external else self.user.role
+            if role is not None:
+                params["role_id"] = role.id
 
-            # In some application we want to display the features owned by a user
-            # than we need his id.
-            if not self.external:
-                params["user_id"] = self.user.id  # pragma: no cover
+                # In some application we want to display the features owned by a user
+                # than we need his id.
+                if not self.external:
+                    params["user_id"] = self.user.id  # pragma: no cover
+            else:  # pragma nocover
+                log.warning(u"The user '{}' has no {}role".format(
+                    self.user.name, "external " if self.external else ""))
 
         # do not allows direct variable substitution
         for k in params.keys():

--- a/c2cgeoportal/views/mapserverproxy.py
+++ b/c2cgeoportal/views/mapserverproxy.py
@@ -203,7 +203,8 @@ class MapservProxy(OGCProxy):
                 content, role_id, self.lower_params.get("service") == "wms",
                 self._get_wms_url(),
                 self.request.headers,
-                self.mapserver_settings.get("proxies")
+                self.mapserver_settings.get("proxies"),
+                self.request
             )
 
         content_type = None

--- a/c2cgeoportal/views/mapserverproxy.py
+++ b/c2cgeoportal/views/mapserverproxy.py
@@ -191,17 +191,16 @@ class MapservProxy(OGCProxy):
         )
         return response
 
-    def _proxy_callback(self, role_id, cache_control, *args, **kwargs):
-        params = kwargs.get("params", {})
+    def _proxy_callback(self, role_id, cache_control, url, params, **kwargs):
         callback = params.get("callback")
         if callback is not None:
             del params["callback"]
-        resp, content = self._proxy(*args, **kwargs)
+        resp, content = self._proxy(url=url, params=params, **kwargs)
 
         if self.lower_params.get("request") == "getcapabilities":
             content = filter_capabilities(
                 content, role_id, self.lower_params.get("service") == "wms",
-                self._get_wms_url(),
+                url,
                 self.request.headers,
                 self.mapserver_settings.get("proxies"),
                 self.request

--- a/c2cgeoportal/views/tinyowsproxy.py
+++ b/c2cgeoportal/views/tinyowsproxy.py
@@ -126,7 +126,7 @@ class TinyOWSProxy(OGCProxy):
         """
 
         writable_layers = set()
-        for gmflayer in get_writable_layers(self.role_id, self.default_ogc_server.url).values():
+        for gmflayer in get_writable_layers(self.role_id, [self.default_ogc_server.id]).values():
             for ogclayer in gmflayer.layer.split(","):
                 writable_layers.add(ogclayer)
         return typenames.issubset(writable_layers)
@@ -142,7 +142,9 @@ class TinyOWSProxy(OGCProxy):
 
         if operation == "getcapabilities":
             content = filter_wfst_capabilities(
-                content, role_id, self.default_ogc_server.url, self.settings.get("proxies")
+                content, role_id,
+                self.default_ogc_server.url_wfs or self.default_ogc_server.url,
+                self.settings.get("proxies"), self.request
             )
 
         content = self._filter_urls(

--- a/doc/developer/server_side.rst
+++ b/doc/developer/server_side.rst
@@ -128,15 +128,8 @@ template at your disposal:
     .. prompt:: bash
 
         sudo -u postgres createdb -E UTF8 -T template0 c2cgeoportal_test
-        sudo -u postgres createlang plpgsql c2cgeoportal_test
         sudo -u postgres psql -d c2cgeoportal_test \
-               -f /usr/share/postgresql/9.1/contrib/postgis-1.5/postgis.sql
-        sudo -u postgres psql -d c2cgeoportal_test \
-               -f /usr/share/postgresql/9.1/contrib/postgis-1.5/spatial_ref_sys.sql
-        sudo -u postgres psql -d c2cgeoportal_test \
-               -c 'GRANT ALL ON geometry_columns TO "www-data";'
-        sudo -u postgres psql -d c2cgeoportal_test \
-               -c 'GRANT SELECT ON spatial_ref_sys TO "www-data";'
+               -c 'CREATE EXTENSION postgis;'
 
     The ``template0`` is needed on Debian and Ubuntu to create a utf-8
     database.
@@ -155,6 +148,15 @@ To create the ``main`` and ``main_static`` schema:
     sudo -u postgres psql -d c2cgeoportal_test -c 'GRANT ALL ON SCHEMA main TO "www-data";'
     sudo -u postgres psql -d c2cgeoportal_test -c 'CREATE SCHEMA main_static;'
     sudo -u postgres psql -d c2cgeoportal_test -c 'GRANT ALL ON SCHEMA main_static TO "www-data";'
+
+Create the tables:
+
+.. prompt:: bash
+
+    make .build/dev-requirements.timestamp c2cgeoportal/tests/functional/alembic.ini \
+        c2cgeoportal/tests/functional/alembic_static.ini
+    .build/venv/bin/alembic --config c2cgeoportal/tests/functional/alembic.ini upgrade head
+    .build/venv/bin/alembic --config c2cgeoportal/tests/functional/alembic_static.ini upgrade head
 
 If you do not use the default variables edit the ``vars.yaml`` and set the ``dbuser``, ``dbpassword``,
 ``dbhost``, ``dbport``, ``db``, and ``mapserv_url`` as appropriate.


### PR DESCRIPTION
Part of #2929 

TODO:
 - [x] Fix DetachedInstanceError: Instance <LayerWMS at 0x7feae2836290> is not bound to a Session; ~~attribute refresh operation cannot proceed -> maybe come frome the `cache_on_argument` It seems to work with a single argument but not with an array  ?~~ -> must to expung objects in session
 - [x] add tests

(I've not tested the things about doing a curl to get capabilities with basic auth.)