### PR TITLE
Fix typo in docker-compose.override.yml

### DIFF
--- a/doc/developer/debugging.rst
+++ b/doc/developer/debugging.rst
@@ -153,7 +153,7 @@ Mount c2cgeoportal in the container
 
 Clone and build c2cgeoportal, see: developer_server_side.
 
-Add a ``docker-compose.override.yaml`` file with a ``geoportal`` service containing the following lines:
+Add a ``docker-compose.override.yml`` file with a ``geoportal`` service containing the following lines:
 
 .. code:: yaml
 


### PR DESCRIPTION
docker-compose.override.yaml (yaml instead of yml) is not loaded automatically.