### PR TITLE
Add layertree view

### DIFF
--- a/admin/acceptance_tests/layertree_test.py
+++ b/admin/acceptance_tests/layertree_test.py
@@ -1,0 +1,194 @@
+# pylint: disable=no-self-use
+
+import pytest
+
+from . import skip_if_travis
+
+
+@pytest.fixture(scope="class")
+@pytest.mark.usefixtures("dbsession")
+def layertree_test_data(dbsession):
+    from c2cgeoportal_commons.models.main import \
+        LayerGroup, LayergroupTreeitem, LayerV1, LayerWMS, LayerWMTS, OGCServer, Theme
+
+    dbsession.begin_nested()
+
+    layers_v1 = []
+    for i in range(0, 10):
+        layer_v1 = LayerV1(name='layer_v1_{}'.format(i))
+        layers_v1.append(layer_v1)
+        dbsession.add(layer_v1)
+
+    layers_wms = []
+    ogc_server = OGCServer(name='ogc_server')
+    dbsession.add(ogc_server)
+    for i in range(0, 10):
+        layer_wms = LayerWMS(name='layer_wms_{}'.format(i))
+        layer_wms.ogc_server = ogc_server
+        layers_wms.append(layer_wms)
+        dbsession.add(layer_wms)
+
+    layers_wmts = []
+    for i in range(0, 10):
+        layer_wmts = LayerWMTS(name='layer_wmts_{}'.format(i))
+        layer_wmts.url = 'http://localhost/wmts'
+        layer_wmts.layer = layer_wmts.name
+        layers_wmts.append(layer_wmts)
+        dbsession.add(layer_wmts)
+
+    groups = []
+    for i in range(0, 10):
+        group = LayerGroup(name='layer_group_{}'.format(i))
+        groups.append(group)
+        dbsession.add(group)
+
+        for j, items in enumerate((layers_v1, layers_wms, layers_wmts)):
+            dbsession.add(LayergroupTreeitem(group=group, item=items[i], ordering=j))
+
+    # a group in a group
+    dbsession.add(LayergroupTreeitem(group=groups[9], item=groups[8], ordering=3))
+
+    themes = []
+    for i in range(0, 5):
+        theme = Theme(name='theme_{}'.format(i))
+        themes.append(theme)
+        dbsession.add(theme)
+
+        dbsession.add(LayergroupTreeitem(group=theme, item=groups[i], ordering=0))
+        dbsession.add(LayergroupTreeitem(group=theme, item=groups[i+5], ordering=1))
+
+    themes[0].ordering = 1
+    themes[3].ordering = 2
+    themes[1].ordering = 3
+    themes[2].ordering = 4
+    themes[4].ordering = 5
+
+    dbsession.flush()
+
+    yield({
+        'themes': themes,
+        'groups': groups,
+        'layers_v1': layers_v1,
+        'layers_wms': layers_wms,
+        'layers_wmts': layers_wmts,
+    })
+
+    dbsession.rollback()
+
+
+@pytest.mark.usefixtures("dbsession", "layertree_test_data", "transact", "test_app")
+class TestLayerTreeView():
+
+    def test_index_view(self, test_app, layertree_test_data):
+        html = test_app.get("/layertree/", status=200).html
+
+        # check themes are sorted by ordering
+        theme_names = [list(tr.select('td')[0].stripped_strings)[0]
+                       for tr in html.select('tr.theme')]
+        expected = [theme.name for theme in sorted(layertree_test_data['themes'],
+                                                   key=lambda theme: theme.ordering)]
+        assert expected == theme_names
+
+        # check total number of nodes
+        lines = html.select('#layertree-table tr')
+        nb_themes = 5
+        nb_groups = 10 + 1  # group 1 in group 9
+        nb_layers = nb_groups * 3
+        assert nb_themes + nb_groups + nb_layers == len(lines)
+
+    def test_edit_button(self, test_app, layertree_test_data):
+        resp = test_app.get("/layertree/", status=200)
+
+        for table, item_id in (
+            ('themes', layertree_test_data['themes'][0].id),
+            ('groups', layertree_test_data['groups'][0].id),
+            # ('layers_v1', layertree_test_data['layers_wms'][0].id),
+            ('layers_wms', layertree_test_data['layers_wms'][0].id),
+            # ('layers_wmts', layertree_test_data['layers_wmts'][0].id),
+        ):
+            link = resp.html.select_one('tr.treegrid-{} li.action-edit a'.format(item_id))
+            assert 'http://localhost/{}/{}'.format(table, item_id) == link['href']
+
+    def test_unlink_button(self, test_app, layertree_test_data):
+        resp = test_app.get("/layertree/", status=200)
+
+        # no unlink on theme
+        assert 0 == len(
+            resp.html.select('tr.treegrid-{} li.action-unlink a'
+                             .format(layertree_test_data['themes'][0].id)))
+
+        for group_id, item_id in (
+            (layertree_test_data['groups'][0].id, layertree_test_data['layers_wmts'][0].id),
+            (layertree_test_data['groups'][0].id, layertree_test_data['layers_wms'][0].id),
+            (layertree_test_data['groups'][0].id, layertree_test_data['layers_v1'][0].id),
+            (layertree_test_data['themes'][0].id, layertree_test_data['groups'][0].id),
+        ):
+            link = resp.html.select_one('tr.treegrid-{}.treegrid-parent-{} li.action-unlink a'.
+                                        format(item_id, group_id))
+            assert 'http://localhost/layertree/unlink/{}/{}'.format(group_id, item_id) == link['data-url']
+
+    def test_unlink_view(self, test_app, layertree_test_data, dbsession):
+        group = layertree_test_data['groups'][0]
+        item = layertree_test_data['layers_wms'][0]
+
+        test_app.delete("/layertree/unlink/{}/{}".format(group.id, item.id), status=200)
+
+        dbsession.expire_all()
+
+        assert item not in group.children
+
+    # @pytest.mark.skip(reason="Waiting for delete views")
+    @skip_if_travis
+    @pytest.mark.usefixtures("selenium", "selenium_app")
+    def test_unlink_selenium(self, dbsession, selenium, selenium_app, layertree_test_data):
+        from selenium.webdriver.common.by import By
+        from selenium.webdriver.support import expected_conditions as EC
+        from selenium.webdriver.support.ui import WebDriverWait
+
+        selenium.get(selenium_app + '/layertree/')
+
+        elem = WebDriverWait(selenium, 10).until(
+            EC.element_to_be_clickable((By.ID, "layertree-expand")))
+        elem.click()
+
+        for group_id, item_id in (
+            (layertree_test_data['groups'][0].id, layertree_test_data['layers_wmts'][0].id),
+            (layertree_test_data['groups'][0].id, layertree_test_data['layers_wms'][0].id),
+            (layertree_test_data['groups'][0].id, layertree_test_data['layers_v1'][0].id),
+            (layertree_test_data['themes'][0].id, layertree_test_data['groups'][0].id),
+        ):
+            elem = WebDriverWait(selenium, 10).until(
+                EC.element_to_be_clickable((By.CSS_SELECTOR,
+                                            "tr.treegrid-{}.treegrid-parent-{} button.dropdown-toggle".
+                                            format(item_id, group_id))))
+            elem.click()
+
+            elem = WebDriverWait(selenium, 10).until(
+                EC.element_to_be_clickable((By.CSS_SELECTOR,
+                                            "tr.treegrid-{}.treegrid-parent-{} li.action-unlink a".
+                                            format(item_id, group_id))))
+            expected_url = '{}/layertree/unlink/{}/{}'.format(selenium_app, group_id, item_id)
+            assert expected_url == elem.get_attribute('data-url')
+
+            elem.click()
+            selenium.switch_to_alert().accept()
+            selenium.switch_to_default_content()
+
+            WebDriverWait(selenium, 10).until(
+                lambda driver: driver.execute_script(
+                    "return (window.jQuery != undefined && jQuery.active == 0)"))
+
+            from c2cgeoportal_commons.models.main import LayergroupTreeitem
+            link = dbsession.query(LayergroupTreeitem). \
+                filter(LayergroupTreeitem.treegroup_id == group_id). \
+                filter(LayergroupTreeitem.treeitem_id == item_id). \
+                one_or_none()
+            assert link is None
+
+            dbsession.expire_all()
+            selenium.refresh()
+
+            from selenium.common.exceptions import NoSuchElementException
+            with pytest.raises(NoSuchElementException):
+                elem = selenium.find_element_by_css_selector("tr.treegrid-{}.treegrid-parent-{}"
+                                                             .format(item_id, group_id))

--- a/admin/c2cgeoportal_admin/routes.py
+++ b/admin/c2cgeoportal_admin/routes.py
@@ -12,6 +12,9 @@ def includeme(config):
     config.add_static_view('static', 'static', cache_max_age=3600)
 
     config.add_route('home', '/')
+    config.add_route('layertree', '/layertree/')
+    config.add_route('layertree_unlink', '/layertree/unlink/{group_id}/{item_id}')
+    config.add_route('layertree_delete', '/layertree/delete/{item_id}')
 
     from c2cgeoportal_commons.models.main import Role
     from c2cgeoportal_commons.models.static import User

--- a/admin/c2cgeoportal_admin/static/theme.css
+++ b/admin/c2cgeoportal_admin/static/theme.css
@@ -1,0 +1,9 @@
+#layertree-actions {
+  margin-top: 5px;
+  margin-bottom: 5px;
+}
+#layertree-table {
+  margin-top: 5px;
+  margin-bottom: 5px;
+  width: auto;
+}

--- a/admin/c2cgeoportal_admin/templates/layertree.jinja2
+++ b/admin/c2cgeoportal_admin/templates/layertree.jinja2
@@ -1,0 +1,130 @@
+{% extends "layout.jinja2" %}
+
+{% block extra_links %}
+<link href="{{request.static_url('c2cgeoportal_admin:node_modules/jquery-treegrid/css/jquery.treegrid.css')}}" rel="stylesheet">
+{% endblock extra_links %}
+
+{% block extra_scripts %}
+<script type="text/javascript" src="{{request.static_url('c2cgeoportal_admin:node_modules/jquery-treegrid/js/jquery.treegrid.js')}}"></script>
+<script type="text/javascript" src="{{request.static_url('c2cgeoportal_admin:node_modules/jquery.cookie/jquery.cookie.js')}}"></script>
+{% endblock extra_scripts %}
+
+{% block content %}
+
+<div id="layertree">
+
+    <div id="layertree-actions" class="btn-group">
+        <button id="layertree-expand" type="button" class="btn btn-default">{{_("Expand all")}}</button>
+        <button id="layertree-collapse" type="button" class="btn btn-default">{{_("Collapse all")}}</button>
+    </div>
+
+    <table id="layertree-table" class="tree table table-hover">
+        {% macro render_node(node, parent_id=None) -%}
+        <tr class="{{ node.item_type }} treegrid-{{ node.id }}{{' treegrid-parent-{}'.format(parent_id) if parent_id else ''}}">
+            <td>
+                {% if node.item_type == 'theme' %}
+                <span class="glyphicon glyphicon-briefcase"></span>
+                {% elif node.item_type == 'group' %}
+                <span class="glyphicon glyphicon-folder-open"></span>
+                {% elif node.item_type == 'layerv1' %}
+                <span class="glyphicon glyphicon-picture" style="color:grey"></span>
+                {% elif node.item_type == 'l_wms' %}
+                <span class="glyphicon glyphicon-picture"></span>
+                {% elif node.item_type == 'l_wmts' %}
+                <span class="glyphicon glyphicon-th"></span>
+                {% endif %}
+                {{ node.name }}
+            </td>
+            <td>
+                <div class="btn-group">
+                    <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                      <span class="glyphicon glyphicon-option-horizontal"></span>
+                    </button>
+                    <ul class="dropdown-menu">
+                        <li class="action-edit">
+                            <a title="{{_("Edit")}}"
+                                href="{{request.route_url('c2cgeoform_action', table=tables[node.item_type], id=node.id)}}">
+                                <span class="glyphicon glyphicon-pencil"></span>
+                                {{_("Edit")}}
+                            </a>
+                        </li>
+                        {% if parent_id %}
+                        <li class="action-unlink">
+                            <a title="{{_("Unlink")}}"
+                                data-url="{{request.route_url('layertree_unlink', group_id=parent_id, item_id=node.id)}}"
+                                href="#"
+                                role="button">
+                                <span class="glyphicon glyphicon-log-out"></span>
+                                {{_("Unlink")}}
+                            </a>
+                        </li>
+                        {% endif %}
+                        <li class="action-delete">
+                            <a title="{{_("Delete")}}"
+                                data-url="{{request.route_url('layertree_delete', item_id=node.id)}}"
+                                href="#"
+                                role="button">
+                                <span class="glyphicon glyphicon-remove"></span>
+                                {{_("Delete")}}
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </td>
+        </tr>
+        {% for child in node.children %}
+        {{ render_node(child, node.id) }}
+        {% endfor %}
+        {%- endmacro %}
+
+        {% for theme in themes %}
+        {{ render_node(theme) }}
+        {% endfor %}
+    </table>
+
+    <script type="text/javascript">
+      $(function() {
+        $('.tree').treegrid({
+          'initialState': 'collapsed',
+          'saveState': true,
+          'saveStateName': 'layertree'
+        });
+
+        $("#layertree-expand").on('click', function() {
+          $('.tree').treegrid('expandAll');
+        });
+
+        $("#layertree-collapse").on('click', function() {
+          $('.tree').treegrid('collapseAll');
+        });
+
+        $("#layertree-table li.action-unlink a").on('click', function() {
+          if (window.confirm('{{_("Are your sure ?")}}')) {
+            $.ajax({
+                url: $(this).attr("data-url"),
+                type: 'DELETE',
+                success: function(result) {
+                    location.reload();
+                }
+            });
+          }
+        });
+
+        $("#layertree-table li.action-delete a").on('click', function() {
+          if (window.confirm('{{_("Are your sure ?")}}')) {
+            $.ajax({
+                url: $(this).attr("data-url"),
+                type: 'DELETE',
+                success: function(result) {
+                    location.reload();
+                }
+            });
+          }
+        });
+
+      });
+    </script>
+
+</div>
+
+{% endblock content %}

--- a/admin/c2cgeoportal_admin/templates/layout.jinja2
+++ b/admin/c2cgeoportal_admin/templates/layout.jinja2
@@ -15,6 +15,7 @@
     <link href="{{request.static_url('c2cgeoportal_admin:node_modules/jquery-bootgrid/dist/jquery.bootgrid.min.css')}}" rel="stylesheet">
     <link href="{{request.static_url('c2cgeoportal_admin:node_modules/jquery-steps/demo/css/jquery.steps.css')}}" rel="stylesheet">
     <link href="{{request.static_url('c2cgeoform:static/theme.css')}}" rel="stylesheet">
+    {% block extra_links %}{% endblock extra_links %}
 
     <!-- Deform dependecies CSS -->
     {% if deform_dependencies %}
@@ -39,6 +40,7 @@
     <script type="text/javascript" src="{{request.static_url('c2cgeoportal_admin:node_modules/jquery-bootgrid/dist/jquery.bootgrid.min.js')}}"></script>
     <script type="text/javascript" src="{{request.static_url('c2cgeoportal_admin:node_modules/jquery-steps/build/jquery.steps.min.js')}}"></script>
     <script type="text/javascript" src="{{request.static_url('c2cgeoform:static/js/c2cgeoform.js')}}"></script>
+    {% block extra_scripts %}{% endblock extra_scripts %}
 
     <!-- Deform JavaScript -->
     {% if deform_dependencies %}
@@ -68,7 +70,7 @@
         <div class="col-md-2">
           {% block navigation %}
             <div id="main-menu">
-              {% include 'c2cgeoform:/templates/navigation.jinja2' %}
+              {% include 'navigation.jinja2' %}
             </div>
           {% endblock navigation %}
         </div>

--- a/admin/c2cgeoportal_admin/templates/navigation.jinja2
+++ b/admin/c2cgeoportal_admin/templates/navigation.jinja2
@@ -1,0 +1,10 @@
+<ul class="nav nav-pills nav-stacked">
+  <li role="presentation" class="{{'active' if request.matched_route.name == 'layertree' else ''}}">
+    <a href="{{request.route_url('layertree')}}">{{_("Layer tree")}}</a>
+  </li>
+  {% for table in tables %}
+  <li role="presentation" class="{{'active' if request.matchdict and request.matchdict.get('table') == table['key'] else ''}}">
+    <a href="{{request.route_url('c2cgeoform_index', table=table['key'])}}">{{table['plural']}}</a>
+  </li>
+  {% endfor %}
+</ul>

--- a/admin/c2cgeoportal_admin/views/layertree.py
+++ b/admin/c2cgeoportal_admin/views/layertree.py
@@ -1,0 +1,70 @@
+from pyramid.httpexceptions import HTTPNotFound
+from pyramid.response import Response
+from pyramid.view import view_config
+
+from sqlalchemy.orm import subqueryload
+
+from c2cgeoportal_commons.models.main import \
+    LayergroupTreeitem, Theme, TreeGroup, TreeItem
+
+
+class LayerTreeViews():
+
+    def __init__(self, request):
+        self._request = request
+        self._dbsession = request.dbsession
+
+    @view_config(route_name="layertree",
+                 renderer="../templates/layertree.jinja2")
+    def index(self):
+        # Preload treeitems and treegroups children relations.
+        # Note that session.identity_map only keep weak references
+        # so we need to keep strong references until the end of rendering.
+        groups = self._dbsession.query(TreeGroup). \
+            options(subqueryload("children_relation")). \
+            all()
+        items = self._dbsession.query(TreeItem). \
+            all()
+
+        themes = self._dbsession.query(Theme). \
+            order_by(Theme.ordering). \
+            all()
+
+        return {
+            "themes": themes,
+            "groups": groups,  # keep strong references
+            "items": items,  # keep strong references
+            "tables": {
+                "theme": "themes",
+                "group": "groups",
+                "layerv1": "layers_v1",
+                "l_wms": "layers_wms",
+                "l_wmts": "layers_wmts"
+            }
+        }
+
+    @view_config(route_name="layertree_unlink",
+                 request_method='DELETE')
+    def unlink(self):
+        group_id = self._request.matchdict.get("group_id")
+        item_id = self._request.matchdict.get("item_id")
+        link = self._request.dbsession.query(LayergroupTreeitem). \
+            filter(LayergroupTreeitem.treegroup_id == group_id). \
+            filter(LayergroupTreeitem.treeitem_id == item_id). \
+            one_or_none()
+        if link is None:
+            raise HTTPNotFound()
+        self._request.dbsession.delete(link)
+        self._request.dbsession.flush()
+        return Response('OK')
+
+    @view_config(route_name="layertree_delete",
+                 request_method='DELETE')
+    def delete(self):
+        item_id = self._request.matchdict.get("item_id")
+        item = self._request.dbsession.query(TreeItem).get(item_id)
+        if item is None:
+            raise HTTPNotFound()
+        self._request.dbsession.delete(item)
+        self._request.dbsession.flush()
+        return Response('OK')

--- a/admin/package.json
+++ b/admin/package.json
@@ -11,6 +11,8 @@
     "jquery": "^3.2.1",
     "jquery-bootgrid": "^1.3.1",
     "jquery-steps": "^1.1.0",
+    "jquery-treegrid": "^0.3.0",
+    "jquery.cookie": "^1.4.1",
     "openlayers": "=3.11.2",
     "typeahead.js": "=0.10.5"
   }

--- a/commons/c2cgeoportal_commons/models/main.py
+++ b/commons/c2cgeoportal_commons/models/main.py
@@ -277,7 +277,7 @@ event.listen(TreeItem, "after_update", cache_invalidate_cb, propagate=True)
 event.listen(TreeItem, "after_delete", cache_invalidate_cb, propagate=True)
 
 
-# association table LayerGroup <> TreeItem
+# association table TreeGroup <> TreeItem
 class LayergroupTreeitem(Base):
     __tablename__ = "layergroup_treeitem"
     __table_args__ = {"schema": _schema}
@@ -326,6 +326,9 @@ class TreeGroup(TreeItem):
     __tablename__ = "treegroup"
     __table_args__ = {"schema": _schema}
     __acl__ = [DENY_ALL]
+    __mapper_args__ = {
+        "polymorphic_identity": "treegroup"  # needed for _identity_class
+    }
 
     id = Column(Integer, ForeignKey(_schema + ".treeitem.id"), primary_key=True)
 
@@ -431,6 +434,9 @@ class Layer(TreeItem):
     __tablename__ = "layer"
     __table_args__ = {"schema": _schema}
     __acl__ = [DENY_ALL]
+    __mapper_args__ = {
+        "polymorphic_identity": "layer"  # needed for _identity_class
+    }
 
     id = Column(Integer, ForeignKey(_schema + ".treeitem.id"), primary_key=True)
     public = Column(Boolean, default=True, info={
@@ -453,6 +459,9 @@ class Layer(TreeItem):
 
 class DimensionLayer(Layer):
     __acl__ = [DENY_ALL]
+    __mapper_args__ = {
+        "polymorphic_identity": "dimensionlayer"  # needed for _identity_class
+    }
 
 
 class LayerV1(Layer):  # Deprecated in v2


### PR DESCRIPTION
Note that I use dbsession identity map to load all treeitems and relations in 2 SQL requests.
Complete tree get loaded in 100ms.
For that I've added some "polymorphic_identity" on abstract classes.

For now we do not have a real context menu but a dropdown menu.

TODO : Test delete, but this was not part of this print in facts.