### PR TITLE
Lowercase layer to filter them

### DIFF
--- a/c2cgeoportal/lib/filter_capabilities.py
+++ b/c2cgeoportal/lib/filter_capabilities.py
@@ -253,6 +253,11 @@ class _CapabilitiesFilter(XMLFilterBase):
             layers_blacklist is not None and
             layers_whitelist is not None), \
             "only either layers_blacklist OR layers_whitelist can be set"
+
+        if layers_blacklist is not None:
+            layers_blacklist = [layer.lower() for layer in layers_blacklist]
+        if layers_whitelist is not None:
+            layers_whitelist = [layer.lower() for layer in layers_whitelist]
         self.layers_blacklist = layers_blacklist
         self.layers_whitelist = layers_whitelist
 


### PR DESCRIPTION
This code already exist in 1.6, was existing in master but was overriden by a 2.1 merge :-(
It's required to keep privacy on private layers in capabilities

It's okay to merge it in 2.1 ? It's also required in 2.0, 2.2, master (1.6 contains already this commit)