### PR TITLE
make checker work on non-standard environments (via parameterization)

### DIFF
--- a/c2cgeoportal/lib/__init__.py
+++ b/c2cgeoportal/lib/__init__.py
@@ -30,6 +30,7 @@
 
 import datetime
 import dateutil
+import httplib2
 import json
 import re
 import urllib
@@ -51,6 +52,10 @@ def get_types_map(types_array):
         else:
             types_map[type_["name"]] = type_
     return types_map
+
+
+def get_http(request):
+    return httplib2.Http(**request.registry.settings.get("http_options", {}))
 
 
 def get_url(url, request, default=None, errors=None):

--- a/c2cgeoportal/lib/filter_capabilities.py
+++ b/c2cgeoportal/lib/filter_capabilities.py
@@ -29,7 +29,6 @@
 
 
 import logging
-import httplib2
 import copy
 from StringIO import StringIO
 from urlparse import urlsplit, urljoin
@@ -47,7 +46,7 @@ from owslib.wms import WebMapService
 
 from c2cgeoportal.lib import caching, get_protected_layers_query, \
     get_writable_layers_query, add_url_params, get_ogc_server_wms_url_ids,\
-    get_ogc_server_wfs_url_ids
+    get_ogc_server_wfs_url_ids, get_http
 from c2cgeoportal.models import DBSession, LayerWMS, OGCServer
 
 cache_region = caching.get_region()
@@ -82,7 +81,7 @@ def get_writable_layers(role_id, ogc_server_ids):
 
 
 @cache_region.cache_on_arguments()
-def wms_structure(wms_url, host):
+def wms_structure(wms_url, host, request):
     url = urlsplit(wms_url)
     wms_url = add_url_params(wms_url, {
         "SERVICE": "WMS",
@@ -91,7 +90,7 @@ def wms_structure(wms_url, host):
     })
 
     # Forward request to target (without Host Header)
-    http = httplib2.Http()
+    http = get_http(request)
     headers = dict()
     if url.hostname == "localhost" and host is not None:  # pragma: no cover
         headers["Host"] = host
@@ -171,7 +170,7 @@ def filter_capabilities(content, role_id, wms, url, headers, proxies, request):
     if proxies:  # pragma: no cover
         enable_proxies(proxies)
 
-    wms_structure_ = wms_structure(url, headers.get("Host"))
+    wms_structure_ = wms_structure(url, headers.get("Host"), request)
 
     ogc_server_ids = (
         get_ogc_server_wms_url_ids(request) if wms else

--- a/c2cgeoportal/lib/lingua_extractor.py
+++ b/c2cgeoportal/lib/lingua_extractor.py
@@ -28,7 +28,6 @@
 # either expressed or implied, of the FreeBSD Project.
 
 
-import httplib2
 import subprocess
 import os
 import yaml
@@ -53,7 +52,7 @@ from mako.template import Template
 from mako.lookup import TemplateLookup
 from owslib.wms import WebMapService
 
-from c2cgeoportal.lib import add_url_params, get_url2
+from c2cgeoportal.lib import add_url_params, get_url2, get_http
 from c2cgeoportal.lib.bashcolor import colorize, RED
 from c2cgeoportal.lib.dbreflection import get_class
 from c2cgeoportal.lib.caching import init_region
@@ -369,9 +368,6 @@ class GeoMapfishThemeExtractor(Extractor):  # pragma: no cover
             if callback is not None:
                 callback(item, messages)
 
-    def _get_http(self):
-        return httplib2.Http(**self.config.get("http_options", {}))
-
     def _import_layer_wms(self, layer, messages):
         server = layer.ogc_server
         url = server.url_wfs or server.url
@@ -475,7 +471,7 @@ class GeoMapfishThemeExtractor(Extractor):  # pragma: no cover
             self.wmscap_cache[url] = None
 
             # forward request to target (without Host Header)
-            http = self._get_http()
+            http = get_http(request)
             h = {}
             if hostname == "localhost":  # pragma: no cover
                 h["Host"] = self.package["host"]
@@ -518,7 +514,7 @@ class GeoMapfishThemeExtractor(Extractor):  # pragma: no cover
             self.featuretype_cache[url] = None
 
             # forward request to target (without Host Header)
-            http = self._get_http()
+            http = get_http(request)
             h = {}
             if hostname == "localhost":  # pragma: no cover
                 h["Host"] = self.package["host"]

--- a/c2cgeoportal/scaffolds/create/project.yaml.mako_tmpl
+++ b/c2cgeoportal/scaffolds/create/project.yaml.mako_tmpl
@@ -1,7 +1,10 @@
 project_folder: {{project}}
 project_package: ${package}
 host: ${host}
+# Legacy configuration option for checker
 checker_path: /${instanceid}/wsgi/check_collector?
+# New configuration option for checker
+#checker_url: https://${host}/${instanceid}/wsgi/check_collector?
 template_vars:
     package: {{package}}
     srid: {{srid}}

--- a/c2cgeoportal/scaffolds/update/CONST_config-schema.yaml
+++ b/c2cgeoportal/scaffolds/update/CONST_config-schema.yaml
@@ -436,6 +436,9 @@ mapping:
 
                             regex;(.+):
                                 type: any
+                    rewrite_as_http_localhost:
+                        type: bool
+                        required: False
             check_collector:
                 type: map
                 required: True

--- a/c2cgeoportal/scaffolds/update/CONST_vars.yaml_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_vars.yaml_tmpl
@@ -426,6 +426,7 @@ vars:
             routes:
             - name: apijs
             - name: printproxy_capabilities
+        rewrite_as_http_localhost: True
 
     # Check collector configuration
     check_collector:

--- a/c2cgeoportal/views/check_collector.py
+++ b/c2cgeoportal/views/check_collector.py
@@ -30,12 +30,12 @@
 
 import logging
 import httplib
-from httplib2 import Http
 from time import time
 
 from pyramid.view import view_config
 from pyramid.response import Response
 
+from c2cgeoportal.lib import get_http
 from c2cgeoportal.views.checker import build_url
 
 log = logging.getLogger(__name__)
@@ -84,7 +84,7 @@ class CheckerCollector:  # pragma: no cover
     def _testurl(self, url):
         url, headers = build_url("Collect", url, self.request)
 
-        h = Http()
+        h = get_http(self.request)
         resp, content = h.request(url, headers=headers)
 
         if resp.status != httplib.OK:

--- a/c2cgeoportal/views/entry.py
+++ b/c2cgeoportal/views/entry.py
@@ -28,7 +28,6 @@
 # either expressed or implied, of the FreeBSD Project.
 
 
-import httplib2
 import logging
 import json
 import sys
@@ -52,7 +51,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from owslib.wms import WebMapService
 
 from c2cgeoportal.lib import get_setting, get_protected_layers_query, \
-    get_url2, get_url, get_typed, get_types_map, add_url_params
+    get_url2, get_url, get_typed, get_types_map, add_url_params, get_http
 from c2cgeoportal.lib.cacheversion import get_cache_version
 from c2cgeoportal.lib.caching import get_region, invalidate_region,  \
     set_common_headers, NO_CACHE, PUBLIC_CACHE, PRIVATE_CACHE
@@ -232,7 +231,7 @@ class Entry:
         log.info(u"Get WMS GetCapabilities for url: {0!s}".format(url))
 
         # forward request to target (without Host Header)
-        http = httplib2.Http()
+        http = get_http(self.request)
         headers = dict(self.request.headers)
 
         role = None if self.request.user is None else self.request.user.role
@@ -1088,7 +1087,7 @@ class Entry:
         log.info(u"WFS GetCapabilities for base url: {0!s}".format(wfsgc_url))
 
         # forward request to target (without Host Header)
-        http = httplib2.Http()
+        http = get_http(self.request)
         headers = dict(self.request.headers)
         if urlparse.urlsplit(wfsgc_url).hostname != "localhost" and "Host" in headers:  # pragma: no cover
             headers.pop("Host")
@@ -1156,7 +1155,7 @@ class Entry:
         ])
 
         # forward request to target (without Host Header)
-        http = httplib2.Http()
+        http = get_http(self.request)
         headers = dict(self.request.headers)
         if urlparse.urlsplit(ext_url).hostname != "localhost" and "Host" in headers:  # pragma: no cover
             headers.pop("Host")

--- a/c2cgeoportal/views/proxy.py
+++ b/c2cgeoportal/views/proxy.py
@@ -29,7 +29,6 @@
 
 
 import sys
-import httplib2
 import urllib
 import logging
 
@@ -39,6 +38,7 @@ from urlparse import urlparse, parse_qs
 from pyramid.response import Response
 from pyramid.httpexceptions import HTTPBadGateway, HTTPInternalServerError
 
+from c2cgeoportal.lib import get_http
 from c2cgeoportal.lib.caching import get_region, \
     set_common_headers, NO_CACHE, PUBLIC_CACHE, PRIVATE_CACHE
 
@@ -82,7 +82,7 @@ class Proxy(object):
             method = self.request.method
 
         # forward request to target (without Host Header)
-        http = httplib2.Http()
+        http = get_http(self.request)
 
         if headers is None:  # pragma: no cover
             headers = dict(self.request.headers)


### PR DESCRIPTION
use http options throughout c2cgeoportal and use config parameter to decide whether to force to localhost on checker