### PR TITLE
Create a variable to skip translation process in enum config

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/lib/lingua_extractor.py
+++ b/geoportal/c2cgeoportal_geoportal/lib/lingua_extractor.py
@@ -257,7 +257,7 @@ class GeomapfishConfigExtractor(Extractor):  # pragma: no cover
             for fieldname in list(attributes.keys()):
                 values = self._enumerate_attributes_values(DBSessions, Layers, layerinfos, fieldname)
                 for value, in values:
-                    if value != "":
+                    if value is not None and isinstance(value, str) and value != "":
                         msgid = value
                         location = "/layers/{}/values/{}/{}".format(
                             layername,
@@ -288,6 +288,9 @@ class GeomapfishConfigExtractor(Extractor):  # pragma: no cover
     @staticmethod
     def _enumerate_attributes_values(dbsessions, layers, layerinfos, fieldname):
         dbname = layerinfos.get("dbsession", "dbsession")
+        translate = layerinfos.get("attributes").get(fieldname, {}).get("translate", True)
+        if not translate:
+            return []
         try:
             dbsession = dbsessions.get(dbname)
             return layers.query_enumerate_attribute_values(dbsession, layerinfos, fieldname)

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/CONST_config-schema.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/CONST_config-schema.yaml
@@ -335,6 +335,8 @@ mapping:
                             type: str
                           separator:
                             type: str
+                          translate:
+                            type: bool
       functionalities:
         type: map
         required: True


### PR DESCRIPTION
This PR was made for two purposes and should solve issues that we have with the layer enumeration configuration (YAML config file):
* It happens that we have None values or columns containing numbers (and defined as having to). This makes the lingua_extractor crash, thus I check for these exceptions and avoid to translate them (https://github.com/camptocamp/c2cgeoportal/compare/master...kalbermattenm:enum_translate?expand=1#diff-88967e2bdedfa9e803c46b29cd0a2e76R260)
* It happens that a DB column already contains the right translated strings, thus it is not useful to translate them. Moreover, for the SITN project and its filters, the translation process added more the 400 lines to the po file, because of that and all these translation additions are useless, we will not translate them (leaving the `msgstr` empty). I added a new config variable at the column level to specify if its content has to be translated (or not), by default it is translated and the variable (`translate`) is not required.

I am opened to any other suggestion in order to improve one or the other point.

Thanks for the review