### PR TITLE
Geoportal: Can have custom wms table delivred by the theme view

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/views/entry.py
+++ b/geoportal/c2cgeoportal_geoportal/views/entry.py
@@ -329,7 +329,7 @@ class Entry:
             query = models.DBSession.query(main.LayerV1.name)
         else:
             query = models.DBSession.query(main.Layer.name).filter(
-                ~main.Layer.item_type.in_(["layerv1"])
+                main.Layer.item_type.notin_(["layerv1"])
             )
 
         query = query.filter(main.Layer.public.is_(True))

--- a/geoportal/c2cgeoportal_geoportal/views/entry.py
+++ b/geoportal/c2cgeoportal_geoportal/views/entry.py
@@ -329,7 +329,7 @@ class Entry:
             query = models.DBSession.query(main.LayerV1.name)
         else:
             query = models.DBSession.query(main.Layer.name).filter(
-                main.Layer.item_type.in_(["l_wms", "l_wmts"])
+                ~main.Layer.item_type.in_(["layerv1"])
             )
 
         query = query.filter(main.Layer.public.is_(True))


### PR DESCRIPTION
I've custom wms tables (`lu_ext_wms` and `lu_int_wms`) that extend the standard `l_wms` tables. Without this (kind of) change, I can't receive them in the theme object. (Or do you have a better idea ?)