### PR TITLE
Fix editingEnumerations

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/lib/dbreflection.py
+++ b/geoportal/c2cgeoportal_geoportal/lib/dbreflection.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2011-2020, Camptocamp SA
+# Copyright (c) 2011-2021, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without
@@ -222,10 +222,10 @@ def _add_association_proxy(cls, col):
     if cls.__enumerations_config__ and col.name in cls.__enumerations_config__:
         enumeration_config = cls.__enumerations_config__[col.name]
         if "value" in enumeration_config:
-            value_attr = getattr(child_cls, enumeration_config["value"])
+            value_attr = enumeration_config["value"]
             order_by = value_attr
         if "order_by" in enumeration_config:
-            order_by = getattr(child_cls, enumeration_config["order_by"])
+            order_by = enumeration_config["order_by"]
 
     setattr(cls, proxy, _AssociationProxy(rel, value_attr, nullable=nullable, order_by=order_by))
 

--- a/geoportal/c2cgeoportal_geoportal/lib/xsd.py
+++ b/geoportal/c2cgeoportal_geoportal/lib/xsd.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2018-2020, Camptocamp SA
+# Copyright (c) 2018-2021, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without
@@ -82,7 +82,7 @@ class XSDGenerator(PapyrusXSDGenerator):
         target_cls = relationship_property.argument
         query = DBSession.query(getattr(target_cls, association_proxy.value_attr))
         if association_proxy.order_by is not None:
-            query = query.order_by(association_proxy.order_by)
+            query = query.order_by(getattr(target_cls, association_proxy.order_by))
         attrs = {}
         if association_proxy.nullable:
             attrs["minOccurs"] = "0"

--- a/geoportal/tests/functional/test_dbreflection.py
+++ b/geoportal/tests/functional/test_dbreflection.py
@@ -236,16 +236,16 @@ class TestReflection(TestCase):
 
         self.assertEqual(enumerations_config, cls.__enumerations_config__)
         association_proxy = getattr(cls, cls.child1_id.info["association_proxy"])
-        self.assertEqual("id", association_proxy.value_attr.key)
-        self.assertEqual("name", association_proxy.order_by.key)
+        self.assertEqual("id", association_proxy.value_attr)
+        self.assertEqual("name", association_proxy.order_by)
 
         # Without order_by.
         enumerations_config = {"child1_id": {"value": "id"}}
         cls = get_class("table_d", enumerations_config=enumerations_config)
 
         association_proxy = getattr(cls, cls.child1_id.info["association_proxy"])
-        self.assertEqual("id", association_proxy.value_attr.key)
-        self.assertEqual("id", association_proxy.order_by.key)
+        self.assertEqual("id", association_proxy.value_attr)
+        self.assertEqual("id", association_proxy.order_by)
 
     def test_get_class_readonly_attributes(self):
         from c2cgeoportal_geoportal.lib.dbreflection import get_class

--- a/geoportal/tests/functional/test_xsd.py
+++ b/geoportal/tests/functional/test_xsd.py
@@ -188,9 +188,7 @@ class TestXSDGenerator(TestCase):
             tostring(e).decode("utf-8"),
         )
 
-        # Test child 2 with an order by.
-        mapper = class_mapper(self.cls)
-
+        # Test child2 enumeration is ordered by Child.custom_order
         tb = TreeBuilder()
         gen.add_association_proxy_xsd(tb, mapper.attrs["child2_id"])
         e = tb.close()


### PR DESCRIPTION
_AssociationProxy.value_attr need to be a str not a InstrumentedAttribute.
See getattr(target, self.value_attr) in _AssociationProxy.__get__ and _AssociationProxy.__set__.
Note it is the same in sqlalchemy.ext.associationproxy.AssociationProxy.

For consistency, do the same for _AssociationProxy.order_by (not InstrumentedAttribute but str).