### PR TITLE
Correct typo 'authtkt' for secure and http_only

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/lib/authentication.py
+++ b/geoportal/c2cgeoportal_geoportal/lib/authentication.py
@@ -40,10 +40,10 @@ def create_authentication(settings):
     timeout = None if timeout is None else int(timeout)
     reissue_time = settings.get("reissue_time")
     reissue_time = None if reissue_time is None else int(reissue_time)
-    http_only = settings.get("authtk_http_only")
-    http_only = True if http_only is None else http_only != "False"
-    secure = settings.get("authtk_secure")
-    secure = True if secure is None else secure != "False"
+    http_only = settings.get("authtkt_http_only", "True")
+    http_only = http_only.lower() in ("true", "yes", "1")
+    secure = settings.get("authtkt_secure", "True")
+    secure = secure.lower() in ("true", "yes", "1")
     cookie_authentication_policy = AuthTktAuthenticationPolicy(
         settings["authtkt_secret"],
         callback=defaultgroupsfinder,


### PR DESCRIPTION
Never see this "authtk" string, without the final `t`. I guess it was a typo.

Also, accept `false, False, No, no, 0` as "false value, and not only `False`.
Still `True` by default.


