### PR TITLE
Doc - Add correct prefix to access cuustom admin tables

### DIFF
--- a/doc/integrator/extend_data_model.rst
+++ b/doc/integrator/extend_data_model.rst
@@ -240,7 +240,7 @@ And finally in ``geoportal/<package>_geoportal/__init__.py`` replace ``config.sc
         ('interfaces', Interface),
         ('userdetail', UserDetail),
         ('title', Title),
-    ))
+    ), 'admin')
 
     with PermissionSetter(config):
         # Scan view decorator for adding routes


### PR DESCRIPTION
Otherwise path like lang redirection are wrong, and there are
conflicts with the /themes path