### PR TITLE
Fix tinyows binding on port 80

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/docker-compose.yaml.mako
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/docker-compose.yaml.mako
@@ -44,7 +44,6 @@ ${service_defaults('mapserver', 8080)}\
     restart: on-failure
     volumes_from:
       - config:ro
-    entrypoint: []
 ${service_defaults('tinyows', 8080)}\
 
   mapcache:


### PR DESCRIPTION
It's on the entrypoint the stuff needed to bind it on port 8080

Fix: https://jira.camptocamp.com/projects/GSGMF/issues/GSGMF-731