### PR TITLE
[1.6] Add missing oldpassword field in html templates

### DIFF
--- a/c2cgeoportal/scaffolds/create/+package+/templates/edit.html_tmpl
+++ b/c2cgeoportal/scaffolds/create/+package+/templates/edit.html_tmpl
@@ -65,6 +65,7 @@
         <form method="POST" id="loginForm" style="display: none">
             <input id="login" name="login" type="text" autocomplete="on"/>
             <input id="password" name="password" type="password" autocomplete="on"/>
+            <input id="oldPassword" name="oldPassword" type="password" />
             <input id="newPassword" name="newPassword" type="password" />
             <input id="confirmNewPassword" name="confirmNewPassword" type="password" />
         </form>

--- a/c2cgeoportal/scaffolds/create/+package+/templates/index.html_tmpl
+++ b/c2cgeoportal/scaffolds/create/+package+/templates/index.html_tmpl
@@ -82,6 +82,7 @@
         <form method="POST" id="loginForm" style="display: none">
             <input id="login" name="login" type="text" autocomplete="on"/>
             <input id="password" name="password" type="password" autocomplete="on"/>
+            <input id="oldPassword" name="oldPassword" type="password" />
             <input id="newPassword" name="newPassword" type="password" />
             <input id="confirmNewPassword" name="confirmNewPassword" type="password" />
         </form>

--- a/c2cgeoportal/scaffolds/create/+package+/templates/routing.html_tmpl
+++ b/c2cgeoportal/scaffolds/create/+package+/templates/routing.html_tmpl
@@ -65,6 +65,7 @@
         <form method="POST" id="loginForm" style="display: none">
             <input id="login" name="login" type="text" autocomplete="on"/>
             <input id="password" name="password" type="password" autocomplete="on"/>
+            <input id="oldPassword" name="oldPassword" type="password" />
             <input id="newPassword" name="newPassword" type="password" />
             <input id="confirmNewPassword" name="confirmNewPassword" type="password" />
         </form>


### PR DESCRIPTION
According to the doc here: https://github.com/camptocamp/c2cgeoportal/commit/2d32486d15bd681293fd9fe0160e7325cfcee9a4#diff-c8f9eab6b316727f9bd103c613a3f8edR126 (that is a doc for migration I guess)
This field is missing and break the app if I try to just point CGXP on a recent 1.6 commit (commits after 1.6.13 release). Adding this form field to the project fixed the issue, but should be reported here in the templates as well.