### PR TITLE
Install binary wheels first on Windows

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/nondockercreate/nondocker-finalise.mk_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/nondockercreate/nondocker-finalise.mk_tmpl
@@ -180,11 +180,12 @@ else
 endif
 ifeq ($(OPERATING_SYSTEM), WINDOWS)
 	$(PYTHON_BIN)/python -m pip install --upgrade pip
-	$(PYTHON_BIN)/python -m pip install $(shell python ./get-pip-dependencies c2cgeoportal-commons c2cgeoportal-geoportal c2cgeoportal-admin linesman networkx pygraphviz Shapely Fiona rasterio GDAL flake8-mypy mypy)
+	$(PYTHON_BIN)/python -m pip install -r requirements.txt
+	$(PYTHON_BIN)/python -m pip install $(shell python ./get-pip-dependencies c2cgeoportal-commons c2cgeoportal-geoportal c2cgeoportal-admin linesman networkx pygraphviz pyproj Shapely Fiona rasterio GDAL flake8-mypy mypy)
 else
 	$(PYTHON_BIN)/python -m pip install `./get-pip-dependencies c2cgeoportal-commons c2cgeoportal-geoportal c2cgeoportal-admin GDAL flake8-mypy mypy`
-endif
 	$(PYTHON_BIN)/python -m pip install -r requirements.txt
+endif
 	$(PYTHON_BIN)/python -m pip install --editable=c2cgeoportal_commons --editable=c2cgeoportal_geoportal --editable=c2cgeoportal_admin
 	$(PYTHON_BIN)/python -m pip install --editable=geoportal
 	$(PYTHON_BIN)/python -m compileall -q .build/venv >/dev/null || true


### PR DESCRIPTION
On Windows we cannot install Pyproj through pip anymore. I added this dependency as a binary wheel. Moreover, as it is a dependency of OWSlib, we have to install it first (before OWSlib).

@sbrunner, I do not know if anybody else is using `nondocker-finalise.mk`, but I would be grateful if this PR could be merged (if Travis is happy, as always...)