### PR TITLE
[multi_role] cascade delete to user_role

### DIFF
--- a/commons/acceptance_tests/test_roles.py
+++ b/commons/acceptance_tests/test_roles.py
@@ -5,9 +5,13 @@ import pytest
 @pytest.mark.usefixtures("dbsession")
 def insert_roles_test_data(dbsession):
     from c2cgeoportal_commons.models.main import Role
+    from c2cgeoportal_commons.models.static import User
     role = Role("secretary")
+    user = User("user1", roles=[role])
     t = dbsession.begin_nested()
     dbsession.add(role)
+    dbsession.add(user)
+    dbsession.flush()
     yield
     t.rollback()
 
@@ -20,7 +24,12 @@ class TestRole:
         assert len(roles) == 1, "querying for roles"
         assert roles[0].name == 'secretary', "role from test data is secretary"
 
-    def test_no_user(self, dbsession):
-        from c2cgeoportal_commons.models.static import User
-        users = dbsession.query(User).all()
-        assert len(users) == 0, "querying for users"
+    def test_delete(self, dbsession):
+        from c2cgeoportal_commons.models.main import Role
+        from c2cgeoportal_commons.models.static import user_role
+        roles = dbsession.query(Role).all()
+        dbsession.delete(roles[0])
+        roles = dbsession.query(Role).all()
+        assert len(roles) == 0, "removed a role"
+        assert 0 == dbsession.query(user_role).\
+            count()

--- a/commons/acceptance_tests/test_users.py
+++ b/commons/acceptance_tests/test_users.py
@@ -10,6 +10,7 @@ def insert_users_test_data(dbsession):
     user.roles = [Role(name='Role1'), Role(name='Role2')]
     t = dbsession.begin_nested()
     dbsession.add(user)
+    dbsession.flush()
     yield
     t.rollback()
 

--- a/commons/c2cgeoportal_commons/models/static.py
+++ b/commons/c2cgeoportal_commons/models/static.py
@@ -35,7 +35,7 @@ import pytz
 from typing import List
 
 from sqlalchemy import Column, ForeignKey, Table
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import relationship, backref
 from sqlalchemy.types import Integer, Boolean, Unicode, String, DateTime
 
 import colander
@@ -133,6 +133,7 @@ class User(Base):
         Role,
         secondary=user_role,
         secondaryjoin=Role.id == user_role.c.role_id,
+        backref=backref('users', info={'colanderalchemy': {'exclude': True}}),
         info={
             'colanderalchemy': {
                 'title': _('Roles'),

--- a/geoportal/tests/functional/__init__.py
+++ b/geoportal/tests/functional/__init__.py
@@ -66,10 +66,10 @@ def cleanup_db():
         DBSession.delete(ti)
     DBSession.query(OGCServer).delete()
     DBSession.query(Interface).delete()
-    DBSession.query(User).delete()
     for r in DBSession.query(Role).all():
         r.functionnalities = []
         DBSession.delete(r)
+    DBSession.query(User).delete()
     DBSession.query(Functionality).delete()
     DBSession.query(FullTextSearch).delete()
     DBSession.query(Shorturl).delete()


### PR DESCRIPTION
SQLAlchemy automatically delete manytomany relationtions when related entity is marked for deletion.
But this only occurs when the relationships exists on considered entity side.

Here I had the backref in User.roles so relations are also deleted when a role is marked for deletion.

As user_role records are deleted with roles, in tests we can safely delete all the users after all roles have been maked for deletion.