### PR TITLE
Fix yaml syntax to match expected data format

### DIFF
--- a/doc/integrator/routing.rst
+++ b/doc/integrator/routing.rst
@@ -55,12 +55,14 @@ To configure the routing feature the constants `ngeoRoutingOptions` and `ngeoNom
                     ngeoRoutingOptions:
                         - backendUrl: https://routing.osm.ch/
                         - profiles:
-                            - label: Car
+                            -
+                              label: Car
                               profile: routed-car
-                            - label: Bike (City)
+                            -
+                              label: Bike (City)
                               profile: routed-bike
                     ngeoNominatimSearchDefaultParams:
-                        - countrycodes: CH
+                        countrycodes: CH
 
 backendUrl
 ^^^^^^^^^^

--- a/doc/integrator/routing.rst
+++ b/doc/integrator/routing.rst
@@ -55,11 +55,9 @@ To configure the routing feature the constants `ngeoRoutingOptions` and `ngeoNom
                     ngeoRoutingOptions:
                         - backendUrl: https://routing.osm.ch/
                         - profiles:
-                            -
-                              label: Car
+                            - label: Car
                               profile: routed-car
-                            -
-                              label: Bike (City)
+                            - label: Bike (City)
                               profile: routed-bike
                     ngeoNominatimSearchDefaultParams:
                         countrycodes: CH

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/vars.yaml_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/vars.yaml_tmpl
@@ -130,7 +130,7 @@ vars:
               - label: Hiking
                 profile: routed-hiking
         ngeoNominatimSearchDefaultParams:
-          - countrycodes: CH
+          countrycodes: CH
         ngeoWfsPermalinkOptions:
           url: https://geomapfish-demo.camptocamp.com/docker/mapserv_proxy?ogcserver=QGIS%20server
           wfsTypes:

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/nondockercreate/vars.yaml_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/nondockercreate/vars.yaml_tmpl
@@ -128,7 +128,7 @@ vars:
               - label: Hiking
                 profile: routed-hiking
         ngeoNominatimSearchDefaultParams:
-          - countrycodes: CH
+          countrycodes: CH
         ngeoWfsPermalinkOptions:
           url: https://geomapfish-demo.camptocamp.com/docker/mapserv_proxy?ogcserver=QGIS%20server
           wfsTypes:


### PR DESCRIPTION
Tested this with @yjacolin. The previous syntax resulted in data structures that did not match the expectations of the angular code.

To explain the unusual syntax:
```
- profiles:
  -
    label: Car
    profile: routed-car
  -
    label: Bike (City)
    profile: routed-bike
```

This results in:
`
[{label: "Car", profile: "routed-car"}, {label: "Bike (City)", profile: "routed-bike"}]`


The `ngeoNominatimSearchDefaultParams` just don't want an array. It is supposed to be just an object.