### PR TITLE
Fix raster profile performances

### DIFF
--- a/doc/integrator/raster.rst
+++ b/doc/integrator/raster.rst
@@ -17,10 +17,12 @@ application config (``vars_<project>.yaml``).  For example:
     raster:
         cache_size: 21
         mns:
-            file: /var/sig/altimetrie/mns.shp
+            file: /var/sig/altimetrie/mns.vrt
+            type: gdal
             round: 1
         mnt:
-            file: /var/sig/altimetrie/mnt.shp
+            file: /var/sig/altimetrie/mnt.vrt
+            type: gdal
             round: 1
 
 ``raster`` is a list of "DEM layers". There are only two entries in this example,
@@ -32,7 +34,11 @@ but there could be more.
 The raster files should be in the Binary Terrain (BT/VTP .bt 1.3) format.
 One may use GDAL/OGR to convert data to such a format.
 
-``round`` specifies how the result values should be rounded.
+``type`` ``shp_index`` (default) for Mapserver shape index, or ``gdal`` for all supported GDAL sources.
+We recommand to use a `vrt <https://www.gdal.org/gdal_vrttut.html>`_ file built with
+`gdalbuildvrt <https://www.gdal.org/gdalbuildvrt.html>`_.
+
+``round`` specifigdalbuildvrtes how the result values should be rounded.
 For instance '1': round to the unit, '0.01': round to the hundredth, etc.
 
 The application viewer should be configured with one (or more) of the

--- a/geoportal/c2cgeoportal_geoportal/__init__.py
+++ b/geoportal/c2cgeoportal_geoportal/__init__.py
@@ -532,7 +532,7 @@ def includeme(config):
         from c2cgeoportal_commons.models.main import InvalidateCacheEvent
 
         @zope.event.classhandler.handler(InvalidateCacheEvent)
-        def handle(event: InvalidateCacheEvent):
+        def handle(event: InvalidateCacheEvent):  # pylint: disable=unused-variable
             del event
             caching.invalidate_region()
 
@@ -728,6 +728,10 @@ def includeme(config):
 
     # Dev
     config.add_route("dev", "/dev/*path", request_method="GET")
+
+    # Used memory in caches
+    add_cors_route(config, "/memory", "memory")
+    config.add_route("memory", "/memory", request_method="GET")
 
     # Scan view decorator for adding routes
     config.scan(ignore=[

--- a/geoportal/c2cgeoportal_geoportal/views/entry.py
+++ b/geoportal/c2cgeoportal_geoportal/views/entry.py
@@ -176,7 +176,7 @@ class Entry:
         from c2cgeoportal_commons.models.main import InvalidateCacheEvent
 
         @zope.event.classhandler.handler(InvalidateCacheEvent)
-        def handle(event: InvalidateCacheEvent):
+        def handle(event: InvalidateCacheEvent):  # pylint: disable=unused-variable
             del event
             Entry.server_wms_capabilities = {}
 

--- a/geoportal/c2cgeoportal_geoportal/views/memory.py
+++ b/geoportal/c2cgeoportal_geoportal/views/memory.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2012-2018, Camptocamp SA
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# The views and conclusions contained in the software and documentation are those
+# of the authors and should not be interpreted as representing official policies,
+# either expressed or implied, of the FreeBSD Project.
+
+
+import inspect
+import logging
+import sys
+
+from pyramid.view import view_config
+
+from c2cgeoportal_geoportal.views import entry, raster
+from c2cwsgiutils import broadcast
+
+log = logging.getLogger(__name__)
+
+
+@view_config(route_name="memory", renderer="fastjson")
+def memory(request):
+    del request
+    return _memory()
+
+
+@broadcast.decorator(expect_answers=True)
+def _memory():
+    wms_capabilities_cache = entry.Entry.server_wms_capabilities
+    raster_data = raster.Raster.data
+    return {
+        "parsed_wms_capabilities_cache_by_ogcserver_id": {
+            id: get_size(wms_capabilities_cache[id]) for id in wms_capabilities_cache
+        },
+        "raster_data": {
+            id: get_size(wms_capabilities_cache[id]) for id in raster_data
+        }
+    }
+
+
+# Get from https://github.com/bosswissam/pysize
+# Licence: MIT - https://github.com/bosswissam/pysize/blob/master/LICENSE.txt
+def get_size(obj, seen=None):
+    """Recursively finds size of objects in bytes"""
+    size = sys.getsizeof(obj)
+    if seen is None:
+        seen = set()
+    obj_id = id(obj)
+    if obj_id in seen:
+        return 0
+    # Important mark as seen *before* entering recursion to gracefully handle
+    # self-referential objects
+    seen.add(obj_id)
+    if hasattr(obj, '__dict__'):
+        for cls in obj.__class__.__mro__:
+            if '__dict__' in cls.__dict__:
+                d = cls.__dict__['__dict__']
+                if inspect.isgetsetdescriptor(d) or inspect.ismemberdescriptor(d):
+                    size += get_size(obj.__dict__, seen)
+                break
+    if isinstance(obj, dict):
+        size += sum((get_size(v, seen) for v in obj.values()))
+        size += sum((get_size(k, seen) for k in obj.keys()))
+    elif hasattr(obj, '__iter__') and not isinstance(obj, (str, bytes, bytearray)):
+        size += sum((get_size(i, seen) for i in obj))
+
+    if hasattr(obj, '__slots__'):  # Can have __slots__ with __dict__
+        size += sum(get_size(getattr(obj, s), seen) for s in obj.__slots__ if hasattr(obj, s))
+
+    return size

--- a/geoportal/c2cgeoportal_geoportal/views/profile.py
+++ b/geoportal/c2cgeoportal_geoportal/views/profile.py
@@ -108,7 +108,7 @@ class Profile(Raster):
 
             values = {}
             for ref in list(rasters.keys()):
-                value = self._get_raster_value(self.rasters[ref], coord[0], coord[1])
+                value = self._get_raster_value(self.rasters[ref], ref, coord[0], coord[1])
                 values[ref] = value
 
             # 10cm accuracy is enough for distances

--- a/geoportal/tests/data/dem4.vrt
+++ b/geoportal/tests/data/dem4.vrt
@@ -1,0 +1,15 @@
+<VRTDataset rasterXSize="7" rasterYSize="7">
+  <SRS>PROJCS["CH1903_LV03",GEOGCS["GCS_CH1903",DATUM["D_CH1903",SPHEROID["Bessel_1841",6377397.155,299.1528128]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]],PROJECTION["Hotine_Oblique_Mercator_Azimuth_Center"],PARAMETER["latitude_of_center",46.95240555555556],PARAMETER["longitude_of_center",7.439583333333333],PARAMETER["azimuth",90],PARAMETER["rectified_grid_angle",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",600000],PARAMETER["false_northing",200000],UNIT["metre",1,AUTHORITY["EPSG","9001"]]]</SRS>
+  <GeoTransform>  5.4798990841145662e+05,  1.0000000154167148e+00,  0.0000000000000000e+00,  2.1601000080037274e+05,  0.0000000000000000e+00, -1.0000000154707647e+00</GeoTransform>
+  <VRTRasterBand dataType="Float32" band="1">
+    <NoDataValue>-32768</NoDataValue>
+    <ComplexSource>
+      <SourceFilename relativeToVRT="1">dem4.bt</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SourceProperties RasterXSize="7" RasterYSize="7" DataType="Float32" BlockXSize="1" BlockYSize="7" />
+      <SrcRect xOff="0" yOff="0" xSize="7" ySize="7" />
+      <DstRect xOff="0" yOff="0" xSize="7" ySize="7" />
+      <NODATA>-32768</NODATA>
+    </ComplexSource>
+  </VRTRasterBand>
+</VRTDataset>


### PR DESCRIPTION
Remove LRU cache
Store only the first level read
Support all GDAL types (especially VRT)
Fix get point position
Add memory view

Time to get the profile throw all the riviera go from more the 70s. to less than 1s. :-) 