### PR TITLE
[WIP] Use get_appsettings instead of get_app in scripts

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scripts/themev1tov2.py
+++ b/geoportal/c2cgeoportal_geoportal/scripts/themev1tov2.py
@@ -33,7 +33,7 @@ import sys
 import transaction
 
 from argparse import ArgumentParser
-from c2cgeoportal_geoportal.scripts import fill_arguments, get_app
+from c2cgeoportal_geoportal.scripts import fill_arguments, get_appsettings, get_session
 from json import loads
 
 
@@ -64,13 +64,11 @@ def main():
     )
     options = parser.parse_args()
 
-    app = get_app(options, parser)
+    settings = get_appsettings(options, parser)
+    session = get_session(settings)
 
     # must be done only once we have loaded the project config
-    from c2cgeoportal_commons.models import DBSession
     from c2cgeoportal_commons.models.main import OGCServer, Theme, LayerWMS, LayerWMTS, LayerV1, LayerGroup
-
-    session = DBSession()
 
     if options.layers:
         table_list = [LayerWMTS, LayerWMS, OGCServer]
@@ -82,7 +80,7 @@ def main():
                 session.delete(t)
 
         # list and create all distinct ogc_server
-        ogc_server(session, app.registry.settings)
+        ogc_server(session, settings)
 
         print("Converting layerv1.")
         for layer in session.query(LayerV1).all():


### PR DESCRIPTION
Note that we may use a custom loader to use pyramid get_app and get_appsettings directly, exemple:
```
from plaster_pastedeploy import Loader
from c2c.template.config import config as configuration

class Loader(Loader):

    def _get_defaults(self, defaults=None):
        d = {}
        d.update(os.environ)
        d.update(defaults or {})
        settings = super()._get_defaults(d)
        configuration.init(settings.get('app.cfg'))
        settings.update(configuration.get_config())
        return settings

    def __repr__(self):
        return 'c2cgeoportal.Loader(uri="{0}")'.format(self.uri)
```
Such loader could be acessible through config_uri, for example : `c2c://production.ini`
Note that this will also allow usage of pyramid scripts, for example `proute`.

It also make duplication with things in c2cwsgiutils as it already pass environ as default.
After a little analyse in c2cwsgiutils, it seems that this could be completely removed:

https://github.com/camptocamp/c2cwsgiutils/blob/master/c2cwsgiutils_run
Orchestrator need to be notified when container crash.

https://github.com/camptocamp/c2cwsgiutils/blob/master/c2cwsgiutils/wsgi_app.py
sentry filter should be activated using settings, or config.

https://github.com/camptocamp/c2cwsgiutils/blob/master/c2cwsgiutils/wsgi.py
not more need to pass os.environ to get_app with custom logger.

Also note support for env vars was merged but reverted in plaster_pastedeploy due to a bug in pastedeploy concerning char % in defaults: 
https://github.com/Pylons/plaster_pastedeploy/pull/15/commits/b34a45d604f8c73bdc670b1c2dae7c9aa31f8b56