### PR TITLE
Get_protected_layer - clear connection to the db instance

### DIFF
--- a/c2cgeoportal/lib/filter_capabilities.py
+++ b/c2cgeoportal/lib/filter_capabilities.py
@@ -56,7 +56,9 @@ log = logging.getLogger(__name__)
 @cache_region.cache_on_arguments()
 def get_protected_layers(role_id, ogc_server_ids):
     q = get_protected_layers_query(role_id, ogc_server_ids, what=LayerWMS, version=2)
-    return {r.id: r for r in q.all()}
+    results = q.all()
+    DBSession.expunge_all()
+    return {r.id: r for r in results}
 
 
 @cache_region.cache_on_arguments()
@@ -73,7 +75,9 @@ def get_private_layers(ogc_server_ids):
 @cache_region.cache_on_arguments()
 def get_writable_layers(role_id, ogc_server_ids):
     q = get_writable_layers_query(role_id, ogc_server_ids)
-    return {r.id: r for r in q.all()}
+    results = q.all()
+    DBSession.expunge_all()
+    return {r.id: r for r in results}
 
 
 @cache_region.cache_on_arguments()


### PR DESCRIPTION
For #3041 again

To fix pdf_report and (almost) any other use of "get_protected_layers".
Fix also possible errors with "get_writable_layers"

(already done in 2.2 with: #3031 ) 