### PR TITLE
add edit url to tables

### DIFF
--- a/admin/acceptance_tests/edit_url_test.py
+++ b/admin/acceptance_tests/edit_url_test.py
@@ -1,0 +1,138 @@
+# pylint: disable=no-self-use
+
+import re
+import pytest
+
+from . import AbstractViewsTests
+
+
+@pytest.fixture(scope='class')
+@pytest.mark.usefixtures('dbsession')
+def edit_url_test_data(dbsession):
+    from c2cgeoportal_commons.models.main import \
+        LayerWMTS, RestrictionArea, Interface, Role, \
+        LayerWMS, LayerV1, LayerGroup, Theme, OGCServer, Functionality
+
+    dbsession.begin_nested()
+
+    restrictionareas = [RestrictionArea(name='restrictionarea_{}'.format(i))
+                        for i in range(0, 5)]
+    functionalities = {}
+    for name in ('default_basemap', 'location'):
+        functionalities[name] = []
+        for v in range(0, 4):
+            functionality = Functionality(
+                name=name,
+                value='value_{}'.format(v))
+            dbsession.add(functionality)
+            functionalities[name].append(functionality)
+
+    interfaces = [Interface(name) for name in ['desktop', 'mobile', 'edit', 'routing']]
+    ogc_server = OGCServer(name='ogc_server')
+
+    layers_wmts = []
+    for i in range(0, 5):
+        name = 'layer_wmts_{}'.format(i)
+        layer_wmts = LayerWMTS(name=name)
+        layer_wmts.layer = name
+        layer_wmts.url = 'https://server{}.net/wmts'.format(i)
+        layer_wmts.restrictionareas = [restrictionareas[i % 5],
+                                       restrictionareas[(i + 2) % 5]]
+        if i % 10 != 1:
+            layer_wmts.interfaces = [interfaces[i % 4], interfaces[(i + 2) % 4]]
+        layer_wmts.public = 1 == i % 2
+        layer_wmts.image_type = 'image/jpeg'
+        dbsession.add(layer_wmts)
+        layers_wmts.append(layer_wmts)
+
+    layers_wms = []
+    for i in range(0, 5):
+        layer_wms = LayerWMS(name='layer_wms_{}'.format(i))
+        layer_wms.layer = 'wms_layer_{}'.format(i)
+        layer_wms.ogc_server = ogc_server
+        layers_wms.append(layer_wms)
+        dbsession.add(layer_wms)
+        layers_wms.append(layer_wms)
+
+    layers_v1 = []
+    for i in range(0, 5):
+        layer_v1 = LayerV1(name='layer_v1_{}'.format(i))
+        layer_v1.image_type = 'image/jpeg'
+        dbsession.add(layer_v1)
+        layers_v1.append(layer_v1)
+
+    roles = []
+    for i in range(0, 5):
+        role = Role('secretary_' + str(i))
+        role.functionalities = [
+            functionalities['default_basemap'][0],
+            functionalities['location'][0],
+            functionalities['location'][1]]
+        role.restrictionareas = [
+            restrictionareas[0],
+            restrictionareas[1]]
+        dbsession.add(role)
+        roles.append(role)
+
+    dbsession.flush()
+
+    group = LayerGroup(name='groups')
+    dbsession.add(group)
+    theme = Theme(name='theme')
+    dbsession.add(theme)
+
+    dbsession.flush()
+    yield {
+        'ogc_server': ogc_server,
+        'layers_wmts': layers_wmts,
+        'layers_wms': layers_wms,
+        'restrictionareas': restrictionareas,
+        'interfaces': interfaces,
+        'layers_v1': layers_v1,
+        'themes': [theme],
+        'group': group,
+        'roles': roles
+    }
+
+    dbsession.rollback()
+
+
+@pytest.mark.usefixtures('edit_url_test_data', 'test_app')
+class TestUrlEdit(AbstractViewsTests):
+
+    _prefix = '/'
+
+    def _get(self, test_app, tablename, pk):
+        path = '/{}/{}'.format(tablename, pk)
+        return test_app.get(path, status=200)
+
+    def _check_link(self, test_app, resp, item, table, status):
+        link = resp.html.select_one('.form-group.item-{} a'.format(item))
+        assert re.match('http://localhost/{}/\d+'.format(table), link['href']) is not None
+        test_app.get(link.get('href'), status=status)
+
+    def test_layer_wms_edit(self, edit_url_test_data, test_app):
+        resp = self._get(test_app, 'layers_wms', edit_url_test_data['layers_wms'][0].id)
+        self._check_link(test_app, resp, 'restrictionareas', 'restrictionareas', 404)
+        self._check_link(test_app, resp, 'interfaces', 'interfaces', 200)
+
+    def test_layer_wmts_edit(self, edit_url_test_data, test_app):
+        resp = self._get(test_app, 'layers_wmts', edit_url_test_data['layers_wmts'][0].id)
+        self._check_link(test_app, resp, 'restrictionareas', 'restrictionareas', 404)
+        self._check_link(test_app, resp, 'interfaces', 'interfaces', 200)
+
+    def test_layer_v1_edit(self, edit_url_test_data, test_app):
+        resp = self._get(test_app, 'layers_v1', edit_url_test_data['layers_v1'][0].id)
+        self._check_link(test_app, resp, 'restrictionareas', 'restrictionareas', 404)
+        self._check_link(test_app, resp, 'interfaces', 'interfaces', 200)
+
+    def test_roles_edit(self, edit_url_test_data, test_app):
+        resp = self._get(test_app, 'roles', edit_url_test_data['roles'][0].id)
+        self._check_link(test_app, resp, 'functionalities', 'functionalities', 404)
+        self._check_link(test_app, resp, 'restrictionareas', 'restrictionareas', 404)
+
+    def test_themes_edit(self, edit_url_test_data, test_app):
+        resp = self._get(test_app, 'themes', edit_url_test_data['themes'][0].id)
+        self._check_link(test_app, resp, 'functionalities', 'functionalities', 404)
+        self._check_link(test_app, resp, 'interfaces', 'interfaces', 200)
+        self._check_link(test_app, resp, 'restricted_roles', 'roles', 200)

--- a/admin/c2cgeoportal_admin/views/interfaces.py
+++ b/admin/c2cgeoportal_admin/views/interfaces.py
@@ -21,7 +21,12 @@ interfaces_schema_node = colander.SequenceSchema(
         Interface,
         'id',
         'name',
-        order_by='name'
+        order_by='name',
+        edit_url=lambda request, value: request.route_url(
+            'c2cgeoform_item',
+            table='interfaces',
+            id=value
+        )
     ),
     validator=manytomany_validator
 )

--- a/admin/c2cgeoportal_admin/views/restrictionareas.py
+++ b/admin/c2cgeoportal_admin/views/restrictionareas.py
@@ -13,7 +13,12 @@ restrictionareas_schema_node = colander.SequenceSchema(
         RestrictionArea,
         'id',
         'name',
-        order_by='name'
+        order_by='name',
+        edit_url=lambda request, value: request.route_url(
+            'c2cgeoform_item',
+            table='restrictionareas',
+            id=value
+        )
     ),
     validator=manytomany_validator
 )

--- a/admin/c2cgeoportal_admin/views/roles.py
+++ b/admin/c2cgeoportal_admin/views/roles.py
@@ -31,7 +31,11 @@ base_schema.add_before(
             ]).alias('functionnality_labels'),
             'id',
             'label',
-            order_by='label'
+            order_by='label',
+            edit_url=lambda request, value: request.route_url(
+                'c2cgeoform_item',
+                table='functionalities', id=value
+            )
         ),
         validator=manytomany_validator
     )
@@ -45,7 +49,12 @@ base_schema.add_before(
             RestrictionArea,
             'id',
             'name',
-            order_by='name'
+            order_by='name',
+            edit_url=lambda request, value: request.route_url(
+                'c2cgeoform_item',
+                table='restrictionareas',
+                id=value
+            )
         ),
         validator=manytomany_validator
     )

--- a/admin/c2cgeoportal_admin/views/themes.py
+++ b/admin/c2cgeoportal_admin/views/themes.py
@@ -36,7 +36,12 @@ base_schema.add(
             ]).alias('functionnality_labels'),
             'id',
             'label',
-            order_by='label'
+            order_by='label',
+            edit_url=lambda request, value: request.route_url(
+                'c2cgeoform_item',
+                table='functionalities',
+                id=value
+            )
         ),
         validator=manytomany_validator
     )
@@ -50,7 +55,12 @@ base_schema.add(
             Role,
             'id',
             'name',
-            order_by='name'
+            order_by='name',
+            edit_url=lambda request, value: request.route_url(
+                'c2cgeoform_item',
+                table='roles',
+                id=value
+            )
         ),
         validator=manytomany_validator
     )
@@ -64,7 +74,12 @@ base_schema.add(
             Interface,
             'id',
             'name',
-            order_by='name'
+            order_by='name',
+            edit_url=lambda request, value: request.route_url(
+                'c2cgeoform_item',
+                table='interfaces',
+                id=value
+            )
         ),
         validator=manytomany_validator
     )

--- a/commons/requirements.txt
+++ b/commons/requirements.txt
@@ -1,1 +1,1 @@
--e git://github.com/camptocamp/c2cgeoform.git@f77bf5295f5a89b245de28f7569d38465770cfe7#egg=c2cgeoform
+-e git://github.com/camptocamp/c2cgeoform.git@af260ab46aec204ede78dd9d7ac2eda5c98bf2c0#egg=c2cgeoform


### PR DESCRIPTION
List of checkboxes have a new pen icon to allow users to edit an element (for instance, a
role). Clicking on this icon will first check if changes were made in the current form. If the
user switches to another form, there's no way back – only one form is open at a time

Requires:
Adapt templates : 
https://github.com/camptocamp/c2cgeoform/pull/153
Check before leaving page if form has changed:
https://github.com/camptocamp/c2cgeoform/pull/155