### PR TITLE
Use only the major version tag

### DIFF
--- a/ci/publish
+++ b/ci/publish
@@ -49,11 +49,17 @@ then
     VERSION_QGIS=${VERSION}
 fi
 
-# Publish the GeoMapFish images
-for IMAGE in geomapfish geomapfish-tools geomapfish-config-build geomapfish-geoportal
+# Publish the GeoMapFish tools and config-build images
+for IMAGE in geomapfish-tools geomapfish-config-build
 do
     docker tag camptocamp/${IMAGE} camptocamp/${IMAGE}:${VERSION}
     docker push camptocamp/${IMAGE}:${VERSION}
+done
+# Publish the GeoMapFish run and default geoportal images
+for IMAGE in geomapfish geomapfish-geoportal
+do
+    docker tag camptocamp/${IMAGE} camptocamp/${IMAGE}:${MAJOR_VERSION}
+    docker push camptocamp/${IMAGE}:${MAJOR_VERSION}
 done
 
 # Publish the GeoMapFish QGIS server images

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/geoportal/Dockerfile_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/geoportal/Dockerfile_tmpl
@@ -18,7 +18,7 @@ CMD [ "webpack-dev-server", "--mode=development", "--debug", "--watch", "--progr
 
 ###############################################################################
 
-FROM camptocamp/geomapfish:{{geomapfish_version}} as runner
+FROM camptocamp/geomapfish:{{geomapfish_main_version}} as runner
 
 COPY requirements.txt /tmp/requirements.txt
 RUN \


### PR DESCRIPTION
For the run and default geoportal images to be able to rebuild them daily to get all the security upgrades