### PR TITLE
Add PGSCHEMA env variable for qgisserver

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/docker-compose-lib.yaml_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/docker-compose-lib.yaml_tmpl
@@ -68,6 +68,7 @@ services:
       - PGPASSWORD
       - PGDATABASE
       - PGSSLMODE
+      - PGSCHEMA
       - PGSCHEMA_STATIC
       - C2C_REDIS_URL
       - C2C_REDIS_SENTINELS


### PR DESCRIPTION
The accesscontrol plugin needs to have the PGSCHEMA env variable at runtime.