### PR TITLE
Update httplib2

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_versions.txt
+++ b/c2cgeoportal/scaffolds/update/CONST_versions.txt
@@ -13,7 +13,7 @@ GeoAlchemy2==0.2.4
 GeoFormAlchemy2==2.0.dev3
 geojson==1.0.9
 http-parser==0.8.3
-httplib2==0.9
+httplib2==0.11.3
 isodate==0.5.1
 Jinja2==2.7.3
 js.jqgrid==4.4.4


### PR DESCRIPTION
Because the current version does not support properly SSL v3. Hence we get a handsake failure when trying to access URLs using SSL v3, like https://wms.geo.admin.ch, through the ogcproxy route (used by the WMS loading plugin). The obtained error using the current version:

```
SSLHandshakeError: [SSL: SSLV3_ALERT_HANDSHAKE_FAILURE] sslv3 alert handshake failure (_ssl.c:590)
```

Thanks