### PR TITLE
Doc - Update doc for create/update feature on webservice layers

### DIFF
--- a/doc/developer/webservices.rst
+++ b/doc/developer/webservices.rst
@@ -387,9 +387,12 @@ A standard xsd document that describe the layer.
 MapFish protocol
 ----------------
 
-URL: ``.../layers/<layer_id>/....``
+URL: ``.../layers/<layer_id>...``
 
 `Parameters and results, see the MapFish protocol <https://github.com/elemoine/papyrus/wiki/Protocol>`_.
+
+With GeoMapFish on Create/Update features (POST and PUT), you have to provide a correct
+`Content-Type` header, the value must be `application/json`.
 
 Enumerate attributes
 --------------------


### PR DESCRIPTION
Target 2.2.

I also can remove the difference by adding or removing the header:
 - https://github.com/elemoine/papyrus/blob/master/papyrus/__init__.py#L34-L38
 - https://github.com/camptocamp/c2cgeoportal/blob/2.2/c2cgeoportal/pyramid_.py#L679-L684