### PR TITLE
Fix distutils.errors.DistutilsArgError: no commands supplied error

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/geoportal/+package+_geoportal/__init__.py_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/geoportal/+package+_geoportal/__init__.py_tmpl
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import distutils.core
 from pyramid.config import Configurator
 from c2cgeoportal_geoportal import locale_negotiator, add_interface, INTERFACE_TYPE_NGEO
 from c2cgeoportal_geoportal.lib.authentication import create_authentication
@@ -16,7 +17,10 @@ def main(global_config, **settings):
         authentication_policy=create_authentication(settings)
     )
 
+    # Workaround to not have the error: distutils.errors.DistutilsArgError: no commands supplied
+    distutils.core._setup_stop_after = 'config'
     config.include('c2cgeoportal_geoportal')
+    distutils.core._setup_stop_after = None
 
     config.add_translation_dirs('{{package}}_geoportal:locale/')
 


### PR DESCRIPTION
Without that I have this:
```
[Mon Mar 19 16:37:49.986154 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59338] error: no commands supplied
[Mon Mar 19 16:37:54.911802 2018] [wsgi:error] [pid 9879] Warning: The key 'arguments' is not present in: ['backend']
[Mon Mar 19 16:37:54.984687 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346] mod_wsgi (pid=9879): Target WSGI script '/home/sbrunner/demo_geomapfish/apache/application.wsgi' cannot be loaded as Python module.
[Mon Mar 19 16:37:54.984798 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346] mod_wsgi (pid=9879): SystemExit exception raised by WSGI script '/home/sbrunner/demo_geomapfish/apache/application.wsgi' ignored.
[Mon Mar 19 16:37:54.985240 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346] Traceback (most recent call last):
[Mon Mar 19 16:37:54.985387 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]   File "/usr/lib/python3.5/distutils/core.py", line 134, in setup
[Mon Mar 19 16:37:54.985423 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]     ok = dist.parse_command_line()
[Mon Mar 19 16:37:54.985543 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]   File "/home/sbrunner/demo_geomapfish/.build/venv/lib/python3.5/site-packages/setuptools/dist.py", line 499, in parse_command_line
[Mon Mar 19 16:37:54.985574 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]     result = _Distribution.parse_command_line(self)
[Mon Mar 19 16:37:54.985700 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]   File "/usr/lib/python3.5/distutils/dist.py", line 490, in parse_command_line
[Mon Mar 19 16:37:54.985766 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]     raise DistutilsArgError("no commands supplied")
[Mon Mar 19 16:37:54.985847 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346] distutils.errors.DistutilsArgError: no commands supplied
[Mon Mar 19 16:37:54.985925 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346] 
[Mon Mar 19 16:37:54.985975 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346] During handling of the above exception, another exception occurred:
[Mon Mar 19 16:37:54.986018 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346] 
[Mon Mar 19 16:37:54.986068 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346] Traceback (most recent call last):
[Mon Mar 19 16:37:54.986175 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]   File "/home/sbrunner/demo_geomapfish/apache/application.wsgi", line 20, in <module>
[Mon Mar 19 16:37:54.986206 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]     application = get_app(configfile, 'main')
[Mon Mar 19 16:37:54.986283 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]   File "/home/sbrunner/demo_geomapfish/.build/venv/lib/python3.5/site-packages/pyramid/paster.py", line 28, in get_app
[Mon Mar 19 16:37:54.986344 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]     return loader.get_wsgi_app(name, options)
[Mon Mar 19 16:37:54.986396 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]   File "/home/sbrunner/demo_geomapfish/.build/venv/lib/python3.5/site-packages/plaster_pastedeploy/__init__.py", line 131, in get_wsgi_app
[Mon Mar 19 16:37:54.986442 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]     global_conf=defaults)
[Mon Mar 19 16:37:54.986492 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]   File "/home/sbrunner/demo_geomapfish/.build/venv/lib/python3.5/site-packages/paste/deploy/loadwsgi.py", line 247, in loadapp
[Mon Mar 19 16:37:54.986539 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]     return loadobj(APP, uri, name=name, **kw)
[Mon Mar 19 16:37:54.986589 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]   File "/home/sbrunner/demo_geomapfish/.build/venv/lib/python3.5/site-packages/paste/deploy/loadwsgi.py", line 272, in loadobj
[Mon Mar 19 16:37:54.986635 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]     return context.create()
[Mon Mar 19 16:37:54.986697 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]   File "/home/sbrunner/demo_geomapfish/.build/venv/lib/python3.5/site-packages/paste/deploy/loadwsgi.py", line 710, in create
[Mon Mar 19 16:37:54.986745 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]     return self.object_type.invoke(self)
[Mon Mar 19 16:37:54.986794 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]   File "/home/sbrunner/demo_geomapfish/.build/venv/lib/python3.5/site-packages/paste/deploy/loadwsgi.py", line 203, in invoke
[Mon Mar 19 16:37:54.986841 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]     app = context.app_context.create()
[Mon Mar 19 16:37:54.986890 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]   File "/home/sbrunner/demo_geomapfish/.build/venv/lib/python3.5/site-packages/paste/deploy/loadwsgi.py", line 710, in create
[Mon Mar 19 16:37:54.986938 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]     return self.object_type.invoke(self)
[Mon Mar 19 16:37:54.986988 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]   File "/home/sbrunner/demo_geomapfish/.build/venv/lib/python3.5/site-packages/paste/deploy/loadwsgi.py", line 146, in invoke
[Mon Mar 19 16:37:54.987034 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]     return fix_call(context.object, context.global_conf, **context.local_conf)
[Mon Mar 19 16:37:54.987084 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]   File "/home/sbrunner/demo_geomapfish/.build/venv/lib/python3.5/site-packages/paste/deploy/util.py", line 55, in fix_call
[Mon Mar 19 16:37:54.987130 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]     val = callable(*args, **kw)
[Mon Mar 19 16:37:54.987180 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]   File "/home/sbrunner/demo_geomapfish/geoportal/demo_geoportal/__init__.py", line 25, in main
[Mon Mar 19 16:37:54.987226 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]     config.include('c2cgeoportal_geoportal')
[Mon Mar 19 16:37:54.987276 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]   File "/home/sbrunner/demo_geomapfish/.build/venv/lib/python3.5/site-packages/pyramid/config/__init__.py", line 839, in include
[Mon Mar 19 16:37:54.987322 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]     c(configurator)
[Mon Mar 19 16:37:54.987372 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]   File "/home/sbrunner/demo_geomapfish/c2cgeoportal_geoportal/c2cgeoportal_geoportal/__init__.py", line 698, in includeme
[Mon Mar 19 16:37:54.987417 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]     config.scan(ignore=["c2cgeoportal_geoportal.scripts", "c2cgeoportal_geoportal.wsgi_app"])
[Mon Mar 19 16:37:54.987467 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]   File "/home/sbrunner/demo_geomapfish/.build/venv/lib/python3.5/site-packages/pyramid/config/__init__.py", line 1043, in scan
[Mon Mar 19 16:37:54.987520 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]     ignore=ignore)
[Mon Mar 19 16:37:54.987570 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]   File "/home/sbrunner/demo_geomapfish/.build/venv/lib/python3.5/site-packages/venusian/__init__.py", line 230, in scan
[Mon Mar 19 16:37:54.987643 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]     __import__(modname)
[Mon Mar 19 16:37:54.987707 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]   File "/home/sbrunner/demo_geomapfish/c2cgeoportal_geoportal/c2cgeoportal_geoportal/setup.py", line 135, in <module>
[Mon Mar 19 16:37:54.987755 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]     'geomapfish-angular = c2cgeoportal_geoportal.lib.lingua_extractor:GeoMapfishAngularExtractor',
[Mon Mar 19 16:37:54.987805 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]   File "/home/sbrunner/demo_geomapfish/.build/venv/lib/python3.5/site-packages/setuptools/__init__.py", line 129, in setup
[Mon Mar 19 16:37:54.987852 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]     return distutils.core.setup(**attrs)
[Mon Mar 19 16:37:54.987902 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]   File "/usr/lib/python3.5/distutils/core.py", line 136, in setup
[Mon Mar 19 16:37:54.987947 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]     raise SystemExit(gen_usage(dist.script_name) + "\\nerror: %s" % msg)
[Mon Mar 19 16:37:54.988008 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346] SystemExit: usage: mod_wsgi [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
[Mon Mar 19 16:37:54.988058 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]    or: mod_wsgi --help [cmd1 cmd2 ...]
[Mon Mar 19 16:37:54.988100 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]    or: mod_wsgi --help-commands
[Mon Mar 19 16:37:54.988141 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346]    or: mod_wsgi cmd --help
[Mon Mar 19 16:37:54.988182 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346] 
[Mon Mar 19 16:37:54.988222 2018] [wsgi:error] [pid 9879] [remote 128.179.66.4:59346] error: no commands supplied
```