### PR TITLE
Add zope.event in commons requirements

### DIFF
--- a/commons/requirements.txt
+++ b/commons/requirements.txt
@@ -8,3 +8,4 @@ papyrus
 pyramid
 sqlalchemy
 transaction
+zope.event


### PR DESCRIPTION
Used at least here: https://github.com/camptocamp/c2cgeoportal/blob/master/commons/c2cgeoportal_commons/models/main.py#L45