### PR TITLE
FTS: Use similarity by default

### DIFF
--- a/doc/integrator/fulltext_search.rst
+++ b/doc/integrator/fulltext_search.rst
@@ -196,22 +196,26 @@ following variables:
 Ranking system
 --------------
 
-By default, the full-text search uses `tsvector` and `ts_rank_cd` to rank your search results (See:
-`textsearch-controls <https://www.postgresql.org/docs/9.0/static/textsearch-controls.html>`_. These methods
-are useful to handle language-based strings. That means for instance that plural nouns are the same as
-singular nouns. This system only checks if your search word exists in the result. That means that if you search
-`B 12 Zug`, `B 120 Zug` has the same weight because the system only see that the `12` exists in each case.
+By default, the full-text search uses the `similarity` system of the
+`pg_trgm module <https://www.postgresql.org/docs/9.0/static/pgtrgm.html>`. This
+is based only on the  similarities of words, without language analysis, and it
+cares only about how near is your search with the result. `12` is nearer to `12`
+than `120`.
 
-Alternatively you can use the `similarity` system of the
-`pg_trgm module <https://www.postgresql.org/docs/9.0/static/pgtrgm.html>`. This is based only on the
-similarities of words, without language analysis, and it cares only about how near is your search with the
-result. `12` is nearer to `12` than `120`.
-To use this system, your request must contains the parameter `rank_system=similarity` and your database must
-have the pg_trgm extension:
+Ensure that the extension is created in you database:
 
-.. code:: sql
+.. prompt:: bash
 
-   CREATE EXTENSION pg_trgm;
+  sudo -u postgres psql -c "CREATE EXTENSION pg_trgm" <db_name>
+
+Alternatively, you can use the `tsvector` and `ts_rank_cd` to rank your search
+results (See: `textsearch-controls <https://www.postgresql.org/docs/9.0/static/textsearch-controls.html>`_.
+These methods are useful to handle language-based strings. That means for instance
+that plural nouns are the same as singular nouns. This system only checks if
+your search word exists in the result. That means that if you search `B 12 Zug`,
+`B 120 Zug` has the same weight because the system only see that the `12` exists
+in each case. To use this system, your request must contains the
+parameter `rank_system=ts_rank_cd`.
 
 Using the unaccent extension
 ----------------------------

--- a/doc/integrator/install_application.rst
+++ b/doc/integrator/install_application.rst
@@ -70,6 +70,13 @@ with ``<db_name>`` replaced by the actual database name.
    Note that the path of the postgis scripts and the template name can
    differ on your host.
 
+Create the "pg_trgm" extension to use the "similarity" function within the
+full-text search:
+
+.. prompt:: bash
+
+  sudo -u postgres psql -c "CREATE EXTENSION pg_trgm" <db_name>
+
 .. _integrator_install_application_create_schema:
 
 Create the schema

--- a/geoportal/c2cgeoportal_geoportal/views/fulltextsearch.py
+++ b/geoportal/c2cgeoportal_geoportal/views/fulltextsearch.py
@@ -123,10 +123,7 @@ class FullTextSearchView:
         ))
 
         rank_system = self.request.params.get("ranksystem")
-        if rank_system == "similarity":
-            # Use similarity ranking system from module pg_trgm.
-            rank = func.similarity(FullTextSearch.label, terms)
-        else:
+        if rank_system == "ts_rank_cd":
             # The numbers used in ts_rank_cd() below indicate a normalization method.
             # Several normalization methods can be combined using |.
             # 2 divides the rank by the document length
@@ -137,6 +134,9 @@ class FullTextSearchView:
             # (the normalization is applied two times with the combination of 2 and 8,
             # so the effect on at least the one-word-results is therefore stronger).
             rank = func.ts_rank_cd(FullTextSearch.ts, func.to_tsquery(language, terms_ts), 2 | 8)
+        else:
+            # Use similarity ranking system from module pg_trgm.
+            rank = func.similarity(FullTextSearch.label, terms)
 
         if partitionlimit:
             # Here we want to partition the search results based on

--- a/geoportal/tests/functional/test_fulltextsearch.py
+++ b/geoportal/tests/functional/test_fulltextsearch.py
@@ -407,7 +407,7 @@ class TestFulltextsearchView(TestCase):
         from c2cgeoportal_geoportal.views.fulltextsearch import FullTextSearchView
 
         request = self._create_dummy_request(
-            params=dict(query="simi", limit=3, ranksystem="similarity")
+            params=dict(query="simi", limit=3)
         )
         fts = FullTextSearchView(request)
         response = fts.fulltextsearch()
@@ -416,3 +416,18 @@ class TestFulltextsearchView(TestCase):
         self.assertEqual(response.features[0].properties["label"], "A 7 simi")
         self.assertEqual(response.features[1].properties["label"], "A 70 simi")
         self.assertEqual(response.features[2].properties["label"], "A 71 simi")
+
+    def test_rank_order_with_ts_rank_cd(self):
+        from geojson.feature import FeatureCollection
+        from c2cgeoportal_geoportal.views.fulltextsearch import FullTextSearchView
+
+        request = self._create_dummy_request(
+            params=dict(query="simi", limit=3, ranksystem="ts_rank_cd")
+        )
+        fts = FullTextSearchView(request)
+        response = fts.fulltextsearch()
+        self.assertTrue(isinstance(response, FeatureCollection))
+        self.assertEqual(len(response.features), 3)
+        self.assertEqual(response.features[0].properties["label"], "A 70 simi")
+        self.assertEqual(response.features[1].properties["label"], "A 71 simi")
+        self.assertEqual(response.features[2].properties["label"], "A 7 simi")


### PR DESCRIPTION
For GEO-908

In 2.3, we want to use "similarity" by default.

As "similarity" is now used by default, should I add a "CREATE EXTENSION pg_trgm;" in an alembic script ?