### PR TITLE
Forward the request tracking ID to the other service

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/print/print-apps/+package+/config.yaml.mako
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/print/print-apps/+package+/config.yaml.mako
@@ -59,6 +59,7 @@ templates:
           - !forwardHeaders
             headers:
               - Referer
+              - X-Request-ID
           - !restrictUris
             matchers:
               - !localMatch

--- a/geoportal/c2cgeoportal_geoportal/views/proxy.py
+++ b/geoportal/c2cgeoportal_geoportal/views/proxy.py
@@ -88,6 +88,10 @@ class Proxy(object):
         if parsed_url.hostname not in self.host_forward_host and "Host" in headers:  # pragma: no cover
             headers.pop("Host")
 
+        # Forward the request tracking ID to the other service. This will allow to follow the logs belonging
+        # to a single request coming from the user
+        headers.setdefault('X-Request-ID', self.request.c2c_request_id)
+
         if not cache:
             headers["Cache-Control"] = "no-cache"
 

--- a/geoportal/tests/functional/__init__.py
+++ b/geoportal/tests/functional/__init__.py
@@ -171,6 +171,7 @@ def create_dummy_request(additional_settings=None, authentication=True, user=Non
     request.get_user = _get_user
     request.registry.validate_user = default_user_validator
     request.client_addr = None
+    request.c2c_request_id = 'test'
     if authentication and user is None:
         request._get_authentication_policy = lambda: create_authentication({
             "authtkt_cookie_name": "__test",


### PR DESCRIPTION
This will allow to follow the logs belonging to a single request coming from
the user.