### PR TITLE
Use DateTimeFormatter in print templates

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/print/print-apps/+package+/A3_Landscape.jrxml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/print/print-apps/+package+/A3_Landscape.jrxml
@@ -10,6 +10,7 @@
 	<parameter name="numberOfLegendRows" class="java.lang.Integer"/>
 	<parameter name="scalebarSubReport" class="java.lang.String"/>
 	<parameter name="northArrowSubReport" class="java.lang.String"/>
+	<parameter name="timezone" class="java.lang.String"/>
 	<parameter name="jrDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
 	<parameter name="mapContext" class="org.mapfish.print.attribute.map.MapfishMapContext"/>
 	<pageHeader>
@@ -36,7 +37,14 @@
 				<textElement textAlignment="Right">
 					<font size="8"/>
 				</textElement>
-				<textFieldExpression><![CDATA["Le " + new SimpleDateFormat("EEEEE dd MMMMM yyyy", new Locale("fr")).format(new Date())]]></textFieldExpression>
+				<textFieldExpression><![CDATA[
+					"Le " + java.time.ZonedDateTime.now().format(
+						java.time.format.DateTimeFormatter.
+						ofPattern("EEEE dd MMMM yyyy HH:mm").
+						withLocale($P{REPORT_LOCALE}).
+						withZone(java.time.ZoneId.of($P{timezone}))
+					)
+				]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement x="180" y="2" width="365" height="20" uuid="953c0d72-060f-4ed9-9b6b-9e26da551dbe">

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/print/print-apps/+package+/A3_Portrait.jrxml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/print/print-apps/+package+/A3_Portrait.jrxml
@@ -10,6 +10,7 @@
 	<parameter name="numberOfLegendRows" class="java.lang.Integer"/>
 	<parameter name="scalebarSubReport" class="java.lang.String"/>
 	<parameter name="northArrowSubReport" class="java.lang.String"/>
+	<parameter name="timezone" class="java.lang.String"/>
 	<parameter name="jrDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
 	<pageHeader>
 		<band height="28">
@@ -38,7 +39,14 @@
 				<textElement textAlignment="Right">
 					<font size="8"/>
 				</textElement>
-				<textFieldExpression><![CDATA["Le " + new SimpleDateFormat("EEEEE dd MMMMM yyyy", new Locale("fr")).format(new Date())]]></textFieldExpression>
+				<textFieldExpression><![CDATA[
+					"Le " + java.time.ZonedDateTime.now().format(
+						java.time.format.DateTimeFormatter.
+						ofPattern("EEEE dd MMMM yyyy HH:mm").
+						withLocale($P{REPORT_LOCALE}).
+						withZone(java.time.ZoneId.of($P{timezone}))
+					)
+				]]></textFieldExpression>
 			</textField>
 			<line>
 				<reportElement x="0" y="25" width="800" height="1" forecolor="#FA7500" uuid="ce77e4cd-7737-4406-bb3e-8186f123125e">

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/print/print-apps/+package+/A4_Landscape.jrxml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/print/print-apps/+package+/A4_Landscape.jrxml
@@ -12,6 +12,7 @@
 	<parameter name="numberOfLegendRows" class="java.lang.Integer"/>
 	<parameter name="scalebarSubReport" class="java.lang.String"/>
 	<parameter name="northArrowSubReport" class="java.lang.String"/>
+	<parameter name="timezone" class="java.lang.String"/>
 	<parameter name="jrDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
 	<pageHeader>
 		<band height="28">
@@ -36,7 +37,14 @@
 				<textElement textAlignment="Right">
 					<font size="8"/>
 				</textElement>
-				<textFieldExpression><![CDATA["Le " + new SimpleDateFormat("EEEEE dd MMMMM yyyy", new Locale("fr")).format(new Date())]]></textFieldExpression>
+				<textFieldExpression><![CDATA[
+					"Le " + java.time.ZonedDateTime.now().format(
+						java.time.format.DateTimeFormatter.
+						ofPattern("EEEE dd MMMM yyyy HH:mm").
+						withLocale($P{REPORT_LOCALE}).
+						withZone(java.time.ZoneId.of($P{timezone}))
+					)
+				]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement x="180" y="2" width="365" height="20" uuid="953c0d72-060f-4ed9-9b6b-9e26da551dbe">

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/print/print-apps/+package+/A4_Portrait.jrxml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/print/print-apps/+package+/A4_Portrait.jrxml
@@ -9,6 +9,7 @@
 	<parameter name="numberOfLegendRows" class="java.lang.Integer"/>
 	<parameter name="scalebarSubReport" class="java.lang.String"/>
 	<parameter name="northArrowSubReport" class="java.lang.String"/>
+	<parameter name="timezone" class="java.lang.String"/>
 	<parameter name="jrDataSource" class="net.sf.jasperreports.engine.JRDataSource"/>
 	<pageHeader>
 		<band height="28">
@@ -37,7 +38,14 @@
 				<textElement textAlignment="Right">
 					<font size="8"/>
 				</textElement>
-				<textFieldExpression><![CDATA["Le " + new SimpleDateFormat("EEEEE dd MMMMM yyyy", new Locale("fr")).format(new Date())]]></textFieldExpression>
+				<textFieldExpression><![CDATA[
+					"Le " + java.time.ZonedDateTime.now().format(
+						java.time.format.DateTimeFormatter.
+						ofPattern("EEEE dd MMMM yyyy HH:mm").
+						withLocale($P{REPORT_LOCALE}).
+						withZone(java.time.ZoneId.of($P{timezone}))
+					)
+				]]></textFieldExpression>
 			</textField>
 			<line>
 				<reportElement x="0" y="25" width="555" height="1" forecolor="#FA7500"/>

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/print/print-apps/+package+/config.yaml.tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/print/print-apps/+package+/config.yaml.tmpl
@@ -46,7 +46,7 @@ templates:
           fontSize: 8
       timezone:
         !string &timezone
-        default: CET
+        default: "Europe/Zurich"
       datasource:
         !datasource &datasource
         attributes:


### PR DESCRIPTION
DateTimeFormatter is more flexible than SimpleDateFormat for print templates
as we can chain setting pattern, timezone and locale in a textFieldExpression.