### PR TITLE
Add some wheel installation exception when using Windows

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/nondockercreate/nondocker-finalise.mk_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/nondockercreate/nondocker-finalise.mk_tmpl
@@ -180,7 +180,7 @@ else
 endif
 ifeq ($(OPERATING_SYSTEM), WINDOWS)
 	$(PYTHON_BIN)/python -m pip install --upgrade pip
-	$(PYTHON_BIN)/python -m pip install $(shell python ./get-pip-dependencies c2cgeoportal-commons c2cgeoportal-geoportal c2cgeoportal-admin Shapely Fiona rasterio GDAL flake8-mypy mypy)
+	$(PYTHON_BIN)/python -m pip install $(shell python ./get-pip-dependencies c2cgeoportal-commons c2cgeoportal-geoportal c2cgeoportal-admin linesman networkx pygraphviz Shapely Fiona rasterio GDAL flake8-mypy mypy)
 else
 	$(PYTHON_BIN)/python -m pip install `./get-pip-dependencies c2cgeoportal-commons c2cgeoportal-geoportal c2cgeoportal-admin GDAL flake8-mypy mypy`
 endif


### PR DESCRIPTION
because these ones cannot be installed straight from pypi using pip, but I think that they are "dev" packages and they are not blocking any "simple" production instance (behind a simple Apache "mod_wsgi" server and in an non-Docker environment).

Please review and eventually merge (if Travis let me through for once...)