### PR TITLE
Add user.last_login, expire_on and deactivated

### DIFF
--- a/admin/c2cgeoportal_admin/views/users.py
+++ b/admin/c2cgeoportal_admin/views/users.py
@@ -23,8 +23,9 @@ class UserViews(AbstractViews):
         _list_field('username'),
         _list_field('role_name'),
         _list_field('email'),
-        _list_field('expiration_date'),
-        _list_field('last_login')]
+        _list_field('last_login'),
+        _list_field('expire_on'),
+        _list_field('deactivated')]
     _id_field = 'id'
     _model = User
     _base_schema = base_schema

--- a/geoportal/c2cgeoportal_geoportal/views/entry.py
+++ b/geoportal/c2cgeoportal_geoportal/views/entry.py
@@ -39,7 +39,6 @@ from random import Random
 from math import sqrt
 from defusedxml.minidom import parseString
 from collections import Counter
-from datetime import datetime
 
 from pyramid.view import view_config
 from pyramid.i18n import TranslationStringFactory
@@ -1469,9 +1468,8 @@ class Entry:
         user = self.request.registry.validate_user(self.request, login, password)
         if user is not None:
             headers = remember(self.request, user)
-            self._set_last_login(login)
+            user.set_last_login()
             log.info("User '{0!s}' logged in.".format(login))
-
             came_from = self.request.params.get("came_from")
             if came_from:
                 return HTTPFound(location=came_from, headers=headers)
@@ -1598,12 +1596,6 @@ class Entry:
         user.set_temp_password(password)
 
         return user, username, password, None
-
-    def _set_last_login(self, username):
-        sess = models.DBSession()
-        user = sess.query(static.User).filter(static.User.username == username).one()
-        user.last_login = datetime.now()
-        sess.add(user)
 
     @view_config(route_name="loginresetpassword", renderer="json")
     def loginresetpassword(self):  # pragma: no cover


### PR DESCRIPTION
Note that this is based on @ger-benjamin branch, could be squashed before merge to master.

Not sure it make sense to set last_login = now during migration. This could be left to administrator.

Note that in mosts systems we use last_connection instead of last_login, as login is not required in all cases (remember using cookie, kerberos authentication, and maybe others).