### PR TITLE
Wait for db to be healthy before starting build container

### DIFF
--- a/docker-compose.yaml.mako
+++ b/docker-compose.yaml.mako
@@ -1,30 +1,42 @@
----
+version: '2.1'
 
-db:
-  image: camptocamp/geomapfish-test-db:latest
-  environment:
-    - POSTGRES_USER=www-data
-    - POSTGRES_PASSWORD=www-data
-    - POSTGRES_DB=geomapfish_tests
+volumes:
+  ${build_volume_name}:
 
-mapserver:
-  image: camptocamp/geomapfish-test-mapserver:latest
-  links:
-    - db
+services:
+  db:
+    image: camptocamp/geomapfish-test-db:latest
+    environment:
+      - POSTGRES_USER=www-data
+      - POSTGRES_PASSWORD=www-data
+      - POSTGRES_DB=geomapfish_tests
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 3
 
-build:
-  image: camptocamp/geomapfish-admin-build:${major_version}
-  volumes:
-    - ${build_volume_name}:/build
-    - .:/src
-  environment:
-    - USER_NAME
-    - USER_ID
-    - GROUP_ID
-    - CI
-  stdin_open: true
-  tty: true
-  command: ${'$'}{RUN}
-  links:
-    - db
-    - mapserver
+  mapserver:
+    image: camptocamp/geomapfish-test-mapserver:latest
+    links:
+      - db
+
+  build:
+    image: camptocamp/geomapfish-admin-build:${major_version}
+    volumes:
+      - ${build_volume_name}:/build
+      - .:/src
+    environment:
+      - USER_NAME
+      - USER_ID
+      - GROUP_ID
+      - CI
+    stdin_open: true
+    tty: true
+    command: ${'$'}{RUN}
+    links:
+      - db
+      - mapserver
+    depends_on:
+      db:
+        condition: service_healthy


### PR DESCRIPTION
Hope this will fix repetitive failed connections to the database with jenkins.
This take place in the composition, so it should not affect commands runned with `./docker-run`