### PR TITLE
Indent print legend per groups

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/print/print-apps/+package+/legend.jrxml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/print/print-apps/+package+/legend.jrxml
@@ -5,18 +5,100 @@
 	<field name="icon" class="java.awt.Image"/>
 	<field name="level" class="java.lang.Integer"/>
 	<detail>
-		<band height="1" splitType="Stretch">
-			<printWhenExpression><![CDATA[!$F{name}.equals("")]]></printWhenExpression>
+		<!-- Always the same content except the x value (indent) per level and bold, for first level
+		     text. Level 0 empty and ignored-->
+		<!--Level 1-->
+		<band height="15" splitType="Stretch">
+			<printWhenExpression><![CDATA[!$F{name}.equals("") && $F{level} <= 1]]></printWhenExpression>
 			<textField textAdjust="StretchHeight">
-				<reportElement x="0" y="0" width="185" height="1"/>
+				<reportElement x="0" y="0" width="185" height="15"/>
+				<box topPadding="10"/>
+				<textElement>
+					<font isBold="true"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{name}]]></textFieldExpression>
+			</textField>
+		</band>
+		<band height="15" splitType="Stretch">
+			<printWhenExpression><![CDATA[!$F{report}.equals("") && $F{level} <= 1]]></printWhenExpression>
+			<subreport>
+				<reportElement x="0" y="0" width="185" height="15" uuid="fa145068-76a5-4834-98ed-ce65b1976b3d">
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<subreportExpression><![CDATA[$F{report}]]></subreportExpression>
+			</subreport>
+		</band>
+		<!--Level 2-->
+		<band height="15" splitType="Stretch">
+			<printWhenExpression><![CDATA[!$F{name}.equals("") && $F{level} == 2]]></printWhenExpression>
+			<textField textAdjust="StretchHeight">
+				<reportElement x="10" y="0" width="185" height="15"/>
 				<box topPadding="10"/>
 				<textFieldExpression><![CDATA[$F{name}]]></textFieldExpression>
 			</textField>
 		</band>
-		<band height="14" splitType="Stretch">
-			<printWhenExpression><![CDATA[!$F{report}.equals("")]]></printWhenExpression>
+		<band height="15" splitType="Stretch">
+			<printWhenExpression><![CDATA[!$F{report}.equals("") && $F{level} == 2]]></printWhenExpression>
 			<subreport>
-				<reportElement x="0" y="0" width="185" height="10" uuid="fa145068-76a5-4834-98ed-ce65b1976b3d">
+				<reportElement x="10" y="0" width="185" height="15" uuid="fa145068-76a5-4834-98ed-ce65b1976b3d">
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<subreportExpression><![CDATA[$F{report}]]></subreportExpression>
+			</subreport>
+		</band>
+		<!--Level 3-->
+		<band height="15" splitType="Stretch">
+			<printWhenExpression><![CDATA[!$F{name}.equals("") && $F{level} == 3]]></printWhenExpression>
+			<textField textAdjust="StretchHeight">
+				<reportElement x="20" y="0" width="185" height="15"/>
+				<box topPadding="10"/>
+				<textFieldExpression><![CDATA[$F{name}]]></textFieldExpression>
+			</textField>
+		</band>
+		<band height="15" splitType="Stretch">
+			<printWhenExpression><![CDATA[!$F{report}.equals("") && $F{level} == 3]]></printWhenExpression>
+			<subreport>
+				<reportElement x="20" y="0" width="185" height="15" uuid="fa145068-76a5-4834-98ed-ce65b1976b3d">
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<subreportExpression><![CDATA[$F{report}]]></subreportExpression>
+			</subreport>
+		</band>
+		<!--Level 4-->
+		<band height="15" splitType="Stretch">
+			<printWhenExpression><![CDATA[!$F{name}.equals("") && $F{level} == 4]]></printWhenExpression>
+			<textField textAdjust="StretchHeight">
+				<reportElement x="30" y="0" width="185" height="15"/>
+				<box topPadding="10"/>
+				<textFieldExpression><![CDATA[$F{name}]]></textFieldExpression>
+			</textField>
+		</band>
+		<band height="15" splitType="Stretch">
+			<printWhenExpression><![CDATA[!$F{report}.equals("") && $F{level} == 4]]></printWhenExpression>
+			<subreport>
+				<reportElement x="30" y="0" width="185" height="15" uuid="fa145068-76a5-4834-98ed-ce65b1976b3d">
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<subreportExpression><![CDATA[$F{report}]]></subreportExpression>
+			</subreport>
+		</band>
+		<!--Level 5-->
+		<band height="15" splitType="Stretch">
+			<printWhenExpression><![CDATA[!$F{name}.equals("") && $F{level} >= 5]]></printWhenExpression>
+			<textField textAdjust="StretchHeight">
+				<reportElement x="40" y="0" width="185" height="15"/>
+				<box topPadding="10"/>
+				<textFieldExpression><![CDATA[$F{name}]]></textFieldExpression>
+			</textField>
+		</band>
+		<band height="15" splitType="Stretch">
+			<printWhenExpression><![CDATA[!$F{report}.equals("") && $F{level} >= 5]]></printWhenExpression>
+			<subreport>
+				<reportElement x="40" y="0" width="185" height="15" uuid="fa145068-76a5-4834-98ed-ce65b1976b3d">
 					<property name="local_mesure_unitheight" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 				</reportElement>

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -56,6 +56,11 @@ Changes to apply
    There is some new documentation about the constants in ngeo
    https://camptocamp.github.io/ngeo/{{geomapfish_main_version}}/apidoc/index.html.
 
+2. If you use the most recent version of the `legend.jrxml` print template, you will obtain a legend with
+   elements indented hierarchically per groups level. If you want to keep to previous legend style, keep your
+   previous `legend.jrxml` template and add a new variable `gmfPrintOptions.legend.showGroupsTitle` in the
+   `interfaces_config` constants of the vars file and set it to false.
+
 
 Version 2.5.0
 =============


### PR DESCRIPTION
For GSGMF-1367
Ngeo part for hierarchical groups: https://github.com/camptocamp/ngeo/pull/6692
Ngeo part to keep current flat legend: https://github.com/camptocamp/ngeo/pull/6725/files 

@jwkaltz can you review the Changelog please ?

I've added a [level-1 * 10px] indentation for level 2-5. Then more levels will have the same indentation as the 5th.
I've not found any better solution for indentation than these `if levels == x` and repeated statements. We can't have variable in attributes, nor loops in xml, nor spaces before element (as we use sub-report for images).

Also, we don't have a lot of possibilities for the design as we can't know if we have only a title or a title and a image for a specific level. (The print generate two different reports for title and image, and in a jrxml we are not aware if the other element exist.)

Current look (c2cgeoportal legend.jrxml copied in the legend example of mapfishprint):
(Bad luck, we are on the end of the main page, it results to a **multi-column legend**.)
![paddingx](https://user-images.githubusercontent.com/1792111/105684031-ae0c3980-5ef4-11eb-8601-c2140086a246.png)

