### PR TITLE
Fix multi-language mapserverless projects

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -272,12 +272,15 @@ I18N_SOURCE_FILES += $(APP_HTML_FILES) \
 	$(APP_JS_FILES) \
 	$(APP_DIRECTIVES_PARTIALS_FILES) \
 	.build/config.yaml
-ifeq ($(DOCKER),FALSE)
+ifeq ($(DOCKER), FALSE)
 # The theme from the database
 I18N_SOURCE_FILES += development.ini
 endif
-I18N_DEPENDENCIES += $(MAP_FILES) \
-	project.yaml
+I18N_DEPENDENCIES += $(VENV_BIN)/pot-create$(PYTHON_BIN_POSTFIX)
+ifeq (${MAPSERVER}, TRUE)
+I18N_DEPENDENCIES += .build/mapserver.timestamp
+endif
+
 
 # CGXP
 JSBUILD_MAIN_FILES = $(shell $(FIND) $(PACKAGE)/static/lib/cgxp $(PACKAGE)/static/js -name "*.js" -print 2> /dev/null)
@@ -709,13 +712,7 @@ $(PACKAGE)/locale/$(PACKAGE)-$(L10N_SERVER_POSTFIX).pot: \
 	[ ! -f $@ ] || chmod go+r $@
 
 .PRECIOUS: $(PACKAGE)/locale/$(PACKAGE)-$(L10N_CLIENT_POSTFIX).pot
-$(PACKAGE)/locale/$(PACKAGE)-$(L10N_CLIENT_POSTFIX).pot: \
-		lingua-client.cfg \
-		$(I18N_DEPENDENCIES) \
-		$(I18N_SOURCE_FILES) \
-		$(VENV_BIN)/pot-create$(PYTHON_BIN_POSTFIX) \
-		.build/mapserver.timestamp \
-		.build/config.yaml
+$(PACKAGE)/locale/$(PACKAGE)-$(L10N_CLIENT_POSTFIX).pot: lingua-client.cfg $(I18N_DEPENDENCIES) $(I18N_SOURCE_FILES)
 	$(PRERULE_CMD)
 	rm -f $@ # Because of WindowsError, thus only problematic on Windows
 	$(VENV_BIN)/pot-create --config $< --output $@ $(I18N_SOURCE_FILES)
@@ -763,7 +760,7 @@ $(TX_RC):
 .tx/config: .tx/CONST_config_mako $(VENV_BIN)/mako-render$(PYTHON_BIN_POSTFIX) .build/requirements.timestamp
 	$(PRERULE_CMD)
 	PYTHONIOENCODING=UTF-8 $(VENV_BIN)/mako-render \
-		--var "tx_version=$(TX_VERSION)" --var "tx_host=$(TX_HOST)" $< > $@
+		--var "tx_version=$(TX_VERSION)" --var "tx_host=$(TX_HOST)" --var "languages=$(LANGUAGES)" $< > $@
 
 .PRECIOUS: .build/locale/%/LC_MESSAGES/gmf.po
 .build/locale/%/LC_MESSAGES/gmf.po: $(TX_DEPENDENCIES)

--- a/c2cgeoportal/tests/functional/test_mapserverproxy.py
+++ b/c2cgeoportal/tests/functional/test_mapserverproxy.py
@@ -138,14 +138,14 @@ class TestMapserverproxyView(TestCase):
 
         TestPoint.__table__.create(bind=DBSession.bind, checkfirst=True)
 
-        geom = WKTElement("POINT((599910 199955))", srid=21781)
-        p1 = TestPoint(the_geom=geom, name=u"foo", city=u"Lausanne", country=u"Swiss")
-        geom = WKTElement("POINT((599910 200045))", srid=21781)
-        p2 = TestPoint(the_geom=geom, name=u"bar", city=u"Chambéry", country=u"France")
-        geom = WKTElement("POINT((600090 200045))", srid=21781)
-        p3 = TestPoint(the_geom=geom, name=u"éàè", city=u"Paris", country=u"France")
-        geom = WKTElement("POINT((600090 199955))", srid=21781)
-        p4 = TestPoint(the_geom=geom, name=u"123", city=u"Londre", country=u"UK")
+        geom = WKTElement("POINT(599910 199955)", srid=21781)
+        p1 = TestPoint(geom=geom, name=u"foo", city=u"Lausanne", country=u"Swiss")
+        geom = WKTElement("POINT(599910 200045)", srid=21781)
+        p2 = TestPoint(geom=geom, name=u"bar", city=u"Chambéry", country=u"France")
+        geom = WKTElement("POINT(600090 200045)", srid=21781)
+        p3 = TestPoint(geom=geom, name=u"éàè", city=u"Paris", country=u"France")
+        geom = WKTElement("POINT(600090 199955)", srid=21781)
+        p4 = TestPoint(geom=geom, name=u"123", city=u"Londre", country=u"UK")
 
         pt1 = Functionality(name=u"print_template", value=u"1 Wohlen A4 portrait")
         pt2 = Functionality(name=u"print_template", value=u"2 Wohlen A3 landscape")

--- a/docker/test-mapserver/mapserver.map.mako
+++ b/docker/test-mapserver/mapserver.map.mako
@@ -77,7 +77,7 @@ MAP
             "gml_include_items" "all"
             "gml_exclude_items" "id"
             "gml_geometries" "geom"
-            "gml_the_geom_type" "point"
+            "gml_geom_type" "point"
             "gml_types" "auto"
             "gml_featureid" "id"
         END
@@ -112,7 +112,7 @@ MAP
             "gml_include_items" "all"
             "gml_exclude_items" "id"
             "gml_geometries" "geom"
-            "gml_the_geom_type" "point"
+            "gml_geom_type" "point"
 
             ${mapserver_layer_metadata}
         END
@@ -149,7 +149,7 @@ MAP
             "gml_include_items" "all"
             "gml_exclude_items" "id"
             "gml_geometries" "geom"
-            "gml_the_geom_type" "point"
+            "gml_geom_type" "point"
 
             ${mapserver_layer_metadata}
         END
@@ -186,7 +186,7 @@ MAP
             "gml_include_items" "all"
             "gml_exclude_items" "id"
             "gml_geometries" "geom"
-            "gml_the_geom_type" "point"
+            "gml_geom_type" "point"
 
             ${mapserver_layer_metadata}
         END
@@ -222,7 +222,7 @@ MAP
             "gml_include_items" "all"
             "gml_exclude_items" "id"
             "gml_geometries" "geom"
-            "gml_the_geom_type" "point"
+            "gml_geom_type" "point"
             "gml_types" "auto"
 
             "s_name_validation_pattern" "^[a-z]*$$"
@@ -262,7 +262,7 @@ MAP
             "gml_include_items" "all"
             "gml_exclude_items" "id"
             "gml_geometries" "geom"
-            "gml_the_geom_type" "point"
+            "gml_geom_type" "point"
             "gml_types" "auto"
 
             "s_cols_validation_pattern" "^[a-z,]*$$"
@@ -303,7 +303,7 @@ MAP
             "gml_include_items" "all"
             "gml_exclude_items" "id"
             "gml_geometries" "geom"
-            "gml_the_geom_type" "point"
+            "gml_geom_type" "point"
             "gml_types" "auto"
             "wms_metadataurl_href" "http://example.com/wmsfeatures.metadata"
             "wms_metadataurl_format" "text/plain"
@@ -511,7 +511,7 @@ MAP
             "gml_include_items" "all"
             "gml_exclude_items" "id"
             "gml_geometries" "geom"
-            "gml_the_geom_type" "point"
+            "gml_geom_type" "point"
             "gml_types" "auto"
             "wms_metadataurl_href" "http://example.com/wmsfeatures.metadata"
             "wms_metadataurl_format" "text/plain"


### PR DESCRIPTION
When MAPSERVER=FALSE, we should not depend on mapserver.timestamp
to build the translations.

Pass the list of languages when creating the TX configuration so that
it is not hardcoded to fr and de anymore.