### PR TITLE
Make config enable_admin_interface scalar

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/geoportal/CONST_config-schema.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/geoportal/CONST_config-schema.yaml
@@ -45,7 +45,7 @@ mapping:
         type: str
         required: True
       enable_admin_interface:
-        type: bool
+        type: scalar
         required: True
       c2c.base_path:
         type: str


### PR DESCRIPTION
Required to set its value using an environment variable and avoid build error such as
```
Value '{ENABLE_ADMIN_INTERFACE}' is not of type 'bool'.
```
Thanks @sbrunner for your help!

Example of related changes in a project: https://github.com/camptocamp/lausanne_mapfish/pull/29/files
I have tested that the default behaviour still works with the change proposed in the current PR.