### PR TITLE
[1.6] remove index-url to pypi.camptocamp.net

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,6 @@ c2cgeoportal/locale/en/LC_MESSAGES/c2cgeoportal.po: c2cgeoportal/locale/c2cgeopo
 	mkdir -p $(dir $@)
 	virtualenv --setuptools --no-site-packages .build/venv
 	$(PIP_CMD) install \
-		--index-url http://pypi.camptocamp.net/pypi \
 		'pip==7.1.2' 'setuptools==21.0.0' $(PIP_REDIRECT)
 	touch $@
 

--- a/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/c2cgeoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -810,7 +810,6 @@ $(INSTANCE_ID_MARKER):
 upgrade: .build/requirements.timestamp project.yaml
 	.build/venv/bin/pip install \
 		--trusted-host pypi.camptocamp.net \
-		--index-url http://pypi.camptocamp.net/pypi \
 		--find-links http://pypi.camptocamp.net/internal-pypi/index/c2cgeoportal \
 		c2cgeoportal==${VERSION}
 	$(VENV_BIN)/c2ctool upgrade $(UPGRADE_MAKE_FILE) ${UPGRADE_ARGS} ${VERSION}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,3 @@
---index-url http://pypi.camptocamp.net/pypi
 c2c.cssmin
 c2c.template==1.1.2
 c2cgeoportal/tests/testegg/dist/testegg-1.0.tar.gz

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
---index-url http://pypi.camptocamp.net/pypi
 -e git+https://github.com/camptocamp/pyramid_closure#egg=pyramid_closure
 -e git+https://github.com/Pylons/pyramid@1e02bbfc0df09259bf207112acf019c8dba44a90#egg=pyramid
 -r c2cgeoportal/scaffolds/update/CONST_versions.txt


### PR DESCRIPTION
remove index-url to pypi.camptocamp.net, as server is no longer maintained