### PR TITLE
Add get_settings used by c2cwsgiutils

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/lib/lingua_extractor.py
+++ b/geoportal/c2cgeoportal_geoportal/lib/lingua_extractor.py
@@ -242,6 +242,9 @@ class GeomapfishConfigExtractor(Extractor):  # pragma: no cover
         class C:
             registry = R()
 
+            def get_settings(self):
+                return self.registry.settings
+
         config_ = C()
         config_.registry.settings = settings
         init_dbsessions(settings, config_)


### PR DESCRIPTION
Currently, I get on `update-po`:
```
Traceback (most recent call last):
  File "/usr/local/bin/pot-create", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.6/dist-packages/lingua/extract.py", line 336, in main
    for message in extractor(real_filename, options):
  File "/opt/c2cgeoportal_geoportal/c2cgeoportal_geoportal/lib/lingua_extractor.py", line 218, in __call__
    return self._collect_app_config(filename)
  File "/opt/c2cgeoportal_geoportal/c2cgeoportal_geoportal/lib/lingua_extractor.py", line 247, in _collect_app_config
    init_dbsessions(settings, config_)
  File "/opt/c2cgeoportal_geoportal/c2cgeoportal_geoportal/__init__.py", line 689, in init_dbsessions
    config, 'sqlalchemy', slave_prefix, force_master=master_paths, force_slave=slave_paths)
  File "/opt/c2cwsgiutils/c2cwsgiutils/db.py", line 65, in setup_session
    ro_engine = sqlalchemy.engine_from_config(config.get_settings(), slave_prefix + ".")
AttributeError: 'C' object has no attribute 'get_settings'
```
