### PR TITLE
Fix session for QGIS

### DIFF
--- a/.github/workflows/qgis.yaml
+++ b/.github/workflows/qgis.yaml
@@ -28,6 +28,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - uses: camptocamp/initialise-gopass-summon-action@v2
         with:

--- a/docker/qgisserver/.pylintrc
+++ b/docker/qgisserver/.pylintrc
@@ -9,7 +9,8 @@ disable=import-error,
     locally-disabled,
     bad-continuation,
     too-many-instance-attributes,
-    line-too-long
+    line-too-long,
+    wrong-import-order
 
 
 [FORMAT]

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/__init__.py
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2011-2020, Camptocamp SA
+# Copyright (c) 2011-2021, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
fix GSGMF-1326 - https://sentry.io/organizations/camptocamp/issues/1384751595/?project=1851011&query=is%3Aunresolved
Related exception:
```
10:15:10 CRITICAL geomapfish_qgisserver.accesscontrol[92]: ERROR Cannot run layerPermissions
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py", line 1248, in _execute_context
    cursor, statement, parameters, context
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/default.py", line 590, in do_execute
    cursor.execute(statement, parameters)
psycopg2.errors.IdleInTransactionSessionTimeout: terminating connection due to idle-in-transaction timeout
SSL connection has been closed unexpectedly


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/var/www/plugins/geomapfish_qgisserver/accesscontrol.py", line 490, in layerPermissions
    roles = self.get_roles()
  File "/var/www/plugins/geomapfish_qgisserver/accesscontrol.py", line 315, in get_roles
    roles = self.DBSession.query(Role).filter(Role.id.in_(parameters.get("ROLE_IDS").split(","))).all()
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/orm/query.py", line 3246, in all
    return list(self)
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/orm/query.py", line 3405, in __iter__
    return self._execute_and_instances(context)
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/orm/query.py", line 3430, in _execute_and_instances
    result = conn.execute(querycontext.statement, self._params)
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py", line 984, in execute
    return meth(self, multiparams, params)
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/sql/elements.py", line 293, in _execute_on_connection
    return connection._execute_clauseelement(self, multiparams, params)
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py", line 1103, in _execute_clauseelement
    distilled_params,
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py", line 1288, in _execute_context
    e, statement, parameters, cursor, context
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py", line 1482, in _handle_dbapi_exception
    sqlalchemy_exception, with_traceback=exc_info[2], from_=e
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/util/compat.py", line 178, in raise_
    raise exception
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py", line 1248, in _execute_context
    cursor, statement, parameters, context
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/default.py", line 590, in do_execute
    cursor.execute(statement, parameters)
sqlalchemy.exc.InternalError: (psycopg2.errors.IdleInTransactionSessionTimeout) terminating connection due to idle-in-transaction timeout
SSL connection has been closed unexpectedly

[SQL: SELECT main_2_6.role.id AS main_2_6_role_id, main_2_6.role.name AS main_2_6_role_name, main_2_6.role.description AS main_2_6_role_description, ST_AsEWKB(main_2_6.role.extent) AS main_2_6_role_extent 
FROM main_2_6.role 
WHERE main_2_6.role.id IN (%(id_1)s, %(id_2)s, %(id_3)s, %(id_4)s, %(id_5)s)]
[parameters: {'id_1': '17', 'id_2': '19', 'id_3': '18', 'id_4': '1', 'id_5': '16'}]
(Background on this error at: http://sqlalche.me/e/2j85)
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py", line 1248, in _execute_context
    cursor, statement, parameters, context
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/default.py", line 590, in do_execute
    cursor.execute(statement, parameters)
psycopg2.errors.IdleInTransactionSessionTimeout: terminating connection due to idle-in-transaction timeout
SSL connection has been closed unexpectedly


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/var/www/plugins/geomapfish_qgisserver/accesscontrol.py", line 164, in layerPermissions
    return self.get_ogcserver_accesscontrol().layerPermissions(layer)
  File "/var/www/plugins/geomapfish_qgisserver/accesscontrol.py", line 490, in layerPermissions
    roles = self.get_roles()
  File "/var/www/plugins/geomapfish_qgisserver/accesscontrol.py", line 315, in get_roles
    roles = self.DBSession.query(Role).filter(Role.id.in_(parameters.get("ROLE_IDS").split(","))).all()
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/orm/query.py", line 3246, in all
    return list(self)
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/orm/query.py", line 3405, in __iter__
    return self._execute_and_instances(context)
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/orm/query.py", line 3430, in _execute_and_instances
    result = conn.execute(querycontext.statement, self._params)
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py", line 984, in execute
    return meth(self, multiparams, params)
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/sql/elements.py", line 293, in _execute_on_connection
    return connection._execute_clauseelement(self, multiparams, params)
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py", line 1103, in _execute_clauseelement
    distilled_params,
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py", line 1288, in _execute_context
    e, statement, parameters, cursor, context
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py", line 1482, in _handle_dbapi_exception
    sqlalchemy_exception, with_traceback=exc_info[2], from_=e
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/util/compat.py", line 178, in raise_
    raise exception
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py", line 1248, in _execute_context
    cursor, statement, parameters, context
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/default.py", line 590, in do_execute
    cursor.execute(statement, parameters)
sqlalchemy.exc.InternalError: (psycopg2.errors.IdleInTransactionSessionTimeout) terminating connection due to idle-in-transaction timeout
SSL connection has been closed unexpectedly

[SQL: SELECT main_2_6.role.id AS main_2_6_role_id, main_2_6.role.name AS main_2_6_role_name, main_2_6.role.description AS main_2_6_role_description, ST_AsEWKB(main_2_6.role.extent) AS main_2_6_role_extent 
FROM main_2_6.role 
WHERE main_2_6.role.id IN (%(id_1)s, %(id_2)s, %(id_3)s, %(id_4)s, %(id_5)s)]
[parameters: {'id_1': '17', 'id_2': '19', 'id_3': '18', 'id_4': '1', 'id_5': '16'}]
(Background on this error at: http://sqlalche.me/e/2j85)
```

@arnaud-morvan do you think that a good way to do?
