### PR TITLE
Fix the tinyows proxy auth to work with uppercases

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/views/tinyowsproxy.py
+++ b/geoportal/c2cgeoportal_geoportal/views/tinyowsproxy.py
@@ -125,7 +125,7 @@ class TinyOWSProxy(OGCProxy):
         writable_layers = set()
         for gmflayer in list(get_writable_layers(self.role_id, [self.default_ogc_server.id]).values()):
             for ogclayer in gmflayer.layer.split(","):
-                writable_layers.add(ogclayer)
+                writable_layers.add(ogclayer.lower())
         return typenames.issubset(writable_layers)
 
     def _get_headers(self):


### PR DESCRIPTION
Layer with uppercase characters in the name where always returning error
403.