### PR TITLE
[WIP] Include translations when installing from source

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include *.txt *.ini *.cfg *.rst
-recursive-include c2cgeoportal *.ico *.png *.css *.gif *.jpg *.pt *.txt *.mak *.mako *.js *.html *.xml *.mo
+recursive-include c2cgeoportal *.ico *.png *.css *.gif *.jpg *.pt *.txt *.mak *.mako *.js *.html *.xml *.mo *.po
 recursive-include c2cgeoportal/scaffolds *
 exclude .build
 prune c2cgeoportal/tests


### PR DESCRIPTION
When installing from source, the locale directory is missing. This should be fixed by adding `*.po` files in MANIFEST.in.