### PR TITLE
Allow static urls in url metadatas

### DIFF
--- a/admin/c2cgeoportal_admin/schemas/metadata.py
+++ b/admin/c2cgeoportal_admin/schemas/metadata.py
@@ -2,6 +2,7 @@ import json
 import colander
 from deform.widget import MappingWidget, SelectWidget, SequenceWidget, TextAreaWidget
 from c2cgeoform.schema import GeoFormSchemaNode
+from c2cgeoportal_commons.lib.validators import url
 from c2cgeoportal_commons.models.main import Metadata
 from c2cgeoportal_admin import _
 
@@ -59,7 +60,7 @@ class MetadataSchemaNode(GeoFormSchemaNode):
         self._add_value_node('boolean', colander.Boolean())
         self._add_value_node('int', colander.Int())
         self._add_value_node('float', colander.Float())
-        self._add_value_node('url', colander.String(), validator=colander.url)
+        self._add_value_node('url', colander.String(), validator=url)
         self._add_value_node(
             'json',
             colander.String(),

--- a/admin/tests/test_metadatas.py
+++ b/admin/tests/test_metadatas.py
@@ -192,13 +192,17 @@ class TestMetadatasView(AbstractViewsTests):
             'gnagnagna',
             'Must be a URL')
 
-    def test_valid_url_metadata(self, test_app, metadatas_test_data):
+    @pytest.mark.parametrize("url", [
+        'www.111111111111111111111111111111111111111111111111111111111111.com',
+        'static://static/img/cadastre.jpeg',
+    ])
+    def test_valid_url_metadata(self, test_app, metadatas_test_data, url):
         self._post_metadata(
             test_app,
             '/layers_wms/new',
             self._base_metadata_params(metadatas_test_data),
             '_url',
-            'www.111111111111111111111111111111111111111111111111111111111111.com',
+            url,
             302)
 
     def test_invalid_json_metadata(self, test_app, metadatas_test_data):

--- a/commons/c2cgeoportal_commons/lib/validators.py
+++ b/commons/c2cgeoportal_commons/lib/validators.py
@@ -1,0 +1,6 @@
+import colander
+import re
+
+# Custom url validator that allow c2cgeoportal static urls.
+URL_REGEX = r'(?:{}|^(:?static|config)://\S+$)'.format(colander.URL_REGEX)
+url = colander.Regex(URL_REGEX, msg=colander._('Must be a URL'), flags=re.IGNORECASE)

--- a/commons/tests/validators_test.py
+++ b/commons/tests/validators_test.py
@@ -1,0 +1,17 @@
+# pylint: disable=no-self-use
+
+import pytest
+from c2cgeoportal_commons.lib.validators import url
+
+
+class TestUrl():
+
+    @pytest.mark.parametrize("valid_url", [
+        'http://geomapfish.org',
+        'https://geomapfish.org/functionalities',
+        'geomapfish.org/functionalities',
+        'static://img/cadastre.jpeg',
+        'config://internal/mapserv'
+    ])
+    def test_valid_url(self, valid_url):
+        url(None, valid_url)


### PR DESCRIPTION
I've put the validator in commons and allowed config://
There is no validators on url fields in schema main, I've not added such validators to propose a harmless fix.