### PR TITLE
Fix WMST enumerated time extent with only one limit

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/lib/wmstparsing.py
+++ b/geoportal/c2cgeoportal_geoportal/lib/wmstparsing.py
@@ -32,6 +32,22 @@ import isodate
 import datetime
 
 
+def min_none(a, b):
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return min(a, b)
+
+
+def max_none(a, b):
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return max(a, b)
+
+
 class TimeInformation:
     """
     Arguments:
@@ -127,8 +143,8 @@ class TimeExtentValue:
                 "Could not mix time defined as a list of "
                 "values with other type of definition")
         self.values.update(extent.values)
-        self.min_def_value = min(self.min_def_value, extent.min_def_value)
-        self.max_def_value = max(self.max_def_value, extent.max_def_value)
+        self.min_def_value = min_none(self.min_def_value, extent.min_def_value)
+        self.max_def_value = max_none(self.max_def_value, extent.max_def_value)
 
     def to_dict(self):
         values = sorted(self.values)
@@ -178,16 +194,16 @@ class TimeExtentInterval:
             raise ValueError(
                 "Could not merge times defined with a "
                 "different interval")
-        self.start = min(self.start, extent.start)
-        self.end = max(self.end, extent.end)
+        self.start = min_none(self.start, extent.start)
+        self.end = max_none(self.end, extent.end)
         self.min_def_value = \
             self.min_def_value if extent.min_def_value is None else \
             extent.min_def_value if self.min_def_value is None else \
-            min(self.min_def_value, extent.min_def_value)
+            min_none(self.min_def_value, extent.min_def_value)
         self.max_def_value = \
             self.max_def_value if extent.max_def_value is None else \
             extent.max_def_value if self.max_def_value is None else \
-            max(self.max_def_value, extent.max_def_value)
+            max_none(self.max_def_value, extent.max_def_value)
 
     def to_dict(self):
         min_def_value = _format_date(self.min_def_value) \


### PR DESCRIPTION
In python 2, we have `max(None, None) == None`. In python 3, we have
`max(None, None) => raise TypeError`.