### PR TITLE
Don't exclude properties everywhere

### DIFF
--- a/c2cgeoportal/lib/lingua_extractor.py
+++ b/c2cgeoportal/lib/lingua_extractor.py
@@ -377,7 +377,7 @@ class GeoMapfishThemeExtractor(Extractor):  # pragma: no cover
         if layer.geo_table is not None and layer.geo_table != "":
             try:
                 from c2cgeoportal.views.layers import get_layer_class
-                cls = get_layer_class(layer)
+                cls = get_layer_class(layer, with_exclude=True)
                 for column_property in class_mapper(cls).iterate_properties:
                     if isinstance(column_property, ColumnProperty) and len(column_property.columns) == 1:
                         column = column_property.columns[0]

--- a/c2cgeoportal/views/layers.py
+++ b/c2cgeoportal/views/layers.py
@@ -414,7 +414,7 @@ class Layers:
         layer = self._get_layer_for_request()
         if not layer.public and self.request.user is None:
             raise HTTPForbidden()
-        return get_layer_class(layer)
+        return get_layer_class(layer, with_exclude=True)
 
     @view_config(route_name="layers_enumerate_attribute_values", renderer="json")
     def enumerate_attribute_values(self):
@@ -468,15 +468,18 @@ class Layers:
         return dbsession.query(distinct(attribute)).order_by(attribute).all()
 
 
-def get_layer_class(layer):
-    # exclude the columns used to record the last features update
-    exclude = [] if layer.exclude_properties is None else layer.exclude_properties.split(",")
-    last_update_date = Layers.get_metadata(layer, "lastUpdateDateColumn")
-    if last_update_date is not None:
-        exclude.append(last_update_date)
-    last_update_user = Layers.get_metadata(layer, "lastUpdateUserColumn")
-    if last_update_user is not None:
-        exclude.append(last_update_user)
+def get_layer_class(layer, with_exclude=False):
+    if with_exclude:
+        # Exclude the columns used to record the last features update
+        exclude = [] if layer.exclude_properties is None else layer.exclude_properties.split(",")
+        last_update_date = Layers.get_metadata(layer, "lastUpdateDateColumn")
+        if last_update_date is not None:
+            exclude.append(last_update_date)
+        last_update_user = Layers.get_metadata(layer, "lastUpdateUserColumn")
+        if last_update_user is not None:
+            exclude.append(last_update_user)
+    else:
+        exclude = []
 
     primary_key = Layers.get_metadata(layer, "geotablePrimaryKey")
     return get_class(
@@ -487,7 +490,7 @@ def get_layer_class(layer):
 
 
 def get_layer_metadatas(layer):
-    cls = get_layer_class(layer)
+    cls = get_layer_class(layer, with_exclude=True)
     edit_columns = []
 
     for column_property in class_mapper(cls).iterate_properties:


### PR DESCRIPTION
Fix regression introduced by https://github.com/camptocamp/c2cgeoportal/commit/496e2bb23194c23b99c72ed377714fc3610369dc

Mainly we shouldn't exclude the lastUpdateDateColumn and lastUpdateUserColumn on insert or update operation otherwise we can't set them.