### PR TITLE
Fix standard login access control

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_vars.yaml_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_vars.yaml_tmpl
@@ -340,7 +340,7 @@ vars:
         themes: &auth_header
             access_control_max_age: 600 # 10 minutes
             access_control_allow_origin:
-            - "{web_protocol}://{host}/"
+            - "{web_protocol}://{host}"
             - "*"
         config: *auth_header
         print: *auth_header
@@ -352,7 +352,7 @@ vars:
         login:
             access_control_max_age: 600 # 10 minutes
             access_control_allow_origin:
-            - "{web_protocol}://{host}/"
+            - "{web_protocol}://{host}"
 
     # Checker configuration
     checker:


### PR DESCRIPTION
For issue https://github.com/camptocamp/c2cgeoportal/issues/3400

Origin host name comes (example from Nyon) like this: https://map-demo.nyon.ch
So the default vars should be "{web_protocol}://{host}, not "{web_protocol}://{host}/