### PR TITLE
Fix typo in manage-users script doc

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scripts/manage_users.py
+++ b/geoportal/c2cgeoportal_geoportal/scripts/manage_users.py
@@ -39,12 +39,12 @@ def main():
     """
     Emergency user create and password reset script
     example, reset toto password to foobar:
-    ./docker-compose-run manage_users --password=foobar toto
+    ./docker-compose-run manage-users --password=foobar toto
     example, create user foo with password bar and role admin:
-    ./docker-compose-run manage_users --create --rolename=role_admin --password=bar foo
+    ./docker-compose-run manage-users --create --rolename=role_admin --password=bar foo
 
     to get the options list, do:
-    ./docker-compose-run manage_users --help
+    ./docker-compose-run manage-users --help
     """
 
     usage = """Usage: %prog [options] USERNAME


### PR DESCRIPTION
Replace entrypoint ``manage-users`` by ``manage_users`` as the filename is actually ``manage_users.py`` and as it is the spelling actually used in the doc examples, see https://github.com/camptocamp/c2cgeoportal/blob/2.4/geoportal/c2cgeoportal_geoportal/scripts/manage_users.py#L42-L47