### PR TITLE
Use WMS version from OGC server URL to GetCapabilities 

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/lib/__init__.py
+++ b/geoportal/c2cgeoportal_geoportal/lib/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2011-2020, Camptocamp SA
+# Copyright (c) 2011-2021, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without
@@ -182,7 +182,8 @@ def add_url_params(url: str, params: Optional[Dict[str, str]]) -> str:
 def add_spliturl_params(spliturl, params):
     query = {k: v[-1] for k, v in list(urllib.parse.parse_qs(spliturl.query).items())}
     for key, value in list(params.items()):
-        query[key] = value
+        if key not in query:
+            query[key] = value
 
     return urllib.parse.urlunsplit(
         (spliturl.scheme, spliturl.netloc, spliturl.path, urllib.parse.urlencode(query), spliturl.fragment)

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -16,6 +16,9 @@ Information
 
 3. Layers which have any errors are not added to the theme anymore.
 
+4. If a WMS version is given in an OGC server URL, it will be used for the GetCapabilities request
+   Supported versions: 1.1.1 and 1.3.0
+
 Changes to apply
 ----------------
 

--- a/geoportal/c2cgeoportal_geoportal/views/theme.py
+++ b/geoportal/c2cgeoportal_geoportal/views/theme.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2011-2020, Camptocamp SA
+# Copyright (c) 2011-2021, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without
@@ -189,9 +189,10 @@ class Theme:
         def build_web_map_service(ogc_server_id):
             del ogc_server_id  # Just for cache
 
+            version = urllib.parse.parse_qs(urllib.parse.urlsplit(url).query)['VERSION'][0]
             layers = {}
             try:
-                wms = WebMapService(None, xml=content)
+                wms = WebMapService(None, xml=content, version=version)
             except Exception as e:  # pragma: no cover
                 error = (
                     "WARNING! an error '{}' occurred while trying to read the mapfile and recover the themes."

--- a/geoportal/tests/functional/test_themes_mixed.py
+++ b/geoportal/tests/functional/test_themes_mixed.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2016-2019, Camptocamp SA
+# Copyright (c) 2016-2021, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without
@@ -63,6 +63,18 @@ class TestThemesView(TestCase):
         ogc_server_external = OGCServer(
             name="__test_ogc_server_external", url="http://wms.geo.admin.ch/", image_type="image/jpeg"
         )
+        ogc_server_valid_wms_version = OGCServer(
+            name="__test_ogc_server_valid_wms_version",
+            url=mapserv_url + "?VERSION=1.3.0",
+            image_type="image/jpeg",
+            wfs_support = False,
+        )
+        ogc_server_invalid_wms_version = OGCServer(
+            name="__test_ogc_server_invalid_wms_version",
+            url=mapserv_url + "?VERSION=1.0.0",
+            image_type="image/jpeg",
+            wfs_support = False,
+        )
 
         layer_internal_wms = LayerWMS(name="__test_layer_internal_wms", public=True)
         layer_internal_wms.layer = "__test_layer_internal_wms"
@@ -74,6 +86,18 @@ class TestThemesView(TestCase):
         )
         layer_external_wms.interfaces = [main]
         layer_external_wms.ogc_server = ogc_server_external
+
+        layer_valid_wms_version = LayerWMS(
+            name="__test_valid_wms_version", layer="testpoint_unprotected", public=True
+        )
+        layer_valid_wms_version.interfaces = [main]
+        layer_valid_wms_version.ogc_server = ogc_server_valid_wms_version
+
+        layer_invalid_wms_version = LayerWMS(
+            name="__test_invalid_wms_version", layer="testpoint_unprotected", public=True
+        )
+        layer_invalid_wms_version.interfaces = [main]
+        layer_invalid_wms_version.ogc_server = ogc_server_invalid_wms_version
 
         layer_wmts = LayerWMTS(name="__test_layer_wmts", public=True)
         layer_wmts.url = "http://example.com/1.0.0/WMTSCapabilities.xml"
@@ -104,6 +128,9 @@ class TestThemesView(TestCase):
         layer_group_8 = LayerGroup(name="__test_layer_group_8")
         layer_group_8.children = [layer_group_2, layer_group_6]
 
+        layer_group_9 = LayerGroup(name="__test_layer_group_9")
+        layer_group_9.children = [layer_valid_wms_version, layer_invalid_wms_version]
+
         theme = Theme(name="__test_theme")
         theme.interfaces = [main]
         theme.children = [
@@ -114,6 +141,7 @@ class TestThemesView(TestCase):
             layer_group_5,
             layer_group_7,
             layer_group_8,
+            layer_group_9,
         ]
 
         DBSession.add(theme)
@@ -172,21 +200,23 @@ class TestThemesView(TestCase):
     @staticmethod
     def _get_filtered_errors(themes):
         errors = themes["errors"]
-        errors = [
-            e
-            for e in errors
-            if e != "The layer '' (__test_layer_external_wms) is not defined in WMS capabilities"
-        ]
+
         regex = re.compile(
-            r"The (GeoMapFish|WMS) layer name '[a-z0-9_]*', cannot be two times in the same block (first level group)."
+            r"The (GeoMapFish|WMS) layer name '[a-z0-9_]*', cannot be two times in the same block \(first level group\)."
         )
-        errors = [e for e in errors if regex.match(e)]
+        errors = [e for e in errors if not regex.match(e)]
+
+        errors = [e[:100] for e in errors]
+
         return set(errors)
 
     def test_theme_mixed(self):
         theme_view = self._create_theme_obj(params={"interface": "main"})
         themes = theme_view.themes()
-        self.assertEqual(self._get_filtered_errors(themes), set())
+        self.assertEqual(
+            self._get_filtered_errors(themes),
+            {"WARNING! an error 'The WMS version (1.0.0) you requested is not implemented. Please use 1.1.1 or 1.3"}
+            )
         self.assertEqual(
             [self._only_name(t, ["name", "mixed"]) for t in themes["themes"]],
             [
@@ -270,6 +300,11 @@ class TestThemesView(TestCase):
                             ],
                             "mixed": True,
                             "name": "__test_layer_group_8",
+                        },
+                        {
+                            "children": [{"name": "__test_valid_wms_version"}],
+                            "mixed": True,
+                            "name": "__test_layer_group_9",
                         },
                     ],
                     "name": "__test_theme",


### PR DESCRIPTION
This is to use the parameters that are given in the OGC server URL instead of overwriting with default values (-> use a specific WMS version)