### PR TITLE
Remove required on dimension.value

### DIFF
--- a/c2cgeoportal/forms.py
+++ b/c2cgeoportal/forms.py
@@ -574,7 +574,6 @@ Metadata.value.set(metadata=dict(mandatory="")).required()
 # Dimension
 Dimension = FieldSet(models.Dimension)
 Dimension.name.set(metadata=dict(mandatory="")).required()
-Dimension.value.set(metadata=dict(mandatory="")).required()
 
 # RestrictionArea
 RestrictionArea = FieldSet(models.RestrictionArea)


### PR DESCRIPTION
As layer dimension config value take precedence over global dimensions values,
it needed to be able set NULL values in dimensions.

Replace #3042