### PR TITLE
The prepare tests should be always run to be able to always run the tests...

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,7 @@ jobs:
       # Tests
       - run:
           command: make preparetest
+          when: always
       - run:
           command: docker-compose logs --timestamps
           when: on_fail


### PR DESCRIPTION
See e.-g. https://circleci.com/gh/camptocamp/c2cgeoportal/4366?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link