### PR TITLE
Add tip about unused docker volumes cleaning

### DIFF
--- a/doc/administrator/editing.rst
+++ b/doc/administrator/editing.rst
@@ -106,7 +106,7 @@ Enable snapping
 ---------------
 
 To be able to snap while editing, the ``snappingConfig`` must be set on the layer metadata.
-The value is a ``json`` object containing the following optional properties::
+The value is a ``json`` object containing the following optional properties:
 
 * edge (boolean): whether to allow snapping on edges or not;
 * vertex (boolean): whether to allow snapping on vertices or not;

--- a/doc/integrator/docker.rst
+++ b/doc/integrator/docker.rst
@@ -59,11 +59,22 @@ Otherwise:
    docker images | grep "<none>" | awk '{print $3}' | xargs --no-run-if-empty docker rmi || true
    docker volume ls --quiet --filter dangling=true | grep '[0-9a-f]\{64\}' | xargs --no-run-if-empty docker volume rm
 
-This will remove::
+This will remove:
 
 * Containers with exit status.
 * Images with version on name as `<none>`.
 * Unnamed dangling volumes.
+
+In addition you may run the following script to get rid of unused
+temporary volumes:
+
+.. prompt:: bash
+
+    #!/bin/bash
+    for vol in $(docker volume ls | awk '{print $2}' | grep -v VOLUME)
+    do
+      docker volume rm $vol
+    done
 
 You can also remove the unused named images, that should be done manually:
 


### PR DESCRIPTION
This PR adds instructions to remove "ghost" volumes, as described at https://techan.fr/docker-chasse-a-lespace-perdu-gare-aux-volumes.html > "Les volumes “fantômes”", pointed by @yjacolin 

By the way I have dropped a reference to ExtJS in the documentation opening page :P 

(Doc successfully built on my laptop)