### PR TITLE
Centralize the get_layer_class code in a unique place

### DIFF
--- a/c2cgeoportal/lib/dbreflection.py
+++ b/c2cgeoportal/lib/dbreflection.py
@@ -185,7 +185,7 @@ def get_class(tablename, session=None, exclude_properties=None, primary_key=None
     if exclude_properties is None:
         exclude_properties = []
     tablename, schema = _get_schema(tablename)
-    cache_key = (schema, tablename, ",".join(exclude_properties))
+    cache_key = (schema, tablename, ",".join(exclude_properties), primary_key)
 
     if cache_key in _class_cache:
         return _class_cache[cache_key]

--- a/c2cgeoportal/lib/lingua_extractor.py
+++ b/c2cgeoportal/lib/lingua_extractor.py
@@ -55,7 +55,6 @@ from owslib.wms import WebMapService
 
 from c2cgeoportal.lib import add_url_params, get_url2
 from c2cgeoportal.lib.bashcolor import colorize, RED
-from c2cgeoportal.lib.dbreflection import get_class
 from c2cgeoportal.lib.caching import init_region
 
 
@@ -380,15 +379,9 @@ class GeoMapfishThemeExtractor(Extractor):  # pragma: no cover
         for wms_layer in layer.layer.split(","):
             self._import_layer_attributes(url, wms_layer, layer.item_type, layer.name, messages)
         if layer.geo_table is not None and layer.geo_table != "":
-            exclude = [] if layer.exclude_properties is None else layer.exclude_properties.split(",")
-            last_update_date = layer.get_metadatas("lastUpdateDateColumn")
-            if len(last_update_date) == 1:
-                exclude.append(last_update_date[0].value)
-            last_update_user = layer.get_metadatas("lastUpdateUserColumn")
-            if len(last_update_user) == 1:
-                exclude.append(last_update_user[0].value)
             try:
-                cls = get_class(layer.geo_table, exclude_properties=exclude)
+                from c2cgeoportal.views.layers import get_layer_class
+                cls = get_layer_class(layer)
                 for column_property in class_mapper(cls).iterate_properties:
                     if isinstance(column_property, ColumnProperty) and len(column_property.columns) == 1:
                         column = column_property.columns[0]


### PR DESCRIPTION
In addition, this should ensure all created classes for a layer are consistent.