### PR TITLE
Remove spell check from CI in scaffold

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/CONST_Makefile_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/CONST_Makefile_tmpl
@@ -357,7 +357,7 @@ docker-build:
 build: $(BUILD_RULES)
 
 .PHONY: checks
-checks: flake8 $(CLIENT_CHECK_RULE) git-attributes yamllint spell printlint
+checks: flake8 $(CLIENT_CHECK_RULE) git-attributes yamllint printlint
 
 .PHONY: git-attributes
 git-attributes:


### PR DESCRIPTION
Spell check by default in CI is really boring.