### PR TITLE
Switch redis to volatile-lru

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/docker-compose-lib.yaml_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/docker-compose-lib.yaml_tmpl
@@ -108,7 +108,7 @@ services:
       - --maxmemory
       - 512mb
       - --maxmemory-policy
-      - allkeys-lru
+      - volatile-lru
       - --tcp-keepalive
       - '30'
 


### PR DESCRIPTION
* Was: allkeys-lru -> Evict any key using approximated LRU.
* Now: volatile-lru -> Evict using approximated LRU among the keys with an expire set.

That supresses the risk of having tilecloud-chain and broadcast queues deleted.

See also: https://github.com/camptocamp/private-geo-charts/pull/26