### PR TITLE
Fix basic auth group finder

### DIFF
--- a/c2cgeoportal/lib/authentication.py
+++ b/c2cgeoportal/lib/authentication.py
@@ -54,5 +54,5 @@ def create_authentication(settings):
 
 def c2cgeoportal_check(username, password, request):  # pragma: nocover
     if request.registry.validate_user(request, username, password):
-        return []
+        return defaultgroupsfinder(username, request)
     return None


### PR DESCRIPTION
Principals was not returned in case of basic auth.

Regarding BasicAuthAuthenticationPolicy documentation for check:
    A callback function passed a username, password and request, in that order as positional arguments. Expected to return None if the userid doesn't exist or a sequence of principal identifiers (possibly empty) if the user does exist.

So we should return the role name here, works for me in aeroportdelyon_sig.