### PR TITLE
Avoid group collision between user group and docker

### DIFF
--- a/docker/build/bin/run
+++ b/docker/build/bin/run
@@ -15,17 +15,17 @@ args = sys.argv[1:]
 has_docker = os.path.exists('/var/run/docker.sock')
 docker_group_id = os.stat('/var/run/docker.sock').st_gid if has_docker else -1
 
-try:
-    subprocess.check_call(['groupadd', '--gid=' + os.environ['GROUP_ID'], 'geomapfish'])
-except subprocess.CalledProcessError:
-    pass
-
 if has_docker:
     try:
         subprocess.check_call(['groupdel', 'docker'])
         subprocess.check_call(['groupadd', '--gid={}'.format(docker_group_id), 'docker'])
     except subprocess.CalledProcessError:
         pass
+
+try:
+    subprocess.check_call(['groupadd', '--gid=' + os.environ['GROUP_ID'], 'geomapfish'])
+except subprocess.CalledProcessError:
+    pass
 
 try:
     subprocess.check_call([


### PR DESCRIPTION
Could seems weird, but on a server I've sigdev with id 999, so I've need docker to be deleted before creating creating geomapfish.