### PR TITLE
Remove default URL length limit in Gunicorn

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/env.default_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/env.default_tmpl
@@ -33,7 +33,8 @@ MAPSERVER_URL=http://mapserver:8080/
 TINYOWS_URL=http://tinyows:8080/
 QGISSERVER_URL=http://qgisserver:8080/
 QGIS_VERSION=3.16
-GUNICORN_PARAMS=--bind=:8080 --worker-class=gthread --threads=10 --workers=1 --timeout=60 --max-requests=1000 --max-requests-jitter=100 --config=/etc/gunicorn/config.py --worker-tmp-dir=/dev/shm
+GUNICORN_PARAMS=--bind=:8080 --worker-class=gthread --threads=10 --workers=1 --timeout=60 --max-requests=1000 --max-requests-jitter=100 --config=/etc/gunicorn/config.py --worker-tmp-dir=/dev/shm  --limit-request-line=8190
+
 DEVSERVER_HOST=webpack_dev_server:8080
 REDIS_SERVICENAME=mymaster
 REDIS_DB=0


### PR DESCRIPTION
We had several users reporting GMF crashes with long URLs (GMF has often permalink with a lot of params) such as:
```
Request Line is too large (5722 > 4094)
```

This is related to Gunicorn limiting by default URLs to 4094 chars: https://docs.gunicorn.org/en/stable/settings.html#limit-request-line

The PR suggests to get rid of the Gunicorn default limit.