### PR TITLE
Upgrade tilecloud-chain to 1.8.2

### DIFF
--- a/docker/build/requirements.txt
+++ b/docker/build/requirements.txt
@@ -64,8 +64,8 @@ simplejson==3.13.2  # geoportal
 Sphinx==1.7.2  # doc
 sphinx-prompt==1.0.0  # doc
 SQLAlchemy==1.2.6
-tilecloud==1.0.0  # Tile generation
-tilecloud-chain==1.7.1  # Tile generation
+tilecloud==1.1.0  # Tile generation
+tilecloud-chain==1.8.2  # Tile generation
 transaction==2.2.1  # commons, geoportal
 transifex-client==0.12.5  # Makefile, rq.filter: >=0.14
 translationstring==1.3  # admin


### PR DESCRIPTION
This fixes the generation of the mapcache config file.