### PR TITLE
pdfreport: srs should be fully specified in configuration

### DIFF
--- a/c2cgeoportal/scaffolds/update/CONST_config-schema.yaml
+++ b/c2cgeoportal/scaffolds/update/CONST_config-schema.yaml
@@ -344,7 +344,7 @@ mapping:
                                         type: bool
                                         required: True
                                     srs:
-                                        type: int
+                                        type: str
                                         required: True
                                     spec:
                                         type: any

--- a/c2cgeoportal/views/pdfreport.py
+++ b/c2cgeoportal/views/pdfreport.py
@@ -147,7 +147,7 @@ class PdfReport(OGCProxy):  # pragma: no cover
                 "request": "GetFeature",
                 "typeName": self.layername,
                 "featureid": ",".join(features_ids),
-                "srsName": "epsg:{}".format(srs)
+                "srsName": srs
             }
         )
 


### PR DESCRIPTION
In our documentation for pdfreport, we say to use for srs a string like EPSG:21781 (see https://camptocamp.github.io/c2cgeoportal/2.2/integrator/pdfreport.html).

But this is currently not possible in the code, because the srs is defined as a number. So right now, projects can only define a number here, like 2056.

And when using the number only, there is an error while printing:
```
Caused by: org.opengis.referencing.NoSuchAuthorityCodeException: No authority was defined for code "2056". Did you forget "AUTHORITY:NUMBER"?
	at org.geotools.referencing.factory.ManyAuthoritiesFactory.noSuchAuthority(ManyAuthoritiesFactory.java:489)
	at org.geotools.referencing.factory.ManyAuthoritiesFactory.getAuthorityFactory(ManyAuthoritiesFactory.java:467)
	at org.geotools.referencing.factory.ManyAuthoritiesFactory.getCRSAuthorityFactory(ManyAuthoritiesFactory.java:548)
	at org.geotools.referencing.factory.AuthorityFactoryAdapter.createCoordinateReferenceSystem(AuthorityFactoryAdapter.java:801)
	at org.geotools.referencing.factory.ThreadedAuthorityFactory.createCoordinateReferenceSystem(ThreadedAuthorityFactory.java:731)
	at org.geotools.referencing.DefaultAuthorityFactory.createCoordinateReferenceSystem(DefaultAuthorityFactory.java:179)
	at org.geotools.referencing.CRS.decode(CRS.java:525)
	at org.geotools.referencing.CRS.decode(CRS.java:453)
	at org.mapfish.print.attribute.map.GenericMapAttribute.parseProjection(GenericMapAttribute.java:88)
```
This PR fixes the type of the srs parameter and its usage in pdfreport (tested manually on schwyz project gmf 2.2).