### PR TITLE
Allow build behind proxy

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -16,6 +16,7 @@ else
 DOCKER_ENTRY_POINT ?= /$(INSTANCE)/
 DOCKER_TAG ?= $(INSTANCE)
 endif
+DOCKER_BUILD_ARGS ?=
 DOCKER_WEB_HOST ?= 172.17.0.1:$(DOCKER_PORT)
 DOCKER_WEB_PROTOCOL ?= https
 DOCKER_PGUSER ?= www-data
@@ -693,7 +694,8 @@ docker-build-config: $(shell docker-required --path .) \
 		$(PRINT_CONFIG_FILE) \
 		$(MAPCACHE_FILE) \
 		qgisserver/geomapfish.yaml
-	docker build --tag=$(DOCKER_BASE)-config:$(DOCKER_TAG) \
+	docker build $(DOCKER_BUILD_ARGS) \
+		--tag=$(DOCKER_BASE)-config:$(DOCKER_TAG) \
 		--build-arg=PGSCHEMA=$(PGSCHEMA) .
 
 .PHONY: docker-build-geoportal
@@ -703,7 +705,8 @@ docker-build-geoportal: $(shell docker-required --path geoportal) \
 		geoportal/config.yaml \
 		geoportal/alembic.ini \
 		geoportal/alembic.yaml
-	docker build --tag=$(DOCKER_BASE)-geoportal:$(DOCKER_TAG) \
+	docker build $(DOCKER_BUILD_ARGS) \
+		--tag=$(DOCKER_BASE)-geoportal:$(DOCKER_TAG) \
 		--build-arg=GIT_HASH=$(GIT_HASH) geoportal
 
 .PHONY: push-docker


### PR DESCRIPTION
Example:

DOCKER_BUILD_ARGS += --build-arg http_proxy=http://proxy:9090
DOCKER_BUILD_ARGS += --build-arg https_proxy=http://proxy:9090