### PR TITLE
Make the raster files (profile) work over http(s)

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/views/profile.py
+++ b/geoportal/c2cgeoportal_geoportal/views/profile.py
@@ -47,7 +47,6 @@ _ = TranslationStringFactory("c2cgeoportal")
 class Profile(Raster):
 
     def __init__(self, request):
-        self.request = request
         Raster.__init__(self, request)
 
     @view_config(route_name="profile.json", renderer="decimaljson")

--- a/geoportal/c2cgeoportal_geoportal/views/raster.py
+++ b/geoportal/c2cgeoportal_geoportal/views/raster.py
@@ -33,7 +33,7 @@ import os
 from decimal import Decimal
 from repoze.lru import LRUCache
 
-import fiona
+from fiona.collection import Collection
 import rasterio
 from pyramid.httpexceptions import HTTPNotFound
 from pyramid.view import view_config
@@ -82,7 +82,7 @@ class Raster:
         path = layer["file"]
         if layer.get("type", "shp_index") == "shp_index":
 
-            with fiona.open(path) as collection:
+            with Collection(path) as collection:
                 tiles = [e for e in collection.filter(mask={
                     "type": "Point",
                     "coordinates": [lon, lat],


### PR DESCRIPTION
Now, we can have something like that in the config:

```yaml
  raster:
    srtm:
      file: /vsicurl/http://url-of-some-http-service/SRTM21781/srtm.shp
      round: 1
```

That http service could be S3.