### PR TITLE
Do not make an inner join on LayerWMS in _create_layer_query

### DIFF
--- a/c2cgeoportal/views/entry.py
+++ b/c2cgeoportal/views/entry.py
@@ -294,7 +294,7 @@ class Entry:
         if role_id is not None:
             query2 = get_protected_layers_query(
                 role_id, None,
-                what=LayerV1.name if version == 1 else LayerWMS.name,
+                what=LayerV1.name if version == 1 else Layer.name,
                 version=version
             )
             if interface is not None:


### PR DESCRIPTION
To get protected WMTS layers returned by query.