### PR TITLE
without the double star, the formating inject all the environment

### DIFF
--- a/doc/administrator/editing.rst
+++ b/doc/administrator/editing.rst
@@ -57,6 +57,19 @@ a string of the form ``[<schemaname>.]<tablename>``.  If ``schemaname`` is
 omitted, the table is assumed to be in the ``public`` schema.  The label
 corresponding to this field is *Related Postgres table* in the admin interface.
 
+The ``geoTable`` field supports named formatting and can get values from the
+environment variables, for example:
+
+ ``[<schemaname>_{some-named-variable}.]<tablename>``
+
+with "some-named-variable" defined in the environment.
+
+Support for other database sessions has also been implemented:
+
+``[<database-session-name>.[<schemaname>.]]<tablename>``
+
+See :doc:`../integrator/multiple_databases`.
+
 .. warning::
 
     Only layers embedded in a layergroup are detected as editable.

--- a/geoportal/c2cgeoportal_geoportal/views/layers.py
+++ b/geoportal/c2cgeoportal_geoportal/views/layers.py
@@ -499,7 +499,7 @@ def get_layer_class(layer, with_last_update_columns=False):
 
     primary_key = Layers.get_metadata(layer, "geotablePrimaryKey")
     cls = get_class(
-        str(layer.geo_table.format(os.environ)),
+        str(layer.geo_table.format(**os.environ)),
         exclude_properties=exclude,
         primary_key=primary_key,
         attributes_order=attributes_order,


### PR DESCRIPTION
variables as a gigantic string and the code fail wonderfully.

export TOTO=foobar
python

>>> import os
>>> print('{TOTO}'.format(**os.environ))
foobar