### PR TITLE
Unfreeze c2cwsgiutils

### DIFF
--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM camptocamp/c2cwsgiutils:1.7
+FROM camptocamp/c2cwsgiutils:1
 LABEL maintainer Camptocamp "info@camptocamp.com"
 
 RUN \


### PR DESCRIPTION
It was frozen because 1.8.0 was requiring graphviz-dev to be installed
on the machine. This requirement was lifted in a later version.