### PR TITLE
Windows cannot run get-pip-dependencies without shell & update pip

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/nondockercreate/nondocker-finalise.mk_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/nondockercreate/nondocker-finalise.mk_tmpl
@@ -162,7 +162,8 @@ else
 	$(PYTHON) -m venv --system-site-packages .build/venv
 endif
 ifeq ($(OPERATING_SYSTEM), WINDOWS)
-	$(PYTHON_BIN)/python -m pip install `./get-pip-dependencies c2cgeoportal-commons c2cgeoportal-geoportal c2cgeoportal-admin Shapely Fiona rasterio GDAL flake8-mypy mypy`
+	$(PYTHON_BIN)/python -m pip install --upgrade pip
+	$(PYTHON_BIN)/python -m pip install $(shell python ./get-pip-dependencies c2cgeoportal-commons c2cgeoportal-geoportal c2cgeoportal-admin Shapely Fiona rasterio GDAL flake8-mypy mypy)
 else
 	$(PYTHON_BIN)/python -m pip install `./get-pip-dependencies c2cgeoportal-commons c2cgeoportal-geoportal c2cgeoportal-admin GDAL flake8-mypy mypy`
 endif


### PR DESCRIPTION
because pip == 10 is much better integrated for installing (& compiling) wheels

Thanks for any review (and eventually merging this if Travis & co. are happy)

Replaces #3852

(sorry about that @sbrunner)