### PR TITLE
Forward the request tracking ID to the other service

### DIFF
--- a/c2cgeoportal/scaffolds/create/print/print-apps/+package+/config.yaml.mako
+++ b/c2cgeoportal/scaffolds/create/print/print-apps/+package+/config.yaml.mako
@@ -49,6 +49,7 @@ templates:
             - !forwardHeaders
                 headers:
                 - Referer
+                - X-Request-ID
             - !restrictUris
                 matchers:
                 - !localMatch

--- a/c2cgeoportal/tests/functional/__init__.py
+++ b/c2cgeoportal/tests/functional/__init__.py
@@ -161,6 +161,7 @@ def create_dummy_request(additional_settings=None, authentication=True, user=Non
     request.get_user = _get_user
     request.registry.validate_user = default_user_validator
     request.client_addr = None
+    request.c2c_request_id = 'test'
     if authentication and user is None:
         request._get_authentication_policy = lambda: create_authentication({
             "authtkt_cookie_name": "__test",

--- a/c2cgeoportal/views/proxy.py
+++ b/c2cgeoportal/views/proxy.py
@@ -90,6 +90,10 @@ class Proxy(object):
         if parsed_url.hostname not in self.host_forward_host and "Host" in headers:  # pragma: no cover
             headers.pop("Host")
 
+        # Forward the request tracking ID to the other service. This will allow to follow the logs belonging
+        # to a single request coming from the user
+        headers.setdefault('X-Request-ID', self.request.c2c_request_id)
+
         if not cache:
             headers["Cache-Control"] = "no-cache"
 


### PR DESCRIPTION
This will allow to follow the logs belonging to a single request coming from
the user.

This is a copy-paste of master's commit 69b4cd372bf621473aab998c15d0bd56645a674d; cherry-pick not possible because of difference in paths.