### PR TITLE
Initialize OGCProxy like it is done for TinyOWSProxy

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/views/pdfreport.py
+++ b/geoportal/c2cgeoportal_geoportal/views/pdfreport.py
@@ -48,7 +48,7 @@ class PdfReport(OGCProxy):  # pragma: no cover
     layername = None
 
     def __init__(self, request):
-        OGCProxy.__init__(self, request)
+        OGCProxy.__init__(self, request, has_default_ogc_server=True)
         self.config = self.request.registry.settings.get("pdfreport", {})
 
     def _do_print(self, spec):


### PR DESCRIPTION
I think in pdfreport the OGCProxy should be initialized the same way as here https://github.com/camptocamp/c2cgeoportal/blob/f2b2c66f2352dd95438089d4d0cfb619c4f070f8/geoportal/c2cgeoportal_geoportal/views/tinyowsproxy.py#L52, otherwise the initialisation will always fail.