### PR TITLE
Fix build command in documentation

### DIFF
--- a/doc/developer/server_side.rst.tmpl
+++ b/doc/developer/server_side.rst.tmpl
@@ -15,7 +15,7 @@ Build the new containers:
 
     git clone git@github.com:camptocamp/c2cgeoportal.git
     cd c2cgeoportal
-    make docker-build
+    make build
 
 Now, the new containers are ready to use in the application on the same host.
 


### PR DESCRIPTION
`make docker-build ` still correct in 2.4. Is now `make build`