### PR TITLE
Allows use of smtps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: precise
 language: python
 
 python:

--- a/c2cgeoportal/lib/email_.py
+++ b/c2cgeoportal/lib/email_.py
@@ -43,13 +43,13 @@ def send_email(from_addr, to_addrs, body, subject, smtp):  # pragma: no cover
     msg.attach(MIMEText(body, "plain", "utf-8"))
 
     # Connect to server
-    if smtp.get('ssl', False):
-        smtp = smtplib.SMTP_SSL(smtp['host'])
+    if smtp.get("ssl", False):
+        smtp = smtplib.SMTP_SSL(smtp["host"])
     else:
-        smtp = smtplib.SMTP(smtp['host'])
-    if smtp.get('user', False):
-        smtp.login(smtp['user'], smtp['password'])
-    if smtp.get('starttls', False):
+        smtp = smtplib.SMTP(smtp["host"])
+    if smtp.get("user", False):
+        smtp.login(smtp["user"], smtp["password"])
+    if smtp.get("starttls", False):
         smtp.starttls()
 
     smtp.sendmail(from_addr, to_addrs, msg.as_string())

--- a/c2cgeoportal/lib/email_.py
+++ b/c2cgeoportal/lib/email_.py
@@ -34,13 +34,23 @@ from email.mime.multipart import MIMEMultipart
 from email.Utils import formatdate
 
 
-def send_email(from_addr, to_addrs, body, subject, smtp_server):  # pragma: no cover
+def send_email(from_addr, to_addrs, body, subject, smtp):  # pragma: no cover
     msg = MIMEMultipart()
     msg["From"] = from_addr
     msg["To"] = ", ".join(to_addrs)
     msg["Date"] = formatdate(localtime=True)
     msg["Subject"] = subject
     msg.attach(MIMEText(body, "plain", "utf-8"))
-    smtp = smtplib.SMTP(smtp_server)
+
+    # Connect to server
+    if smtp.get('ssl', False):
+        smtp = smtplib.SMTP_SSL(smtp['host'])
+    else:
+        smtp = smtplib.SMTP(smtp['host'])
+    if smtp.get('user', False):
+        smtp.login(smtp['user'], smtp['password'])
+    if smtp.get('starttls', False):
+        smtp.starttls()
+
     smtp.sendmail(from_addr, to_addrs, msg.as_string())
     smtp.close()

--- a/c2cgeoportal/scaffolds/create/vars_+package+.yaml_tmpl
+++ b/c2cgeoportal/scaffolds/create/vars_+package+.yaml_tmpl
@@ -110,7 +110,12 @@ vars:
 
             Sincerely yours
             The GeoMapfish team
-        smtp_server: smtp.example.com
+        smtp:
+          host: smtp.example.com
+          ssl: true
+          user: <username>
+          password: <password>
+          starttls: false
 
 update_paths:
 - authtkt

--- a/c2cgeoportal/scaffolds/create/vars_+package+.yaml_tmpl
+++ b/c2cgeoportal/scaffolds/create/vars_+package+.yaml_tmpl
@@ -111,11 +111,11 @@ vars:
             Sincerely yours
             The GeoMapfish team
         smtp:
-          host: smtp.example.com
-          ssl: true
-          user: <username>
-          password: <password>
-          starttls: false
+            host: smtp.example.com
+            ssl: true
+            user: <username>
+            password: <password>
+            starttls: false
 
 update_paths:
 - authtkt

--- a/c2cgeoportal/scaffolds/create/vars_+package+.yaml_tmpl
+++ b/c2cgeoportal/scaffolds/create/vars_+package+.yaml_tmpl
@@ -98,6 +98,14 @@ vars:
         # - display: Child:
         #   url: http://${host}/child/wsgi
 
+    smtp:
+        # Used to send email from various feature
+        host: smtp.example.com
+        ssl: true
+        user: <username>
+        password: <password>
+        starttls: false
+
     reset_password:
         # Used to send a confirmation email
         email_from: info@camptocamp.com
@@ -110,12 +118,6 @@ vars:
 
             Sincerely yours
             The GeoMapfish team
-        smtp:
-            host: smtp.example.com
-            ssl: true
-            user: <username>
-            password: <password>
-            starttls: false
 
 update_paths:
 - authtkt

--- a/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -3,13 +3,17 @@ This file includes migration steps for each release of c2cgeoportal.
 Version 1.6.12
 ==============
 
-1. In the `vars_{{package}}.yaml` file, change:
+1. In the `vars_{{package}}.yaml` file, remove:
 
    - smtp_server: smtp.example.com
-   + smtp:
-   +   host: smtp.example.com
 
-check the documentation if you need ssl, startls, username and password for
+  and add this line to the parent node:
+   + smtp:
+   +     host: smtp.example.com
+     reset_password:
+        ...
+
+Check the documentation if you need ssl, startls, username and password for
 your SMTP service.
 
 Version 1.6.8

--- a/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -1,5 +1,16 @@
 This file includes migration steps for each release of c2cgeoportal.
 
+Version 1.6.12
+==============
+
+1. In the `vars_{{package}}.yaml` file, change:
+
+   - smtp_server: smtp.example.com
+   + smtp:
+   +   host: smtp.example.com
+
+check the documentation if you need ssl, startls, username and password for
+your SMTP service.
 
 Version 1.6.8
 =============

--- a/c2cgeoportal/views/entry.py
+++ b/c2cgeoportal/views/entry.py
@@ -1369,7 +1369,7 @@ class Entry(object):
             settings["email_from"], [user.email],
             settings["email_body"].format(user=username, password=password).encode("utf-8"),
             settings["email_subject"],
-            settings["smtp_server"],
+            settings["smtp"],
         )
 
         return {

--- a/c2cgeoportal/views/entry.py
+++ b/c2cgeoportal/views/entry.py
@@ -1364,7 +1364,7 @@ class Entry(object):
         set_common_headers(self.request, "loginresetpassword", NO_CACHE)
 
         user, username, password = self._loginresetpassword()
-        settings = self.request.registry.settings["reset_password"]
+        settings = self.request.registry.settings["smtp"]
         send_email(
             settings["email_from"], [user.email],
             settings["email_body"].format(user=username, password=password).encode("utf-8"),

--- a/c2cgeoportal/views/shortener.py
+++ b/c2cgeoportal/views/shortener.py
@@ -125,12 +125,13 @@ class Shortener(object):
 
         email = email or user_email
 
+        smtp = self.request.registry.settings.get("smtp", {})
         if \
                 email is not None and \
                 "email_from" in self.settings and \
                 "email_subject" in self.settings and \
                 "email_body" in self.settings and \
-                "smtp_server" in self.settings:  # pragma: no cover
+                "host" in smtp:  # pragma: no cover
             text = self.settings["email_body"] % {
                 "full_url": url,
                 "short_url": s_url,
@@ -140,7 +141,7 @@ class Shortener(object):
                 [email],
                 text.encode("utf-8"),
                 self.settings["email_subject"],
-                self.settings["smtp"],
+                smtp,
             )
 
         set_common_headers(

--- a/c2cgeoportal/views/shortener.py
+++ b/c2cgeoportal/views/shortener.py
@@ -140,7 +140,7 @@ class Shortener(object):
                 [email],
                 text.encode("utf-8"),
                 self.settings["email_subject"],
-                self.settings["smtp_server"],
+                self.settings["smtp"],
             )
 
         set_common_headers(

--- a/doc/integrator/reset_password.rst
+++ b/doc/integrator/reset_password.rst
@@ -17,6 +17,14 @@ And to generate the required e-mail, in the ``vars_<package>.yaml`` file, add th
 
 .. code:: yaml
 
+    # SMTP configuration could be already there if needed by other feature
+    smtp:
+        host: smtp.example.com:465
+        ssl: true
+        user: <username>
+        password: <password>
+        starttls: false
+
     reset_password:
         # Used to send a confirmation email
         email_from: info@camptocamp.com
@@ -29,12 +37,6 @@ And to generate the required e-mail, in the ``vars_<package>.yaml`` file, add th
 
             Sincerely yours
             The GeoMapfish team
-        smtp:
-            host: smtp.example.com:465
-            ssl: true
-            user: <username>
-            password: <password>
-            starttls: false
 
 If the SMTP host ends with a colon (`:`) followed by a number, and
 there is no port specified, that suffix will be stripped off and the

--- a/doc/integrator/reset_password.rst
+++ b/doc/integrator/reset_password.rst
@@ -30,11 +30,11 @@ And to generate the required e-mail, in the ``vars_<package>.yaml`` file, add th
             Sincerely yours
             The GeoMapfish team
         smtp:
-          host: smtp.example.com:465
-          ssl: true
-          user: <username>
-          password: <password>
-          starttls: false
+            host: smtp.example.com:465
+            ssl: true
+            user: <username>
+            password: <password>
+            starttls: false
 
 If the SMTP host ends with a colon (`:`) followed by a number, and
 there is no port specified, that suffix will be stripped off and the

--- a/doc/integrator/reset_password.rst
+++ b/doc/integrator/reset_password.rst
@@ -29,6 +29,15 @@ And to generate the required e-mail, in the ``vars_<package>.yaml`` file, add th
 
             Sincerely yours
             The GeoMapfish team
-        smtp_server: smtp.example.com
+        smtp:
+          host: smtp.example.com:465
+          ssl: true
+          user: <username>
+          password: <password>
+          starttls: false
+
+If the SMTP host ends with a colon (`:`) followed by a number, and
+there is no port specified, that suffix will be stripped off and the
+number interpreted as the port number to use.
 
 Replace the ``smtp.example.com`` value by a working SMTP server name.

--- a/doc/integrator/shortener.rst
+++ b/doc/integrator/shortener.rst
@@ -7,6 +7,14 @@ The configuration in ``vars_<project>.yaml`` looks like this:
 
 .. code:: yaml
 
+   # SMTP configuration could be already there if needed by other feature
+   smtp:
+       host: smtp.example.com:465
+       ssl: true
+       user: <username>
+       password: <password>
+       starttls: false
+
    shortener:
         # The base of created URL
         base_url:  http://{host}/{apache_entry_point}s/
@@ -21,7 +29,6 @@ The configuration in ``vars_<project>.yaml`` looks like this:
             full URL: %(full_url)s
 
             The Mapfish team
-        smtp_server: smtp.example.com
         # length (default) of ref of new short url
         # Can be change when you want
         # max 20 (size of the column)
@@ -30,3 +37,9 @@ The configuration in ``vars_<project>.yaml`` looks like this:
 The shortened URL is sent by email to the current registered user email address
 unless another address has been provided through the email field in the
 viewer interface.
+
+If the SMTP host ends with a colon (`:`) followed by a number, and
+there is no port specified, that suffix will be stripped off and the
+number interpreted as the port number to use.
+
+Replace the ``smtp.example.com`` value by a working SMTP server name.


### PR DESCRIPTION
More and more smtp service needs authentication to use a SMTP service (SSL,
auth, stattls). So we need to support authenticated smtp, smtps, etc.