### PR TITLE
[doc, 2.1] add update infos from GSSZ2-22

### DIFF
--- a/doc/builddoc.rst
+++ b/doc/builddoc.rst
@@ -8,3 +8,21 @@ Build this doc
   make doc
 
 The HTML should now be available in the ``doc/_build/html`` directory.
+
+Contribute to the documentation
+-------------------------------
+
+You can contribute to the documentation by making changes to the git-managed
+files and creating a pull request, just like for any change proposals to
+c2cgeoportal or other git managed projects.
+
+To make changes to the documentation, you need to edit the ``.rst.mako``
+files where available; otherwise directly the ``.rst`` if there is no corresponding
+``mako`` file.
+
+To verify that the syntax of your changes is OK (no trailing whitespace etc.),
+you should execute the following command (in addition to the ``make doc``):
+
+.. prompt:: bash
+
+  make git-attributes

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -49,7 +49,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'c2cgeoportal'
-copyright = u'2011-2016, Camptocamp'
+copyright = u'2011-2017, Camptocamp'
 
 # The version info for the project you are documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/doc/integrator/upgrade_application.rst.mako
+++ b/doc/integrator/upgrade_application.rst.mako
@@ -1,8 +1,10 @@
 .. _integrator_upgrade_application:
 
+==================================
 Upgrading a GeoMapFish application
 ==================================
 
+----------------
 Preliminary work
 ----------------
 
@@ -11,7 +13,10 @@ target environment, some preliminary work is necessary before applying the
 update steps via scripts.
 
 GMF 1.X to GMF 2.1
-~~~~~~~~~~~~~~~~~~
+==================
+
+pip dependency
+--------------
 If you are updating directly from a GeoMapFish 1.X version to GeoMapFish 2.1,
 and your target environment contains a new recent of pip (such as found on,
 for example, Debian 9), you need to apply the following changes:
@@ -42,6 +47,12 @@ Edit ``CONST_dev-requirements.txt``:
     +c2cgeoportal==2.1.8
     ...
 
+usage of intranet detection
+---------------------------
+If you are using automatic login via intranet detection, beware that the necessary code
+has changed with GMF 2.1. See :ref:`integrator_intranet` and update your code accordingly.
+
+-----------------------------
 Updating the application code
 -----------------------------
 
@@ -65,7 +76,7 @@ Then run:
 
 Where ``<makefile>`` is your user make file (``<user>.mk``).
 
-
+------------------------
 Upgrading an application
 ------------------------
 
@@ -129,6 +140,7 @@ And follow the instructions.
       ``.build\venv\Scripts\...`` instead of ``.build\venv\bin\...`` in all given
       commands
 
+--------------------
 Upgrade the database
 --------------------
 

--- a/doc/integrator/upgrade_application.rst.mako
+++ b/doc/integrator/upgrade_application.rst.mako
@@ -3,6 +3,44 @@
 Upgrading a GeoMapFish application
 ==================================
 
+Preliminary work
+----------------
+
+Depending on your current version of GeoMapFish and the environment of your
+target environment, some preliminary work is necessary before applying the
+update steps via scripts.
+
+GMF 1.X to GMF 2.1
+~~~~~~~~~~~~~~~~~~
+If you are updating directly from a GeoMapFish 1.X version to GeoMapFish 2.1,
+and your target environment contains a new recent of pip (such as found on,
+for example, Debian 9), you need to apply the following changes:
+
+Edit ``CONST_Makefile`` (lines starting with a "+" need to be added;
+lines starting with a "-" need to be removed):
+
+.. code:: yaml
+
+    ...
+    -PIP_INSTALL_ARGS += install --trusted-host pypi.camptocamp.net
+    +PIP_INSTALL_ARGS += install
+    ...
+    $(PIP_CMD) install \
+    -    --index-url http://pypi.camptocamp.net/pypi \
+         '$(PIP_VERSION)' '$(SETUPTOOL_VERSION)'
+    ...
+
+Edit ``CONST_dev-requirements.txt``:
+
+.. code:: yaml
+
+    ...
+    -    --index-url http://pypi.camptocamp.net/pypi
+    -    --find-links http://pypi.camptocamp.net/internal-pypi/index/c2cgeoportal
+    ...
+    -c2cgeoportal==1.6.8
+    +c2cgeoportal==2.1.8
+    ...
 
 Updating the application code
 -----------------------------


### PR DESCRIPTION
Add infos to c2cgeoportal 2.1 docu, as obtained when updating gmf 1.6 to gmf 2.1 in SZ project (as preliminary step to upgrade to gmf 2.2.), handled in ticket GSSZ2-22.