### PR TITLE
Add puppeteer docker image to run check-example.js

### DIFF
--- a/docker/puppeteer/Dockerfile
+++ b/docker/puppeteer/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:8.11.3
+
+RUN apt-get update && \
+    apt-get -y install xvfb gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 \
+      libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 \
+      libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
+      libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 \
+      libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+    #rm -rf /var/lib/apt/lists/*
+
+RUN apt-get -y install apache2
+
+RUN npm install puppeteer url-parse
+
+# Add user so we don't need --no-sandbox.
+RUN groupadd -r pptruser && useradd -r -g pptruser -G audio,video pptruser \
+    && mkdir -p /home/pptruser/Downloads \
+    && chown -R pptruser:pptruser /home/pptruser
+
+# Run everything after as non-privileged user.
+USER pptruser


### PR DESCRIPTION
https://jira.camptocamp.com/browse/GSGMF-1090

Expected final usage in demo_geomapfish:
```
docker-compose run --rm geomapfish-puppeteer node check-example.js http://geoportal:8080
```
