### PR TITLE
Switch to a token for OpenShift Auth in Travis

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/+dot+travis.yml_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/+dot+travis.yml_tmpl
@@ -15,8 +15,6 @@ env:
 #    - DOCKER_USERNAME=username
 #    - secure: travis encrypt DOCKER_PASSWORD=password
 #    - OPENSHIFT_URL=https://openshift-ch-3.camptocamp.com/
-#    - OPENSHIFT_USERNAME=username
-#    - secure: travis encrypt OPENSHIFT_PASSWORD=password
 
 script:
   - ./docker-run make checks

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/scripts/deploy-docker
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/scripts/deploy-docker
@@ -47,13 +47,11 @@ subprocess.check_call([
 ], cwd='/tmp')
 
 subprocess.check_call([
-    'oc', 'login', os.environ['OPENSHIFT_URL'],
-    '--username=' + os.environ['OPENSHIFT_USERNAME'],
-    '--password=' + os.environ['OPENSHIFT_PASSWORD'],
+    'oc', 'login', os.environ['OPENSHIFT_URL'], '--token=' + os.environ['OPENSHIFT_TOKEN'],
 ])
-subprocess.check_call(['oc', 'project', os.environ['OPENSHIFT_PROJECT']])
 for image in images:
     openshift_image_ref = '{}-c2cgeoportal-{}:{}'.format(version, image, version)
     subprocess.check_call([
         'oc', 'import-image', openshift_image_ref, '--scheduled=true', '--reference-policy=local',
+        '--namespace=' + os.environ['OPENSHIFT_PROJECT']
     ])


### PR DESCRIPTION
The OPENSHIFT_TOKEN environment variable is automatically added by the
`get_ci_tokens` script in private-geo-charts.