### PR TITLE
Make it possible to have the alembic version table written in a custo…

### DIFF
--- a/commons/c2cgeoportal_commons/alembic/env.py
+++ b/commons/c2cgeoportal_commons/alembic/env.py
@@ -42,12 +42,13 @@ def get_config():
     config.init(context.config.get_main_option('app.cfg'))
     settings = {}
     settings.update(config.get_config())
-    main = context.config.get_main_option('type') == 'main'
+    alembic_name = context.config.get_main_option('type')
+    schema_config_name = 'schema{}'.format('_{}'.format(alembic_name) if alembic_name != 'main' else '')
     settings.update({
         'script_location': context.config.get_main_option('script_location'),
         'version_table': context.config.get_main_option('version_table'),
         'version_locations': context.config.get_main_option('version_locations'),
-        'version_table_schema': config['schema' if main else 'schema_static'],
+        'version_table_schema': config[schema_config_name],
     })
     return settings
 


### PR DESCRIPTION
…m schema (when adding custom alembic script to a project).

"alembic_name" because the option in alembic is called "name", as seen in "usage: alembic [-h] [-c CONFIG] [-n NAME] [-x X] [--raiseerr]"

"schema_config_name" because it's the name of the variable in the project's config where the schema name is set.