### PR TITLE
format require a list of named attribute, not a dict

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/views/layers.py
+++ b/geoportal/c2cgeoportal_geoportal/views/layers.py
@@ -511,7 +511,7 @@ def get_layer_class(layer, with_last_update_columns=False):
 
     primary_key = Layers.get_metadata(layer, "geotablePrimaryKey")
     cls = get_class(
-        str(layer.geo_table.format(os.environ)),
+        str(layer.geo_table.format(**os.environ)),
         exclude_properties=exclude,
         primary_key=primary_key,
         attributes_order=attributes_order,


### PR DESCRIPTION
os.environ is a dict, but format doesnt work with dict, it needs named attributes

this solve error like:

```
  File "/opt/c2cgeoportal/geoportal/c2cgeoportal_geoportal/views/layers.py", line 514, in get_layer_class
    str(layer.geo_table.format(os.environ)),
KeyError: 'PGSCHEMA_GEODATA_EDIT'
```