### PR TITLE
Fix interface override defaults

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/CONST_vars.yaml_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/CONST_vars.yaml_tmpl
@@ -229,8 +229,6 @@ vars:
           name: printproxy
     mobile:
       redirect_interface: desktop
-      constants:
-        gmfSearchGroups: []
     mobile_alt:
       redirect_interface: desktop_alt
       constants:

--- a/geoportal/c2cgeoportal_geoportal/views/dynamic.py
+++ b/geoportal/c2cgeoportal_geoportal/views/dynamic.py
@@ -37,7 +37,9 @@ from sqlalchemy import func
 from c2cgeoportal_commons import models
 from c2cgeoportal_commons.models import main
 from c2cgeoportal_geoportal.lib.cacheversion import get_cache_version
-from c2cgeoportal_geoportal.lib.caching import NO_CACHE, set_common_headers
+from c2cgeoportal_geoportal.lib.caching import NO_CACHE, set_common_headers, get_region
+
+CACHE_REGION = get_region()
 
 
 class DynamicView:
@@ -52,6 +54,45 @@ class DynamicView:
         result = dict(self.default.get(value, {}))
         result.update(self.interfaces_config.get(interface, {}).get(value, {}))
         return result
+
+    @CACHE_REGION.cache_on_arguments()
+    def _fulltextsearch_groups(self):
+        return [
+            group[0] for group in models.DBSession.query(
+                func.distinct(main.FullTextSearch.layer_name)
+            ).filter(main.FullTextSearch.layer_name.isnot(None)).all()
+        ]
+
+    def _interface(self, interface_config, interface_name, dynamic, constants):
+
+        constants.update({
+            name: value for name, value in interface_config.get('constants', {}).items()
+        })
+        constants.update({
+            name: dynamic[value]
+            for name, value in interface_config.get('dynamic_constants', {}).items()
+            if value is not None
+        })
+        constants.update({
+            name: self.request.static_url(static_['name']) + static_.get('append', '')
+            for name, static_ in interface_config.get('static', {}).items()
+        })
+
+        routes = dict(currentInterfaceUrl={'name': interface_name})
+        routes.update(interface_config.get('routes', {}))
+        for constant, config in routes.items():
+            params = {}
+            params.update(config.get('params', {}))
+            for name, dyn in config.get('dynamic_params', {}).items():
+                params[name] = dynamic[dyn]
+            constants[constant] = self.request.route_url(
+                config['name'],
+                *config.get('elements', []),
+                _query=params,
+                **config.get('kw', {})
+            )
+
+        return constants
 
     @view_config(route_name='dynamic', renderer='fast_json')
     def dynamic(self):
@@ -73,35 +114,14 @@ class DynamicView:
                 ))
                 for lang in self.request.registry.settings["available_locale_names"]
             },
-            'fulltextsearch_groups': [
-                group[0] for group in models.DBSession.query(
-                    func.distinct(main.FullTextSearch.layer_name)
-                ).filter(main.FullTextSearch.layer_name.isnot(None)).all()
-            ],
+            'fulltextsearch_groups': self._fulltextsearch_groups(),
         }
-
-        constants = {name: value for name, value in self.get('constants', interface_name).items()}
-        constants.update({
-            name: dynamic[value]
-            for name, value in self.get('dynamic_constants', interface_name).items()
-            if value is not None
-        })
-        constants.update({
-            name: self.request.static_url(static_['name']) + static_.get('append', '')
-            for name, static_ in self.get('static', interface_name).items()
-        })
-
-        routes = dict(currentInterfaceUrl={'name': interface_name})
-        routes.update(self.get('routes', interface_name))
-        for constant, config in routes.items():
-            params = {}
-            params.update(config.get('params', {}))
-            for name, dyn in config.get('dynamic_params', {}).items():
-                params[name] = dynamic[dyn]
-            constants[constant] = self.request.route_url(config['name'],
-                                                         *config.get('elements', []),
-                                                         _query=params,
-                                                         **config.get('kw', {}))
+        constants = self._interface(
+            self.default, interface_name, dynamic, {}
+        )
+        constants = self._interface(
+            interface_config, interface_name, dynamic, constants
+        )
 
         do_redirect = False
         url = None

--- a/geoportal/tests/functional/test_dynamicview.py
+++ b/geoportal/tests/functional/test_dynamicview.py
@@ -403,3 +403,43 @@ class TestDynamicView(TestCase):
             'doRedirect': True,
             'redirectUrl': '/dummy/route/url/test_redirect?',
         }
+
+    def test_cross_overrid_1(self):
+        from c2cgeoportal_geoportal.views.dynamic import DynamicView
+        request = self._request()
+        request.registry.settings = self._get_settings({
+            'default': {
+                'constants': {
+                    'XTest': 'TOTO'
+                }
+            },
+            'test': {
+                'dynamic_constants': {
+                    'XTest': 'interface'
+                }
+            }
+        })
+        dynamic = DynamicView(request).dynamic()
+
+        assert 'XTest' in dynamic['constants'], dynamic
+        assert dynamic['constants']['XTest'] == 'test'
+
+    def test_cross_overrid_2(self):
+        from c2cgeoportal_geoportal.views.dynamic import DynamicView
+        request = self._request()
+        request.registry.settings = self._get_settings({
+            'default': {
+                'dynamic_constants': {
+                    'XTest': 'interface'
+                }
+            },
+            'test': {
+                'constants': {
+                    'XTest': 'TOTO'
+                }
+            }
+        })
+        dynamic = DynamicView(request).dynamic()
+
+        assert 'XTest' in dynamic['constants'], dynamic
+        assert dynamic['constants']['XTest'] == 'TOTO'


### PR DESCRIPTION
Currently
```
      constants:
        gmfSearchActions: []
```
don't override
```
      dynamic_constants:
        gmfSearchGroups: fulltextsearch_groups
```