### PR TITLE
Fix scripts themev1tov2 and l10nv1tov2 with docker

### DIFF
--- a/doc/integrator/upgrade_application.rst.mako
+++ b/doc/integrator/upgrade_application.rst.mako
@@ -186,15 +186,38 @@ Layer definition for ngeo clients is separate and different from layer
 definition for CGXP clients, see :ref:`administrator_administrate_layers`
 for details.
 To migrate the layer definitions from the CGXP structure to the ngeo
-structure, you can use the script ``.build/venv/bin/themev1tov2``.
+structure, you can use the script themev1tov2.
+
+In non docker context, run the script from venv:
+
+.. prompt:: bash
+
+   .build/venv/bin/themev1tov2 -i geoportal/production.ini
+
+In docker context, run the script from geoportal service:
+
+.. prompt:: bash
+
+   docker-compose up -d
+   docker-compose run --rm geoportal themev1tov2 -i production.ini
 
 Text translations for ngeo clients are separate and different from text
 translations for CGXP clients.
 To migrate the text translations from CGXP to ngeo, you can use the script
+
 ``.build/venv/bin/l10nv1tov2``.
-For example, for converting french texts the script can be used as follows:
+For example, for converting french texts, in non docker context, the script can
+be used as follows:
 
 .. code:: bash
 
-   .build/venv/bin/l10nv1tov2 fr geoportal/static/js/Proj/Lang/fr.js \
+   .build/venv/bin/l10nv1tov2 fr geoportal/<package>_geoportal/static/js/Proj/Lang/fr.js \
    geoportal/locale/fr/LC_MESSAGES/geoportal-client.po
+
+In docker context, run the script using docker-compose-run:
+
+.. prompt:: bash
+
+   docker-compose up -d
+   ./docker-compose-run l10nv1tov2 fr geoportal/<package>_geoportal/static/js/Proj/Lang/fr.js \
+   geoportal/<package>_geoportal/locale/fr/LC_MESSAGES/geoportal-client.po

--- a/geoportal/c2cgeoportal_geoportal/scripts/l10nv1tov2.py
+++ b/geoportal/c2cgeoportal_geoportal/scripts/l10nv1tov2.py
@@ -93,5 +93,5 @@ msgstr ""
                 destination.write(("""
 msgid "{0!s}"
 msgstr "{1!s}"
-""".format(key, value.replace('"', '\\"'))).encode("utf-8"),
+""".format(key, value.replace('"', '\\"'))),
                 )

--- a/geoportal/c2cgeoportal_geoportal/scripts/themev1tov2.py
+++ b/geoportal/c2cgeoportal_geoportal/scripts/themev1tov2.py
@@ -46,7 +46,7 @@ def main():
 
     parser.add_argument(
         "-i", "--app-config",
-        default="geoportal/production.ini",
+        default="production.ini",
         dest="app_config",
         help="the application .ini config file (optional, default is 'production.ini')"
     )


### PR DESCRIPTION
* Fix themev1tov2 and l10nv1tov2 in docker/python3 context.
* Use production.ini path from docker context by default.
* Update the documentation for docker context.