### PR TITLE
Invalidate Jenkins docker cache

### DIFF
--- a/Dockerfile.mako
+++ b/Dockerfile.mako
@@ -20,6 +20,8 @@ RUN \
   cd /tmp && \
   webpack --mode production --profile --json > stats.json || webpack --mode production
 
+RUN echo "test"
+
 RUN \
   mkdir --parents /opt/angular-locale && \
   for LANG in en fr de it en-ch fr-ch de-ch it-ch; \


### PR DESCRIPTION
This is just a hack to invalidate docker intermediate cache on Jenkins servers.
This might be reverted at some time.