### PR TITLE
Specify alembic config file in documentation

### DIFF
--- a/doc/integrator/upgrade_application.rst.mako
+++ b/doc/integrator/upgrade_application.rst.mako
@@ -165,13 +165,13 @@ Upgrade the main schema:
 
 .. prompt:: bash
 
-   ./docker-run alembic --name=main upgrade head
+   ./docker-run alembic --name=main --config=geoportal/alembic.ini upgrade head
 
 Upgrade the static schema:
 
 .. prompt:: bash
 
-   ./docker-run alembic --name=static upgrade head
+   ./docker-run alembic --name=static --config=geoportal/alembic.ini upgrade head
 
 .. _integrator_upgrade_application_cgxp_to_ngeo:
 


### PR DESCRIPTION
As it is not anymore at the root of the project path, but inside the `geoportal` folder.

I do not know it there is another way to do this, but this is currently working in the sitn project.