### PR TITLE
Add doc about excluded or readonly attributes while editing

### DIFF
--- a/doc/administrator/administrate.rst.tmpl
+++ b/doc/administrator/administrate.rst.tmpl
@@ -57,7 +57,7 @@ Some metadata items are used by the ``layers`` views (for editing) on the server
   polygon), for example, to prevent creation of a 2-point polygon.
 * ``lastUpdateDateColumn``: Define a column which will be automatically filled with the date of the last edit.
 * ``lastUpdateUserColumn``: Define a column which will be automatically filled with the user of the last edit.
-* ``readonlyAttributes``: Set attributes as read only.
+* ``readonlyAttributes``: Set attributes as read only in the :ref:`administrator_editing` form.
 
 Some metadata items are used by the ``theme2fts`` script:
 

--- a/doc/administrator/editing.rst
+++ b/doc/administrator/editing.rst
@@ -109,3 +109,13 @@ The value is a ``json`` object containing the following optional properties:
 * edge (boolean): whether to allow snapping on edges or not;
 * vertex (boolean): whether to allow snapping on vertices or not;
 * tolerance (number): the pixel tolerance.
+
+Managing attributes
+-------------------
+
+To exclude some attributes from the editing form, list them as a comma-separated string
+(with no blank spaces) in the ``Exclude properties`` field of the WMS/WMTS layer forms
+in the admin interface.
+
+To make some attributes readonly, add a ``readonlyAttributes`` metadata in the same form,
+also as a comma-separated list of attributes.


### PR DESCRIPTION
This PR adds a section to https://camptocamp.github.io/c2cgeoportal/master/administrator/editing.html giving tips about excluded or readonly attributes while editing.

Excluded properties are already mentioned at https://camptocamp.github.io/c2cgeoportal/master/administrator/administrate.html#common-attributes but that's worth mentioning it in the Editing chapter as well.