### PR TITLE
Fix hostnameMatch in print config

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/print/print-apps/+package+/config.yaml.tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/print/print-apps/+package+/config.yaml.tmpl
@@ -55,7 +55,9 @@ templates:
               https?://${VISIBLE_WEB_HOST_RE_ESCAPED}${VISIBLE_ENTRY_POINT_RE_ESCAPED}(.*): "${GEOPORTAL_INTERNAL_URL}${VISIBLE_ENTRY_POINT}$1"
           - !forwardHeaders
             matchers:
-              - !localMatch {}
+              - !hostnameMatch
+                host: ${GEOPORTAL_INTERNAL_HOST}
+                port: ${GEOPORTAL_INTERNAL_PORT}
             headers:
               - Cookie
               - Host


### PR DESCRIPTION
This was missing in the print config and the consequences was that some private layers weren't printed.