### PR TITLE
Gunicorn: adapt tmpdir setting for Docker environment

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/+dot+env.mako_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/+dot+env.mako_tmpl
@@ -35,7 +35,7 @@ REDIS_PORT=6379
 REDIS_DB=0
 TILEGENERATION_SQS_QUEUE=<queue_name>
 TILEGENERATION_S3_BUCKET=<bucket_name>
-GUNICORN_PARAMS=--bind=:8080 --worker-class=gthread --threads=10 --workers=5 --timeout=60 --max-requests=1000 --max-requests-jitter=100
+GUNICORN_PARAMS=--bind=:8080 --worker-class=gthread --threads=10 --workers=5 --timeout=60 --max-requests=1000 --max-requests-jitter=100 --worker-tmp-dir=/dev/shm
 # Use the mutualised print, ask Camptocamp to configure your project.
 PRINT_URL=https://mutualized-print.apps.openshift-ch-1.camptocamp.com/print/${mutualized_print_app}/
 DEVSERVER_HOST=webpack_dev_server:8080


### PR DESCRIPTION
Adapt Gunicorn tmpdir setting for Docker environment, to avoid locks (see https://pythonspeed.com/articles/gunicorn-in-docker/ )

