### PR TITLE
Remove obsolete comments

### DIFF
--- a/doc/integrator/install_application.rst
+++ b/doc/integrator/install_application.rst
@@ -135,16 +135,6 @@ commands should be used to download CGXP and its dependencies:
 
     cd <my_project>
 
-The ``foreach`` command aims to init and update CGXP's own submodules, for GXP,
-OpenLayers and GeoExt.
-
-.. note::
-
-    We do not just use ``git submodule update --init --recursive`` here because
-    that would also download GXP's submodules. We do not want that because we
-    do not need GXP's submodules. CGXP indeed has its own submodules for
-    OpenLayers and GeoExt.
-
 Non Apt/Dpkg based OS Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Remove comments about a `git submodule` invocation that was removed in PR #1814.

See https://github.com/camptocamp/c2cgeoportal/pull/1814/files#diff-4b823d11f6d824081a897715d515cf86L137