### PR TITLE
Doc - Add custom alembic

### DIFF
--- a/doc/administrator/mapfile.rst
+++ b/doc/administrator/mapfile.rst
@@ -214,7 +214,7 @@ The ``${MAPSERVER_DATA_SUBSELECT}`` is defined as follows:
 .. warning::
 
     In some cases you can have geometries that overlap the restriction
-    area. Theses features will not be displayed as they are not in the area (ie not
+    area. These features will not be displayed as they are not in the area (ie not
     *contained*). *st_intersects* or another operator could be used instead of the
     *st_contains* operator.
 

--- a/doc/developer/cache.rst
+++ b/doc/developer/cache.rst
@@ -92,7 +92,7 @@ Private cache
 Internal cache
 --------------
 
-We have two different internal cache types, one (``std``) for the serializable objets (Like JSON) and
+We have two different internal cache types, one (``std``) for the serializable objects (Like JSON) and
 one (``obj``) for the non serializable objects.
 
 The ``std`` cache is stored on redis, and the ``obj`` cache is stored in memory.

--- a/doc/developer/custom_alembic.rst
+++ b/doc/developer/custom_alembic.rst
@@ -1,0 +1,104 @@
+.. _custom_alembic:
+
+Alembic on custom tables
+========================
+
+If you want to manage custom tables (GMF tables; not in the ``main`` nor the ``static`` schema)
+with alembic you must setup a custom alembic process. Here's an example. Others solutions
+are possible, but do not try to reuse the existing ``alembic.ini`` (because you will not be able to specify a
+schema through the configuration levels).
+
+The following example uses ``docker cp``. You can achieve the same with a volume, but you will
+have to set the owner (root) of copied files.
+
+Init alembic
+------------
+
+In your project, add a ``geoportal/alembic_<project_name>`` folder.
+
+Build and run your project.
+
+In the running container initialize alembic in a folder that have **not** already
+an ``alembic.ini`` file, like the /tmp folder. Create also directly the first revision file:
+
+.. prompt:: bash
+
+  docker-compose exec geoportal mkdir /tmp/new_alembic
+  docker-compose exec geoportal bash -c "cd /tmp/new_alembic; alembic init alembic"
+  # Ignore the warning message about setting the alembic.ini file for now.
+  docker-compose exec geoportal bash -c "cd /tmp/new_alembic; alembic revision -m 'Inital revision'"
+
+Run ``docker-compose ps geoportal`` to know the name of the running geoportal container.
+
+Then copy the generated alembic folder in the ``geoportal`` folder of your project:
+
+.. prompt:: bash
+
+  PROJECT=<your_project>
+  docker cp <geoportal_container_name>:/tmp/new_alembic geoportal/alembic_${PROJECT}
+
+You can now customize the ``alembic.ini`` and the ``env.py``.
+
+Configure ``alembic.ini``
+-------------------------
+
+The main change to apply is to use environment variables to run alembic on the right database.
+To do so, use a ``tmpl`` file:
+
+.. prompt:: bash
+
+  mv geoportal/alembic_${PROJECT}/alembic.ini{,.tmpl}
+  rm geoportal/alembic_${PROJECT}/alembic.ini
+  echo "/geoportal/alembic_${PROJECT}/alembic.ini" >> .gitignore
+
+And inside the ``alembic.ini.tmpl`` set the ``sqlalchemy.url`` to
+``postgresql://${PGUSER}:${PGPASSWORD}@${PGHOST}:${PGPORT}/${PGDATABASE}``.
+
+In this file, you may also directly set a new variable ``version_table_schema`` to set the
+name of the schema inside which alembic must create its revision table. See:
+`The Environment Context <https://alembic.sqlalchemy.org/en/latest/api/runtime.html#the-environment-context>`_.
+
+You must now set permissions on this tmpl file to authorise evaluation of this ``tmpl`` file.
+Add the following lines in the ``geoportal/Dockerfile`` just before the command
+``ENTRYPOINT [ "/usr/bin/eval-templates" ]``, in the ``FROM camptocamp/geomapfish`` section.
+
+.. code::
+
+  # Custom - To be able to run tmpl on alembic.ini.tmpl file
+  RUN rm -f /app/alembic_<project>/alembic.ini && \
+      chmod g+w /app/alembic_<project> && \
+      chown www-data /app/alembic_<project>/alembic.ini.tmpl
+
+Configure ``env.py``
+--------------------
+
+Edit the file ``geoportal/alembic_${PROJECT}/alembic/env.py``.
+
+In there, update the ``run_migrations_offline`` function by adding
+``version_table_schema = config.get_main_option("version_table_schema")`` to get the schema
+name from the ``alembic.ini`` file. Add this value as parameter of the ``context.configure()``
+function.
+
+Do the same in the ``run_migrations_online`` function.
+
+At this point, you should be able to run your (currently empty) first revision file.
+
+Run an alembic upgrade
+----------------------
+
+Once your revision file completed, build and run docker-compose up on your project.
+Your alembic files should be in the running container. You can now run manually an upgrade with:
+
+.. prompt:: bash
+
+  docker-compose exec geoportal bash -c "cd /app/alembic_${PROJECT}; alembic upgrade head"
+
+Create a new revision file
+--------------------------
+
+With a running instance, execute:
+
+.. prompt:: bash
+
+  docker-compose exec geoportal bash -c "cd /app/alembic_${PROJECT}; alembic revision -m '<msg>'"
+  docker cp <geoportal_container_name>:/app/alembic_${PROJECT}/alembic/versions/<the_new_file> geoportal/alembic_${PROJECT}/alembic/versions/.

--- a/doc/developer/debugging.rst
+++ b/doc/developer/debugging.rst
@@ -90,7 +90,7 @@ With the following command, you can access the logs:
    docker-compose logs -f --tail=20 [<service_name>]
 
 To have the access log on gunicorn you should add the option ``--access-logfile=-`` in the gunicorn
-arguments (``GUNICORN_PARAMS`` environement variable).
+arguments (``GUNICORN_PARAMS`` environment variable).
 
 Go inside a container
 .....................

--- a/doc/developer/index.rst
+++ b/doc/developer/index.rst
@@ -20,3 +20,4 @@ Content:
     webservices
     cache
     build_release
+    custom_alembic

--- a/doc/developer/server_side.rst.tmpl
+++ b/doc/developer/server_side.rst.tmpl
@@ -93,7 +93,6 @@ For instance, via a functionality you can define which basemap is to be used whe
 The ``metadata`` contains attributes that are directly related to the element;
 for example, the layer disclaimer.
 
-
 Migration
 ~~~~~~~~~
 
@@ -130,6 +129,7 @@ More information at:
  * https://alembic.readthedocs.org/en/latest/tutorial.html#create-a-migration-script
  * https://alembic.readthedocs.org/en/latest/ops.html
 
+To use alembic scripts on custom schemas or tables see :ref:`custom_alembic`.
 
 Code
 ----

--- a/doc/integrator/backend_qgis.rst
+++ b/doc/integrator/backend_qgis.rst
@@ -117,8 +117,8 @@ with a section looking like that:
 
 Do not forget to gracefully restart Apache.
 
-Extra PostGIS connexion
-***********************
+Extra PostGIS connection
+************************
 
 If you need to add another database connection, add a new section in the ``$HOME/.pg_service.conf``.
 In the ``qgisserver/pg_service.conf.tmpl`` files, add a new section:

--- a/doc/integrator/create_application.rst.tmpl
+++ b/doc/integrator/create_application.rst.tmpl
@@ -228,6 +228,6 @@ Dynamic configuration
 ---------------------
 
 Several files are generated on runtime, their content depending of the variables you
-have set as environement variables.
+have set as environment variables.
 
 The files can have the extension ``.tmpl`` and it use bash syntax (``${DOLLAR}{VARIABLE}``).

--- a/doc/integrator/functionality.rst
+++ b/doc/integrator/functionality.rst
@@ -9,7 +9,7 @@ A functionality may be associated to users through the admin interface.
 Some technical roles are used to define default functionalities depending on the user's context,
 they are named `anonymous`, `registered` and `intranet`.
 
-User get functionnalities from, by priority order:
+User get functionalities from, by priority order:
 
 If authenticated::
 

--- a/doc/integrator/requirements.rst
+++ b/doc/integrator/requirements.rst
@@ -38,7 +38,7 @@ Required Apache modules
 * ``mod_proxy_http``
 
 
-Required PostgreSQL extentions
+Required PostgreSQL extensions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * ``postgis``


### PR DESCRIPTION
Add instruction to run alembic on a custom schema or on custom tables (GMF 2.5).
I don't have seen better solution. The setup is a little bit long, but it works well then.

Fix also some typo.

(I've added some reviewers only to inform them that this page exist now.)