### PR TITLE
Push the right image

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -160,17 +160,19 @@ jobs:
       - name: Get versions
         id: version
         run: scripts/get-version --github
+
+      - name: Publish
+        run: c2cciutils-publish --group=full
+        if: >
+          github.ref != format('refs/heads/{0}', env.MAIN_BRANCH)
+          && github.repository == 'camptocamp/c2cgeoportal'
+
       - run: ci/create-new-project ${HOME}/workspace geomapfish
       - run: (cd ${HOME}/workspace/geomapfish/; ./build)
 
       - name: Publish
         run: c2cciutils-publish
         if: github.repository == 'camptocamp/c2cgeoportal'
-      - name: Publish
-        run: c2cciutils-publish --group=full
-        if: >
-          github.ref != format('refs/heads/{0}', env.MAIN_BRANCH)
-          && github.repository == 'camptocamp/c2cgeoportal'
       - name: Publish
         run: c2cciutils-publish --group=full --type=version_branch --version=${{ steps.version.outputs.full }}
         if: >


### PR DESCRIPTION
It's not so good, but the c2cgeoportal build creates an image named `camptocamp/geomapfish-config` and the `create-new-project` with his build creates an image with the same name...