### PR TITLE
update mfp version

### DIFF
--- a/c2cgeoportal/scaffolds/create/CONST_print_url
+++ b/c2cgeoportal/scaffolds/create/CONST_print_url
@@ -1,0 +1,1 @@
+https://repo1.maven.org/maven2/org/mapfish/print/print-servlet/3.10.7/print-servlet-3.10.7.war

--- a/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -1,6 +1,14 @@
 This file includes migration steps for each release of c2cgeoportal.
 
 
+Version 2.2.3
+=============
+
+1. To update MapFish Print, you should get the corresponding file:
+
+    cp CONST_create_template/CONST_print_url .
+
+
 Version 2.2.0
 =============
 

--- a/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -114,7 +114,7 @@ ifndef TEST_PACKAGES
 TEST_PACKAGES = common
 ifeq ($(DOCKER), FALSE)
 TEST_PACKAGES += main
-ifneq (, $(filter $(PRINT_VERSION), 2 3))
+ifeq ($(PRINT_VERSION), 3)
 TEST_PACKAGES += print
 endif
 ifeq ($(MAPSERVER), TRUE)
@@ -143,9 +143,6 @@ DEFAULT_BUILD_RULES += test-packages
 endif
 ifeq ($(TILECLOUD_CHAIN), TRUE)
 DEFAULT_BUILD_RULES += tilegeneration/config.yaml
-endif
-ifeq ($(PRINT_VERSION), 2)
-DEFAULT_BUILD_RULES += print
 endif
 ifeq ($(PRINT_VERSION), 3)
 DEFAULT_BUILD_RULES += print
@@ -449,17 +446,8 @@ PRINT_REQUIREMENT += \
 	$(shell $(FIND) $(PRINT_BASE_DIR)/print-apps)
 I18N_SOURCE_FILES += print/print-apps/$(PACKAGE)/config.yaml
 endif
-ifeq ($(PRINT_VERSION), 2)
-PRINT_OUTPUT_WAR = $(PRINT_OUTPUT)/$(PRINT_WAR)
-PRINT_BASE_WAR ?= print-servlet-2.1-SNAPSHOT-IMG-MAGICK.war
-PRINT_INPUT_LS += config.yaml WEB-INF/classes/log4j.properties
-PRINT_INPUT_FIND += *.tif *.bmp *.jpg *.jpeg *.gif *.png *.pdf *.xml
-PRINT_INPUT += $(shell cd $(PRINT_BASE_DIR) && ls -1 $(PRINT_INPUT_LS) 2> /dev/null)
-PRINT_INPUT += $(foreach INPUT, $(PRINT_INPUT_FIND), $(shell cd $(PRINT_BASE_DIR) && $(FIND) -name '$(INPUT)' -type f))
-PRINT_REQUIREMENT += $(addprefix $(PRINT_BASE_DIR)/, $(PRINT_INPUT))
-endif
 
-ifneq (, $(filter $(PRINT_VERSION), 2 3))
+ifeq ($(PRINT_VERSION), 3)
 PRINT_FILES += $(shell $(FIND) print $(FIND_OPTS) -not -name ".mako" -not -name ".jinja" -print)
 PRINT_MAKO_FILES += $(shell $(FIND) print $(FIND_OPTS) -name "*.mako" -print)
 PRINT_JINJA_FILES += $(shell $(FIND) print $(FIND_OPTS) -name "*.jinja" -print)
@@ -1151,7 +1139,9 @@ endif
 else
 	cp $(PRINT_BASE_DIR)/$(PRINT_BASE_WAR) $(PRINT_TMP)/$(PRINT_WAR)
 ifeq ($(PRINT_VERSION), 3)
-	zip -d $(PRINT_TMP)/$(PRINT_WAR) print-apps/
+	# Versions mfp up to 3.10 have a print-apps directory; later versions do not,
+	# so ignore any errors resulting from zip
+	zip -d $(PRINT_TMP)/$(PRINT_WAR) print-apps/ || true
 endif
 	cd $(PRINT_BASE_DIR) && jar -uf $(PRINT_TMP)/$(PRINT_WAR) $(PRINT_INPUT)
 	chmod g+r,o+r $(PRINT_TMP)/$(PRINT_WAR)

--- a/c2cgeoportal/scaffolds/update/CONST_print_url
+++ b/c2cgeoportal/scaffolds/update/CONST_print_url
@@ -1,1 +1,0 @@
-https://repo1.maven.org/maven2/org/mapfish/print/print-servlet/3.10.6/print-servlet-3.10.6.war

--- a/c2cgeoportal/scaffolds/update/print/Dockerfile
+++ b/c2cgeoportal/scaffolds/update/print/Dockerfile
@@ -1,4 +1,4 @@
-FROM camptocamp/mapfish_print:3.10.6
+FROM camptocamp/mapfish_print:3.10.7
 LABEL maintainer Camptocamp "info@camptocamp.com"
 
 RUN rm -rf webapps/ROOT/print-apps


### PR DESCRIPTION
update mfp version; needs an update to Makefile, too, because mfp starting 3.11 no longer contains a print-apps directory.

Note that mfp 3.11 and older require a Java 8 runtime on the system. A Debian 8 backport for Java 8 is available, and installed on c2c's test and demo servers.