### PR TITLE
[admin] Set layertree header background to white

### DIFF
--- a/admin/c2cgeoportal_admin/static/layertree.css
+++ b/admin/c2cgeoportal_admin/static/layertree.css
@@ -10,7 +10,7 @@
 }
 .jstree-grid-wrapper .jstree-grid-header {
   border-bottom: 1px solid #ddd;
-  background-color: inherit;
+  background-color: white;
 }
 .jstree-grid-wrapper .jstree-grid-column {
   border-right: 1px solid #ddd;


### PR DESCRIPTION
Because when transparent, rows are visible behing the header when scrolling