### PR TITLE
Fix HOME when using make as entry point

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ VALIDATE_PY_TEST_FOLDERS = geoportal/tests
 SPHINX_FILES = $(shell find doc -name "*.rst" -print)
 SPHINX_MAKO_FILES = $(shell find doc -name "*.rst.mako" -print)
 
-HOME=$(HOME_DIR)
+HOME_DIR=$(HOME)
 export TX_VERSION = $(shell echo $(MAJOR_VERSION) | awk -F . '{{print $$1"_"$$2}}')
 TX_DEPENDENCIES = $(HOME_DIR)/.transifexrc .tx/config
 ifeq (,$(wildcard $(HOME_DIR)/.transifexrc))

--- a/docker-run
+++ b/docker-run
@@ -96,7 +96,6 @@ def main():
     else:
         # For Jenkins slave in Docker
         docker_adrs = netifaces.gateways()[netifaces.AF_INET][0][0]
-    docker_cmd.append("--env=HOME_DIR={}".format(os.environ["HOME"]))
     docker_cmd.append("--env=DOCKER_HOST_={}".format(docker_adrs))
     docker_cmd.append("--env=BUILD_VOLUME_NAME={}".format(build_volume_name))
     docker_cmd.append("--env=PROJECT_DIRECTORY={}".format(os.getcwd()))


### PR DESCRIPTION
Here I fix HOME when running make directly ex : make docker-build.
HOME_DIR seems always equals to HOME so I suppose it could be removed completely.
With this I can now create a amorvan.mk file with custom tasks for special dev purposes.
Ex: 
```
.PHONY: testgeomapfish
testgeomapfish:
	# ./docker-run make build-docker
	export SRID=21781 EXTENT=489246.36,78873.44,837119.76,296543.14
	./docker-run --image=camptocamp/geomapfish-build --share ${HOME}/workspace pcreate --scaffold=c2cgeoportal_create \
		--ignore-conflicting-name --package-name testgeomapfish ${HOME}/workspace/testgeomapfish --overwrite
	./docker-run --image=camptocamp/geomapfish-build --share ${HOME}/workspace pcreate --scaffold=c2cgeoportal_update \
		--ignore-conflicting-name --package-name testgeomapfish ${HOME}/workspace/testgeomapfish --overwrite
```