### PR TITLE
Use assertEqual instead of assertEquals

### DIFF
--- a/geoportal/tests/functional/test_layers.py
+++ b/geoportal/tests/functional/test_layers.py
@@ -410,10 +410,10 @@ class TestLayers(TestCase):
         request.body = '{"type": "FeatureCollection", "features": [{"type": "Feature", "properties": {"email": "novalidemail", "name": "foo", "child": "c1é"}, "geometry": {"type": "Point", "coordinates": [5, 45]}}, {"type": "Feature", "properties": {"text": "foo", "child": "c2é"}, "geometry": {"type": "Point", "coordinates": [5, 45]}}]}'  # noqa
         layers = Layers(request)
         response = layers.create()
-        self.assertEquals(request.response.status_int, 400)
+        self.assertEqual(request.response.status_int, 400)
         self.assertTrue("error_type" in response)
         self.assertTrue("message" in response)
-        self.assertEquals(response["error_type"], "integrity_error")
+        self.assertEqual(response["error_type"], "integrity_error")
 
     def test_create_log(self):
         from datetime import datetime
@@ -455,11 +455,11 @@ class TestLayers(TestCase):
         request.body = '{"type": "FeatureCollection", "features": [{"type": "Feature", "properties": {"name": "foo", "child": "c1é"}, "geometry": {"type": "Point", "coordinates": [5, 45]}}, {"type": "Feature", "properties": {"text": "foo", "child": "c2é"}, "geometry": {"type": "LineString", "coordinates": [[5, 45], [5, 45]]}}]}'  # noqa
         layers = Layers(request)
         response = layers.create()
-        self.assertEquals(request.response.status_int, 400)
+        self.assertEqual(request.response.status_int, 400)
         self.assertTrue("error_type" in response)
         self.assertTrue("message" in response)
-        self.assertEquals(response["error_type"], "validation_error")
-        self.assertEquals(response["message"], "Too few points in geometry component[5 45]")
+        self.assertEqual(response["error_type"], "validation_error")
+        self.assertEqual(response["message"], "Too few points in geometry component[5 45]")
 
     def test_create_no_validation(self):
         from geojson.feature import FeatureCollection
@@ -559,11 +559,11 @@ class TestLayers(TestCase):
         request.body = '{"type": "Feature", "id": 1, "properties": {"name": "foobar", "child": "c2é"}, "geometry": {"type": "LineString", "coordinates": [[5, 45], [5, 45]]}}'  # noqa
         layers = Layers(request)
         response = layers.update()
-        self.assertEquals(request.response.status_int, 400)
+        self.assertEqual(request.response.status_int, 400)
         self.assertTrue("error_type" in response)
         self.assertTrue("message" in response)
-        self.assertEquals(response["error_type"], "validation_error")
-        self.assertEquals(response["message"], "Too few points in geometry component[5 45]")
+        self.assertEqual(response["error_type"], "validation_error")
+        self.assertEqual(response["message"], "Too few points in geometry component[5 45]")
 
     def test_update_validation_fails_simple(self):
         from c2cgeoportal_geoportal.views.layers import Layers
@@ -575,11 +575,11 @@ class TestLayers(TestCase):
         request.body = '{"type": "Feature", "id": 1, "properties": {"name": "foobar", "child": "c2é"}, "geometry": {"type": "LineString", "coordinates": [[5, 45], [6, 45], [5, 45]]}}'  # noqa
         layers = Layers(request)
         response = layers.update()
-        self.assertEquals(request.response.status_int, 400)
+        self.assertEqual(request.response.status_int, 400)
         self.assertTrue("error_type" in response)
         self.assertTrue("message" in response)
-        self.assertEquals(response["error_type"], "validation_error")
-        self.assertEquals(response["message"], "Not simple")
+        self.assertEqual(response["error_type"], "validation_error")
+        self.assertEqual(response["message"], "Not simple")
 
     def test_update_validation_fails_constraint(self):
         from c2cgeoportal_geoportal.views.layers import Layers
@@ -591,10 +591,10 @@ class TestLayers(TestCase):
         request.body = '{"type": "Feature", "id": 1, "properties": {"email": "novalidemail"}, "geometry": {"type": "Point", "coordinates": [5, 45]}}'  # noqa
         layers = Layers(request)
         response = layers.update()
-        self.assertEquals(request.response.status_int, 400)
+        self.assertEqual(request.response.status_int, 400)
         self.assertTrue("error_type" in response)
         self.assertTrue("message" in response)
-        self.assertEquals(response["error_type"], "integrity_error")
+        self.assertEqual(response["error_type"], "integrity_error")
 
     def test_update_no_validation(self):
         from c2cgeoportal_geoportal.views.layers import Layers

--- a/geoportal/tests/functional/test_themes_dimensions.py
+++ b/geoportal/tests/functional/test_themes_dimensions.py
@@ -214,7 +214,7 @@ class TestThemesView(TestCase):
             "The layer '__test_layer_wms_2' has a wrong dimension value 'b' for 'A', expected 'a' or empty.",
             "The layer '__test_layer_wmts_2' has an unsupported dimension value 'countries:\"name\" IN ( 'Germany' , 'Italy' )' ('FILTER')."
         ]))
-        self.assertEquals(
+        self.assertEqual(
             [self._only_name(t, ["name", "dimensions", "dimensionsFilters"]) for t in themes["themes"]],
             [{
                 "children": [{

--- a/geoportal/tests/functional/test_themes_private.py
+++ b/geoportal/tests/functional/test_themes_private.py
@@ -182,8 +182,8 @@ class TestThemesPrivateView(TestCase):
     def test_public(self):
         entry = self._create_entry_obj()
         themes = entry.themes()
-        self.assertEquals(self._get_filtered_errors(themes), set())
-        self.assertEquals(
+        self.assertEqual(self._get_filtered_errors(themes), set())
+        self.assertEqual(
             [self._only_name(t) for t in themes["themes"]],
             [{
                 "name": "__test_theme",
@@ -203,8 +203,8 @@ class TestThemesPrivateView(TestCase):
         from c2cgeoportal_commons.models.static import User
         entry = self._create_entry_obj(user=DBSession.query(User).filter_by(username=u"__test_user").one())
         themes = entry.themes()
-        self.assertEquals(self._get_filtered_errors(themes), set())
-        self.assertEquals(
+        self.assertEqual(self._get_filtered_errors(themes), set())
+        self.assertEqual(
             [self._only_name(t) for t in themes["themes"]],
             [{
                 "name": u"__test_theme",


### PR DESCRIPTION
`assertEquals` is deprecated, the following warning is raised in the tests:
```
/src/geoportal/tests/functional/test_layers.py:457: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(request.response.status_int, 400)
```
