### PR TITLE
[admin] Fix convert without defaults. GSGMF429

### DIFF
--- a/admin/acceptance_tests/layers_wms_test.py
+++ b/admin/acceptance_tests/layers_wms_test.py
@@ -352,6 +352,12 @@ class TestLayerWMSViews(AbstractViewsTests):
         resp = test_app.get(resp.json['redirect'], status=200)
         assert 'image/jpeg' == resp.form['image_type'].value
 
+    def test_convert_without_wmts_defaults(self, test_app, layer_wms_test_data, dbsession):
+        from c2cgeoportal_commons.models.main import LayerWMTS
+        dbsession.delete(LayerWMTS.get_default(dbsession))
+        layer = layer_wms_test_data['layers'][3]
+        test_app.post("/layers_wms/{}/convert_to_wmts".format(layer.id), status=200)
+
     def test_unicity_validator(self, layer_wms_test_data, test_app):
         layer = layer_wms_test_data['layers'][2]
         resp = test_app.get("/layers_wms/{}/duplicate".format(layer.id), status=200)

--- a/admin/acceptance_tests/layers_wmts_test.py
+++ b/admin/acceptance_tests/layers_wmts_test.py
@@ -255,3 +255,9 @@ class TestLayerWMTS(AbstractViewsTests):
         self._check_dimensions(resp.html, layer.dimensions)
         assert 'Your submission has been taken into account.' == \
             resp.html.find('div', {'class': 'msg-lbl'}).getText()
+
+    def test_convert_without_wms_defaults(self, test_app, layer_wmts_test_data, dbsession):
+        from c2cgeoportal_commons.models.main import LayerWMS
+        dbsession.delete(LayerWMS.get_default(dbsession))
+        layer = layer_wmts_test_data['layers'][3]
+        test_app.post("/layers_wmts/{}/convert_to_wms".format(layer.id), status=200)

--- a/admin/c2cgeoportal_admin/views/layers_wms.py
+++ b/admin/c2cgeoportal_admin/views/layers_wms.py
@@ -113,17 +113,24 @@ class LayerWmsViews(DimensionLayerViews):
         src = self._get_object()
         dbsession = self._request.dbsession
         default_wmts = LayerWMTS.get_default(dbsession)
+        values = {
+            'url': default_wmts.url,
+            'matrix_set': default_wmts.matrix_set
+        } if default_wmts else {
+            'url': '',
+            'matrix_set': ''
+        }
         with dbsession.no_autoflush:
             d = delete(LayerWMS.__table__)
             d = d.where(LayerWMS.__table__.c.id == src.id)
             i = insert(LayerWMTS.__table__)
-            i = i.values({
+            values.update({
                 'id': src.id,
-                'url': default_wmts.url,
-                'matrix_set': default_wmts.matrix_set,
                 'layer': src.layer,
                 'image_type': src.ogc_server.image_type,
-                'style': src.style})
+                'style': src.style
+            })
+            i = i.values(values)
             u = update(TreeItem.__table__)
             u = u.where(TreeItem.__table__.c.id == src.id)
             u = u.values({'type': 'l_wmts'})


### PR DESCRIPTION
This is a workaround for the case the defaults layers does not exist.

In case we convert a WMS to WMTS without default WMTS layer the converted WMTS layer has this values:
* url: ""
* matrix_set: ""
=> already committed, but when user click on submit in the resulting WMTS form the empty fields are refused by the validation (interpreted as NULL).

This seems acceptable.

On the other side (WMTS => WMS), I take the first OGCServer id.

Note that it should also be possible to create the default layers by an alembic script, but we will have the same choices to do concerning the missing default values.

Better handling could be to propose the values to the user before committing, but this may be a little more complex to change now.