### PR TITLE
Add missing delete cascades

### DIFF
--- a/commons/c2cgeoportal_commons/alembic/main/87f8330ed64e_add_missing_delete_cascades.py
+++ b/commons/c2cgeoportal_commons/alembic/main/87f8330ed64e_add_missing_delete_cascades.py
@@ -1,0 +1,302 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2020, Camptocamp SA
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# The views and conclusions contained in the software and documentation are those
+# of the authors and should not be interpreted as representing official policies,
+# either expressed or implied, of the FreeBSD Project.
+
+"""Add missing delete cascades
+
+Revision ID: 87f8330ed64e
+Revises: 16e43f8c0330
+Create Date: 2020-05-25 14:53:36.289305
+"""
+
+from alembic import op
+from c2c.template.config import config
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "87f8330ed64e"
+down_revision = "16e43f8c0330"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    schema = config["schema"]
+
+    op.drop_constraint(
+        "interface_layer_interface_id_fkey", "interface_layer", schema=schema, type_="foreignkey"
+    )
+    op.create_foreign_key(
+        "interface_layer_interface_id_fkey",
+        "interface_layer",
+        "interface",
+        ["interface_id"],
+        ["id"],
+        source_schema=schema,
+        referent_schema=schema,
+        ondelete="CASCADE",
+    )
+
+    op.drop_constraint(
+        "interface_theme_interface_id_fkey", "interface_theme", schema=schema, type_="foreignkey"
+    )
+    op.drop_constraint("interface_theme_theme_id_fkey", "interface_theme", schema=schema, type_="foreignkey")
+    op.create_foreign_key(
+        "interface_theme_interface_id_fkey",
+        "interface_theme",
+        "interface",
+        ["interface_id"],
+        ["id"],
+        source_schema=schema,
+        referent_schema=schema,
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        "interface_theme_theme_id_fkey",
+        "interface_theme",
+        "theme",
+        ["theme_id"],
+        ["id"],
+        source_schema=schema,
+        referent_schema=schema,
+        ondelete="CASCADE",
+    )
+
+    op.drop_constraint(
+        "layer_restrictionarea_restrictionarea_id_fkey",
+        "layer_restrictionarea",
+        schema=schema,
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        "layer_restrictionarea_layer_id_fkey", "layer_restrictionarea", schema=schema, type_="foreignkey"
+    )
+    op.create_foreign_key(
+        "layer_restrictionarea_layer_id_fkey",
+        "layer_restrictionarea",
+        "layer",
+        ["layer_id"],
+        ["id"],
+        source_schema=schema,
+        referent_schema=schema,
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        "layer_restrictionarea_restrictionarea_id_fkey",
+        "layer_restrictionarea",
+        "restrictionarea",
+        ["restrictionarea_id"],
+        ["id"],
+        source_schema=schema,
+        referent_schema=schema,
+        ondelete="CASCADE",
+    )
+
+    op.drop_constraint(
+        "restricted_role_theme_theme_id_fkey", "restricted_role_theme", schema=schema, type_="foreignkey"
+    )
+    op.drop_constraint(
+        "restricted_role_theme_role_id_fkey", "restricted_role_theme", schema=schema, type_="foreignkey"
+    )
+    op.create_foreign_key(
+        "restricted_role_theme_theme_id_fkey",
+        "restricted_role_theme",
+        "theme",
+        ["theme_id"],
+        ["id"],
+        source_schema=schema,
+        referent_schema=schema,
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        "restricted_role_theme_role_id_fkey",
+        "restricted_role_theme",
+        "role",
+        ["role_id"],
+        ["id"],
+        source_schema=schema,
+        referent_schema=schema,
+        ondelete="CASCADE",
+    )
+
+    op.drop_constraint(
+        "role_restrictionarea_role_id_fkey", "role_restrictionarea", schema=schema, type_="foreignkey"
+    )
+    op.drop_constraint(
+        "role_restrictionarea_restrictionarea_id_fkey",
+        "role_restrictionarea",
+        schema=schema,
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "role_restrictionarea_role_id_fkey",
+        "role_restrictionarea",
+        "role",
+        ["role_id"],
+        ["id"],
+        source_schema=schema,
+        referent_schema=schema,
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        "role_restrictionarea_restrictionarea_id_fkey",
+        "role_restrictionarea",
+        "restrictionarea",
+        ["restrictionarea_id"],
+        ["id"],
+        source_schema=schema,
+        referent_schema=schema,
+        ondelete="CASCADE",
+    )
+
+    op.alter_column("theme", "ordering", existing_type=sa.INTEGER(), nullable=False, schema=schema)
+
+
+def downgrade():
+    schema = config["schema"]
+
+    op.alter_column("theme", "ordering", existing_type=sa.INTEGER(), nullable=True, schema=schema)
+
+    op.drop_constraint(
+        "role_restrictionarea_restrictionarea_id_fkey",
+        "role_restrictionarea",
+        schema=schema,
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        "role_restrictionarea_role_id_fkey", "role_restrictionarea", schema=schema, type_="foreignkey"
+    )
+    op.create_foreign_key(
+        "role_restrictionarea_restrictionarea_id_fkey",
+        "role_restrictionarea",
+        "restrictionarea",
+        ["restrictionarea_id"],
+        ["id"],
+        source_schema=schema,
+        referent_schema=schema,
+    )
+    op.create_foreign_key(
+        "role_restrictionarea_role_id_fkey",
+        "role_restrictionarea",
+        "role",
+        ["role_id"],
+        ["id"],
+        source_schema=schema,
+        referent_schema=schema,
+    )
+
+    op.drop_constraint(
+        "restricted_role_theme_role_id_fkey", "restricted_role_theme", schema=schema, type_="foreignkey"
+    )
+    op.drop_constraint(
+        "restricted_role_theme_theme_id_fkey", "restricted_role_theme", schema=schema, type_="foreignkey"
+    )
+    op.create_foreign_key(
+        "restricted_role_theme_role_id_fkey",
+        "restricted_role_theme",
+        "role",
+        ["role_id"],
+        ["id"],
+        source_schema=schema,
+        referent_schema=schema,
+    )
+    op.create_foreign_key(
+        "restricted_role_theme_theme_id_fkey",
+        "restricted_role_theme",
+        "theme",
+        ["theme_id"],
+        ["id"],
+        source_schema=schema,
+        referent_schema=schema,
+    )
+
+    op.alter_column("ogc_server", "name", existing_type=sa.VARCHAR(), nullable=False, schema=schema)
+
+    op.drop_constraint(
+        "layer_restrictionarea_layer_id_fkey", "layer_restrictionarea", schema=schema, type_="foreignkey"
+    )
+    op.drop_constraint(
+        "layer_restrictionarea_restrictionarea_id_fkey",
+        "layer_restrictionarea",
+        schema=schema,
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "layer_restrictionarea_layer_id_fkey",
+        "layer_restrictionarea",
+        "layer",
+        ["layer_id"],
+        ["id"],
+        source_schema=schema,
+        referent_schema=schema,
+    )
+    op.create_foreign_key(
+        "layer_restrictionarea_restrictionarea_id_fkey",
+        "layer_restrictionarea",
+        "restrictionarea",
+        ["restrictionarea_id"],
+        ["id"],
+        source_schema=schema,
+        referent_schema=schema,
+    )
+
+    op.drop_constraint("interface_theme_theme_id_fkey", "interface_theme", schema=schema, type_="foreignkey")
+    op.drop_constraint(
+        "interface_theme_interface_id_fkey", "interface_theme", schema=schema, type_="foreignkey"
+    )
+    op.create_foreign_key(
+        "interface_theme_theme_id_fkey",
+        "interface_theme",
+        "theme",
+        ["theme_id"],
+        ["id"],
+        source_schema=schema,
+        referent_schema=schema,
+    )
+    op.create_foreign_key(
+        "interface_theme_interface_id_fkey",
+        "interface_theme",
+        "interface",
+        ["interface_id"],
+        ["id"],
+        source_schema=schema,
+        referent_schema=schema,
+    )
+
+    op.drop_constraint(
+        "interface_layer_interface_id_fkey", "interface_layer", schema=schema, type_="foreignkey"
+    )
+    op.create_foreign_key(
+        "interface_layer_interface_id_fkey",
+        "interface_layer",
+        "interface",
+        ["interface_id"],
+        ["id"],
+        source_schema=schema,
+        referent_schema=schema,
+    )

--- a/commons/c2cgeoportal_commons/alembic/static/107b81f5b9fe_add_missing_delete_cascades.py
+++ b/commons/c2cgeoportal_commons/alembic/static/107b81f5b9fe_add_missing_delete_cascades.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# -*- coding: utf-8 -*-
 
 # Copyright (c) 2020, Camptocamp SA
 # All rights reserved.
@@ -28,32 +27,49 @@
 # of the authors and should not be interpreted as representing official policies,
 # either expressed or implied, of the FreeBSD Project.
 
-"""${message}
+"""Add missing delete cascades
 
-Revision ID: ${up_revision}
-Revises: ${down_revision}
-Create Date: ${create_date}
+Revision ID: 107b81f5b9fe
+Revises: bd029dbfc11a
+Create Date: 2020-05-25 15:13:12.194192
 """
 
 from alembic import op
 from c2c.template.config import config
 
 # revision identifiers, used by Alembic.
-revision = ${repr(up_revision)}
-down_revision = ${repr(down_revision)}
-branch_labels = ${repr(branch_labels)}
-depends_on = ${repr(depends_on)}
+revision = "107b81f5b9fe"
+down_revision = "bd029dbfc11a"
+branch_labels = None
+depends_on = None
 
 
 def upgrade():
-    schema = config['schema']
-    staticschema = config['schema_static']
+    staticschema = config["schema_static"]
 
-    ${upgrades if upgrades else '# Instructions'}
+    op.drop_constraint("user_role_user_id_fkey", "user_role", schema=staticschema, type_="foreignkey")
+    op.create_foreign_key(
+        "user_role_user_id_fkey",
+        "user_role",
+        "user",
+        ["user_id"],
+        ["id"],
+        source_schema=staticschema,
+        referent_schema=staticschema,
+        ondelete="CASCADE",
+    )
 
 
 def downgrade():
-    schema = config['schema']
-    staticschema = config['schema_static']
+    staticschema = config["schema_static"]
 
-    ${downgrades if downgrades else '# Instructions'}
+    op.drop_constraint("user_role_user_id_fkey", "user_role", schema=staticschema, type_="foreignkey")
+    op.create_foreign_key(
+        "user_role_user_id_fkey",
+        "user_role",
+        "user",
+        ["user_id"],
+        ["id"],
+        source_schema=staticschema,
+        referent_schema=staticschema,
+    )

--- a/commons/c2cgeoportal_commons/models/main.py
+++ b/commons/c2cgeoportal_commons/models/main.py
@@ -128,8 +128,13 @@ event.listen(Functionality, "after_delete", cache_invalidate_cb)
 role_functionality = Table(
     "role_functionality",
     Base.metadata,
-    Column("role_id", Integer, ForeignKey(_schema + ".role.id"), primary_key=True),
-    Column("functionality_id", Integer, ForeignKey(_schema + ".functionality.id"), primary_key=True),
+    Column("role_id", Integer, ForeignKey(_schema + ".role.id", ondelete="CASCADE"), primary_key=True),
+    Column(
+        "functionality_id",
+        Integer,
+        ForeignKey(_schema + ".functionality.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
     schema=_schema,
 )
 
@@ -137,8 +142,13 @@ role_functionality = Table(
 theme_functionality = Table(
     "theme_functionality",
     Base.metadata,
-    Column("theme_id", Integer, ForeignKey(_schema + ".theme.id"), primary_key=True),
-    Column("functionality_id", Integer, ForeignKey(_schema + ".functionality.id"), primary_key=True),
+    Column("theme_id", Integer, ForeignKey(_schema + ".theme.id", ondelete="CASCADE"), primary_key=True),
+    Column(
+        "functionality_id",
+        Integer,
+        ForeignKey(_schema + ".functionality.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
     schema=_schema,
 )
 
@@ -248,7 +258,10 @@ class LayergroupTreeitem(Base):
     id = Column(Integer, primary_key=True, info={"colanderalchemy": {"widget": HiddenWidget()}})
     description = Column(Unicode, info={"colanderalchemy": {"exclude": True}})
     treegroup_id = Column(
-        Integer, ForeignKey(_schema + ".treegroup.id"), info={"colanderalchemy": {"exclude": True}}
+        Integer,
+        ForeignKey(_schema + ".treegroup.id"),
+        nullable=False,
+        info={"colanderalchemy": {"exclude": True}},
     )
     treegroup = relationship(
         "TreeGroup",
@@ -262,7 +275,10 @@ class LayergroupTreeitem(Base):
         info={"colanderalchemy": {"exclude": True}, "c2cgeoform": {"duplicate": False}},
     )
     treeitem_id = Column(
-        Integer, ForeignKey(_schema + ".treeitem.id"), info={"colanderalchemy": {"widget": HiddenWidget()}}
+        Integer,
+        ForeignKey(_schema + ".treeitem.id"),
+        nullable=False,
+        info={"colanderalchemy": {"widget": HiddenWidget()}},
     )
     treeitem = relationship(
         "TreeItem",
@@ -353,8 +369,8 @@ class LayerGroup(TreeGroup):
 restricted_role_theme = Table(
     "restricted_role_theme",
     Base.metadata,
-    Column("role_id", Integer, ForeignKey(_schema + ".role.id"), primary_key=True),
-    Column("theme_id", Integer, ForeignKey(_schema + ".theme.id"), primary_key=True),
+    Column("role_id", Integer, ForeignKey(_schema + ".role.id", ondelete="CASCADE"), primary_key=True),
+    Column("theme_id", Integer, ForeignKey(_schema + ".theme.id", ondelete="CASCADE"), primary_key=True),
     schema=_schema,
 )
 
@@ -442,7 +458,7 @@ class OGCServer(Base):
     __colanderalchemy_config__ = {"title": _("OGC Server"), "plural": _("OGC Servers")}
     __c2cgeoform_config__ = {"duplicate": True}
     id = Column(Integer, primary_key=True, info={"colanderalchemy": {"widget": HiddenWidget()}})
-    name = Column(Unicode, info={"colanderalchemy": {"title": _("Name")}})
+    name = Column(Unicode, nullable=False, unique=True, info={"colanderalchemy": {"title": _("Name")}})
     description = Column(Unicode, info={"colanderalchemy": {"title": _("Description")}})
     url = Column(Unicode, nullable=False, info={"colanderalchemy": {"title": _("Basic URL")}})
     url_wfs = Column(Unicode, info={"colanderalchemy": {"title": _("WFS URL")}})
@@ -669,8 +685,13 @@ class LayerWMTS(DimensionLayer):
 role_ra = Table(
     "role_restrictionarea",
     Base.metadata,
-    Column("role_id", Integer, ForeignKey(_schema + ".role.id"), primary_key=True),
-    Column("restrictionarea_id", Integer, ForeignKey(_schema + ".restrictionarea.id"), primary_key=True),
+    Column("role_id", Integer, ForeignKey(_schema + ".role.id", ondelete="CASCADE"), primary_key=True),
+    Column(
+        "restrictionarea_id",
+        Integer,
+        ForeignKey(_schema + ".restrictionarea.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
     schema=_schema,
 )
 
@@ -678,8 +699,13 @@ role_ra = Table(
 layer_ra = Table(
     "layer_restrictionarea",
     Base.metadata,
-    Column("layer_id", Integer, ForeignKey(_schema + ".layer.id"), primary_key=True),
-    Column("restrictionarea_id", Integer, ForeignKey(_schema + ".restrictionarea.id"), primary_key=True),
+    Column("layer_id", Integer, ForeignKey(_schema + ".layer.id", ondelete="CASCADE"), primary_key=True),
+    Column(
+        "restrictionarea_id",
+        Integer,
+        ForeignKey(_schema + ".restrictionarea.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
     schema=_schema,
 )
 
@@ -798,8 +824,10 @@ event.listen(RestrictionArea, "after_delete", cache_invalidate_cb)
 interface_layer = Table(
     "interface_layer",
     Base.metadata,
-    Column("interface_id", Integer, ForeignKey(_schema + ".interface.id"), primary_key=True),
-    Column("layer_id", Integer, ForeignKey(_schema + ".layer.id"), primary_key=True),
+    Column(
+        "interface_id", Integer, ForeignKey(_schema + ".interface.id", ondelete="CASCADE"), primary_key=True
+    ),
+    Column("layer_id", Integer, ForeignKey(_schema + ".layer.id", ondelete="CASCADE"), primary_key=True),
     schema=_schema,
 )
 
@@ -807,8 +835,10 @@ interface_layer = Table(
 interface_theme = Table(
     "interface_theme",
     Base.metadata,
-    Column("interface_id", Integer, ForeignKey(_schema + ".interface.id"), primary_key=True),
-    Column("theme_id", Integer, ForeignKey(_schema + ".theme.id"), primary_key=True),
+    Column(
+        "interface_id", Integer, ForeignKey(_schema + ".interface.id", ondelete="CASCADE"), primary_key=True
+    ),
+    Column("theme_id", Integer, ForeignKey(_schema + ".theme.id", ondelete="CASCADE"), primary_key=True),
     schema=_schema,
 )
 

--- a/commons/c2cgeoportal_commons/models/static.py
+++ b/commons/c2cgeoportal_commons/models/static.py
@@ -72,7 +72,7 @@ _schema: str = config["schema_static"] or "static"
 user_role = Table(
     "user_role",
     Base.metadata,
-    Column("user_id", Integer, ForeignKey(_schema + ".user.id"), primary_key=True),
+    Column("user_id", Integer, ForeignKey(_schema + ".user.id", ondelete="CASCADE"), primary_key=True),
     Column("role_id", Integer, primary_key=True),
     schema=_schema,
 )


### PR DESCRIPTION
Add missing delete cascades.
In case of n-n relationship, we can safely cascade deletes to relationships (to avoid having to delete manually all relationships before to delete related entities).

Superseed https://github.com/camptocamp/c2cgeoportal/pull/5778

Note that this PR also fix some other differences between Alembic migrations and SQLAlchemy model like `nullable=False` or `unique=False` (detected by alembic revision --autogenerate).