### PR TITLE
Support passing values for elements in routes in interfaces configura…

### DIFF
--- a/doc/integrator/ngeo.rst.mako
+++ b/doc/integrator/ngeo.rst.mako
@@ -99,8 +99,13 @@ The sub section is the interface name, and after that we have:
 * ``static``: key: Constant name, value: name of the static view that we want to have the URL.
 * ``routes``: key: Constant name, value:
     ``name``: Name of the route witch one we want to have the URL.
-    ``params``: View parameters.
-    ``dynamic_params``: View parameters from dynamic values.
+    ``kw``: Keyword arguments to supply for dynamic path elements in the route definition.
+    ``elements``: Additional positional path segments to append the URL after it is generated.
+    ``params``: Query string parameters to append to the URL.
+    ``dynamic_params``: Query string parameters from dynamic values to append to the URL.
+
+For more information ``elements`` and ``kw`` properties see *Pyramid* ``Request.route_url`` documentation:
+https://docs.pylonsproject.org/projects/pyramid/en/latest/api/request.html#pyramid.request.Request.route_url
 
 The dynamic values names are: ``interface``, ``cache_version``, ``lang_urls``, ``fulltextsearch_groups``.
 

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/CONST_config-schema.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/CONST_config-schema.yaml
@@ -152,6 +152,15 @@ mapping:
                       name:
                         type: str
                         required: True
+                      elements:
+                        type: seq
+                        sequence:
+                          - type: str
+                      kw:
+                        type: map
+                        mapping:
+                          regex;.+:
+                            type: str
                       params:
                         type: map
                         mapping:

--- a/geoportal/c2cgeoportal_geoportal/views/dynamic.py
+++ b/geoportal/c2cgeoportal_geoportal/views/dynamic.py
@@ -90,7 +90,10 @@ class DynamicView:
             params.update(config.get('params', {}))
             for name, dyn in config.get('dynamic_params', {}).items():
                 params[name] = dynamic[dyn]
-            constants[constant] = self.request.route_url(config['name'], _query=params)
+            constants[constant] = self.request.route_url(config['name'],
+                                                         *config.get('elements', []),
+                                                         _query=params,
+                                                         **config.get('kw', {}))
 
         do_redirect = False
         url = None


### PR DESCRIPTION
…tions
As I cannot use dummy ``route_url`` as constructed in _request for my tests, I've used testConfig coming from pyramid testing to register routes. This might be generalized to other tests for consistency.