### PR TITLE
The character <> are not allowed in a fulltext search request

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/views/fulltextsearch.py
+++ b/geoportal/c2cgeoportal_geoportal/views/fulltextsearch.py
@@ -42,7 +42,7 @@ from c2cgeoportal_geoportal import locale_negotiator
 from c2cgeoportal_geoportal.lib.caching import NO_CACHE, get_region, set_common_headers
 
 CACHE_REGION = get_region("std")
-IGNORED_CHARS_RE = re.compile(r"[()&|!:]")
+IGNORED_CHARS_RE = re.compile(r"[()&|!:<>]")
 
 
 class FullTextSearchView:


### PR DESCRIPTION
Fix: https://sentry.io/organizations/camptocamp/issues/1396111348/