### PR TITLE
Adding documentation for ngeo externs

### DIFF
--- a/doc/integrator/ngeo.rst
+++ b/doc/integrator/ngeo.rst
@@ -230,9 +230,9 @@ By default it is done for the desktop and mobile interface.
 Externs
 -------
 
-Adding additional external depedencies requires `declaring them as externs <https://developers.google.com/closure/compiler/docs/api-tutorial3#externs>`_.
+Adding additional external dependencies requires `declaring them as externs <https://developers.google.com/closure/compiler/docs/api-tutorial3#externs>`_.
 This prevents the closure-compiler from renaming the objects and their properties and allows type-checking.
-Good examples for such externs can be found in `ngeo <https://github.com/camptocamp/ngeo/tree/master/externs>`_ or directly at the `closure-compiler <https://github.com/google/closure-compiler/tree/master/contrib/externs>`_.
+Good examples for such externs can be found in `ngeo <https://github.com/camptocamp/ngeo/tree/master/externs>`_ or directly in the `closure-compiler <https://github.com/google/closure-compiler/tree/master/contrib/externs>`_ project.
 
 Project-specific externs are best placed in ``<package>/static-ngeo/externs/``.
 

--- a/doc/integrator/ngeo.rst
+++ b/doc/integrator/ngeo.rst
@@ -226,3 +226,16 @@ And in the ``all`` (``vars.checker.all``) check all the ngeo interface in standa
        debug: true
 
 By default it is done for the desktop and mobile interface.
+
+Externs
+-------
+
+Adding additional external depedencies requires `declaring them as externs <https://developers.google.com/closure/compiler/docs/api-tutorial3#externs>`_.
+This prevents the closure-compiler from renaming the objects and their properties and allows type-checking.
+Good examples for such externs can be found in `ngeo <https://github.com/camptocamp/ngeo/tree/master/externs>`_ or directly at the `closure-compiler <https://github.com/google/closure-compiler/tree/master/contrib/externs>`_.
+
+Project-specific externs are best placed in ``<package>/static-ngeo/externs/``.
+
+These externs need to be referenced in the ``MAKO_BUILD_ARGS`` variable in your ``<package>.mk``, example::
+
+    MAKO_BUILD_ARGS = --var externs=package/static-ngeo/externs/recaptcha.js,package/static-ngeo/externs/anotherdep.js


### PR DESCRIPTION
This is a [new feature](https://github.com/camptocamp/c2cgeoportal/pull/2971) (with 2.2.1), which is not documented (I found nothing).

My instructions describe how I used the MAKO_BUILD_ARGS in a project. Whether this us actually the intended way is up for discussion.