### PR TITLE
Generate geoportal/alembic.yaml using /build/c2ctemplate-cache.json

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -760,9 +760,9 @@ push-docker:
 	docker push $(DOCKER_BASE)-config:$(DOCKER_TAG)
 	docker push $(DOCKER_BASE)-geoportal:$(DOCKER_TAG)
 
-geoportal/alembic.yaml: $(ALEMBIC_YAML_FILE) vars.yaml CONST_vars.yaml
+geoportal/alembic.yaml: /build/c2ctemplate-cache.json
 	$(PRERULE_CMD)
-	c2c-template --vars $< --get-config /build/_alembic.yaml srid schema schema_static sqlalchemy.url cache
+	c2c-template --cache /build/c2ctemplate-cache.json --get-config /build/_alembic.yaml srid schema schema_static sqlalchemy.url cache
 	mv /build/_alembic.yaml $@
 
 testdb/11-schemas.sql: vars_alembic.yaml $(ALEMBIC_YAML_FILE) testdb/11-schemas.sql_mako vars.yaml CONST_vars.yaml


### PR DESCRIPTION
For now alembic.yaml is not regenerated when user development vars file is modified because it does not depends on VARS_FILES (plural version).
As /build/c2ctemplate-cache.json should have correct dependencies, using the cache as dependendy and data source should fix the problem and improve performance at the same time.