### PR TITLE
Fix: update-po doesn't use PGSCHEMA defined in .env file

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/docker-compose-lib.yaml_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/docker-compose-lib.yaml_tmpl
@@ -174,7 +174,7 @@ services:
     image: ${DOCKER_BASE}-geoportal:${DOCKER_TAG}
     user: www-data
     restart: unless-stopped
-    environment: &env
+    environment:
       - DEVELOPMENT
       - VISIBLE_ENTRY_POINT
       - PACKAGE={{package}}
@@ -239,7 +239,69 @@ services:
   tools:
     image: camptocamp/geomapfish-tools:{{geomapfish_version}}
     restart: unless-stopped
-    environment: *env
+    environment:
+      - PGSCHEMA
+      # From geoportal
+      - DEVELOPMENT
+      - VISIBLE_ENTRY_POINT
+      - PACKAGE={{package}}
+      - PGHOST
+      - PGHOST_SLAVE
+      - PGPORT
+      - PGPORT_SLAVE
+      - PGUSER
+      - PGPASSWORD
+      - PGDATABASE
+      - PGSSLMODE
+      - PGSCHEMA_STATIC
+      - PGOPTIONS
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_DEFAULT_REGION
+      - AWS_S3_ENDPOINT
+      - GUNICORN_PARAMS
+      - VISIBLE_WEB_HOST
+      - VISIBLE_WEB_PROTOCOL
+      - AUTHTKT_TIMEOUT
+      - AUTHTKT_REISSUE_TIME
+      - AUTHTKT_MAXAGE
+      - AUTHTKT_SECRET
+      - AUTHTKT_COOKIENAME
+      - AUTHTKT_HTTP_ONLY
+      - AUTHTKT_SECURE
+      - AUTHTKT_SAMESITE
+      - BASICAUTH
+      - TINYOWS_URL
+      - MAPSERVER_URL
+      - QGISSERVER_URL
+      - PRINT_URL
+      - DEVSERVER_HOST
+      - REDIS_HOST
+      - REDIS_PORT
+      - REDIS_DB
+      - REDIS_SERVICENAME
+      - REDIS_TIMEOUT
+      - C2C_BASE_PATH
+      - C2C_REDIS_URL
+      - C2C_REDIS_SENTINELS
+      - C2C_REDIS_TIMEOUT
+      - C2C_REDIS_SERVICENAME
+      - C2C_REDIS_DB
+      - C2C_BROADCAST_PREFIX
+      - C2C_REQUESTS_DEFAULT_TIMEOUT
+      - C2C_LOG_VIEW_ENABLED=TRUE
+      - C2C_SQL_PROFILER_ENABLED=TRUE
+      - C2C_PROFILER_PATH
+      - C2C_PROFILER_MODULES
+      - C2C_DEBUG_VIEW_ENABLED=TRUE
+      - C2C_SECRET
+      - LOG_LEVEL
+      - C2CGEOPORTAL_LOG_LEVEL
+      - SQL_LOG_LEVEL
+      - GUNICORN_LOG_LEVEL
+      - OTHER_LOG_LEVEL
+      - DOGPILECACHE_LOG_LEVEL
+      - LOG_TYPE
 
   alembic:
     image: ${DOCKER_BASE}-geoportal:${DOCKER_TAG}


### PR DESCRIPTION
Fix GSGMF-1395

The PGSCHEMA should come from the Docker image for the geoportal service and from the .env for the tools service...