### PR TITLE
Removes SQLalchemy warning

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/Dockerfile_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/Dockerfile_tmpl
@@ -3,8 +3,8 @@ FROM camptocamp/geomapfish-tools:{{geomapfish_version}} as builder
 ENV LANGUAGES="en fr de"
 ENV VARS_FILE=vars.yaml
 ENV CONFIG_VARS sqlalchemy.url sqlalchemy.pool_recycle sqlalchemy.pool_size sqlalchemy.max_overflow \
-    sqlalchemy.use_batch_mode sqlalchemy_slave.url sqlalchemy_slave.pool_recycle sqlalchemy_slave.pool_size \
-    sqlalchemy_slave.max_overflow sqlalchemy_slave.use_batch_mode schema schema_static enable_admin_interface \
+    sqlalchemy.executemany_mode sqlalchemy_slave.url sqlalchemy_slave.pool_recycle sqlalchemy_slave.pool_size \
+    sqlalchemy_slave.max_overflow sqlalchemy_slave.executemany_mode schema schema_static enable_admin_interface \
     default_locale_name servers layers available_locale_names cache admin_interface getitfixed functionalities \
     raster shortener hide_capabilities tinyowsproxy resourceproxy print_url print_get_redirect \
     checker check_collector default_max_age package srid \

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/qgisserver/geomapfish.yaml.tmpl_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/qgisserver/geomapfish.yaml.tmpl_tmpl
@@ -9,7 +9,7 @@ vars:
     pool_recycle: 30
     pool_size: 5
     max_overflow: 25
-    use_batch_mode: true
+    executemany_mode: batch
 environment:
   - PGUSER
   - PGPASSWORD

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/geoportal/CONST_config-schema.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/geoportal/CONST_config-schema.yaml
@@ -59,8 +59,8 @@ mapping:
         type: int
       sqlalchemy.pool_overflow:
         type: int
-      sqlalchemy.use_batch_mode:
-        type: bool
+      sqlalchemy.executemany_mode:
+        type: str
       sqlalchemy_slave.url:
         type: str
         required: True
@@ -70,8 +70,8 @@ mapping:
         type: int
       sqlalchemy_slave.pool_overflow:
         type: int
-      sqlalchemy_slave.use_batch_mode:
-        type: bool
+      sqlalchemy_slave.executemany_mode:
+        type: str
       default_max_age:
         type: int
         required: True

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/geoportal/CONST_vars.yaml_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/geoportal/CONST_vars.yaml_tmpl
@@ -22,13 +22,13 @@ vars:
     pool_recycle: 30
     pool_size: 5
     max_overflow: 25
-    use_batch_mode: true
+    executemany_mode: batch
   sqlalchemy_slave:
     url: postgresql://{PGUSER}:{PGPASSWORD}@{PGHOST_SLAVE}:{PGPORT_SLAVE}/{PGDATABASE}?sslmode={PGSSLMODE}
     pool_recycle: 30
     pool_size: 5
     max_overflow: 25
-    use_batch_mode: true
+    executemany_mode: batch
 
   # Session backend
   session:


### PR DESCRIPTION
sqlalchemy.exc.SADeprecationWarning: The psycopg2 use_batch_mode flag is superseded by executemany_mode='batch'

Fix GSGMF-1248