### PR TITLE
Be able to cancel a dynamic_constants

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/views/dynamic.py
+++ b/geoportal/c2cgeoportal_geoportal/views/dynamic.py
@@ -77,6 +77,7 @@ class DynamicView:
         constants.update({
             name: dynamic[value]
             for name, value in self.get('dynamic_constants', interface_name).items()
+            if value is not None
         })
         constants.update({
             name: self.request.static_url(static_['name']) + static_.get('append', '')


### PR DESCRIPTION
that come from the Const_vars.yaml, without changing the update_paths.

Fix https://jira.camptocamp.com/browse/GSGMF-949