### PR TITLE
Merge 2.2 into 2.3

### DIFF
--- a/commons/c2cgeoportal_commons/alembic/main/7530011a66a7_trigger_on_role_updates_user_in_static.py
+++ b/commons/c2cgeoportal_commons/alembic/main/7530011a66a7_trigger_on_role_updates_user_in_static.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2017-2018, Camptocamp SA
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# The views and conclusions contained in the software and documentation are those
+# of the authors and should not be interpreted as representing official policies,
+# either expressed or implied, of the FreeBSD Project.
+
+"""trigger_on_role_updates_user_in_static
+
+Revision ID: 7530011a66a7
+Revises: d8ef99bc227e
+Create Date: 2018-03-23 09:08:56.910629
+"""
+
+from alembic import op
+from c2cgeoportal_commons.config import config
+
+# revision identifiers, used by Alembic.
+revision = '7530011a66a7'
+down_revision = 'd8ef99bc227e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    schema = config['schema']
+    staticschema = config['schema_static']
+
+    op.execute("""
+CREATE OR REPLACE FUNCTION {schema}.on_role_name_change()
+RETURNS trigger AS
+$$
+BEGIN
+IF NEW.name <> OLD.name THEN
+UPDATE {staticschema}."user" SET role_name = NEW.name WHERE role_name = OLD.name;
+END IF;
+RETURN NEW;
+END;
+$$
+LANGUAGE plpgsql""".format(schema=schema, staticschema=staticschema))
+
+
+def downgrade():
+    schema = config['schema']
+
+    op.execute("""
+CREATE OR REPLACE FUNCTION {schema}.on_role_name_change()
+RETURNS trigger AS
+$$
+BEGIN
+IF NEW.name <> OLD.name THEN
+UPDATE {schema}."user" SET role_name = NEW.name WHERE role_name = OLD.name;
+END IF;
+RETURN NEW;
+END;
+$$
+LANGUAGE plpgsql""".format(schema=schema))

--- a/commons/c2cgeoportal_commons/alembic/main/dba87f2647f9_merge_2_2_on_2_3.py
+++ b/commons/c2cgeoportal_commons/alembic/main/dba87f2647f9_merge_2_2_on_2_3.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2017-2018, Camptocamp SA
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# The views and conclusions contained in the software and documentation are those
+# of the authors and should not be interpreted as representing official policies,
+# either expressed or implied, of the FreeBSD Project.
+
+"""Merge 2.2 on 2.3
+
+Revision ID: dba87f2647f9
+Revises: ('7530011a66a7', '809650bd04c3')
+Create Date: 2018-10-04 09:32:07.634452
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'dba87f2647f9'
+down_revision = ('7530011a66a7', '809650bd04c3')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/docker/test-mapserver/mapserver.map.mako
+++ b/docker/test-mapserver/mapserver.map.mako
@@ -40,7 +40,7 @@ MAP
         METADATA
             "wms_title" "changeme"
             "wms_abstract" "changeme"
-            "wms_onlineresource" "changeme"
+            "ows_onlineresource" "changeme"
             "wms_encoding" "UTF-8"
             "wms_enable_request" "*"
             "ows_title" "changeme"

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/nondockercreate/mapserver/mapserver.map.mako_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/nondockercreate/mapserver/mapserver.map.mako_tmpl
@@ -4,13 +4,13 @@
 # Test requests:
 #
 # WMS GetCapabilities:
-# /mapserv?service=wms&version=1.1.1&request=getcapabilities
+# /wsgi/mapserv_proxy?service=wms&version=1.1.1&request=getcapabilities
 #
 # WMS GetMap:
-# /mapserv?service=wms&version=1.1.1&request=getmap&bbox=-180,-90,180,90&layers=countries&width=600&height=400&srs=EPSG:4326&format=image/png
+# /wsgi/mapserv_proxy?service=wms&version=1.1.1&request=getmap&bbox=-180,-90,180,90&layers=countries&width=600&height=400&srs=EPSG:4326&format=image/png
 #
 # WMS GetFeatureInfo:
-# /mapserv?service=wms&version=1.1.1&request=getfeatureinfo&bbox=-180,-90,180,90&layers=countries&query_layers=countries&width=600&height=400&srs=EPSG:4326&format=image/png&x=180&y=90&info_format=application/vnd.ogc.gml
+# /wsgi/mapserv_proxy?service=wms&version=1.1.1&request=getfeatureinfo&bbox=-180,-90,180,90&layers=countries&query_layers=countries&width=600&height=400&srs=EPSG:4326&format=image/png&x=180&y=90&info_format=application/vnd.ogc.gml
 #
 
 MAP
@@ -70,7 +70,7 @@ MAP
         METADATA
             "wms_title" "changeme"
             "wms_abstract" "changeme"
-            "wms_onlineresource" "${web_protocol}://${host}/${instanceid}/wsgi/mapserv_proxy"
+            "ows_onlineresource" "${web_protocol}://${host}/${instanceid}/wsgi/mapserv_proxy"
             "wms_srs" "EPSG:{{srid}}"
             "wms_encoding" "UTF-8"
             "wms_enable_request" "*"

--- a/geoportal/c2cgeoportal_geoportal/views/entry.py
+++ b/geoportal/c2cgeoportal_geoportal/views/entry.py
@@ -837,12 +837,11 @@ class Entry:
 
         for tree_item in group.children:
             if isinstance(tree_item, main.LayerGroup):
-                depth += 1
                 if isinstance(group, main.Theme) or catalogue or \
                         group.is_internal_wms == tree_item.is_internal_wms:
                     gp, gp_errors = self._group(
                         u"{0!s}/{1!s}".format(path, tree_item.name),
-                        tree_item, layers, depth=depth, min_levels=min_levels,
+                        tree_item, layers, depth=depth + 1, min_levels=min_levels,
                         catalogue=catalogue, role_id=role_id, version=version, mixed=mixed,
                         time=time, dim=dim, wms_layers=wms_layers, layers_name=layers_name, **kwargs
                     )


### PR DESCRIPTION
I had a conflict with this file:
2.2: https://github.com/camptocamp/c2cgeoportal/commit/1d28b290cc5ef106fd972e5fb58ebee3188f3489
2.3: https://github.com/camptocamp/c2cgeoportal/blob/2.3/commons/c2cgeoportal_commons/alembic/main/21f11066f8ec_trigger_on_role_updates_user_in_static.py

It's not in this merge, I think we had to move it / adapt it manually. That's why it's already on 2.3