### PR TITLE
Improve changelog about the relocation of the config to the vars.yaml

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -11,42 +11,74 @@ Client application configuration
 ................................
 
 Previous versions had configuration in the `*.html.ejs`, in the `Controler*.js`, and in the `vars.yaml` file.
-The goal of this change is to move this configuration to the `vars.yaml` file (with default values in
+The goal of this change is to group all this configuration to the `vars.yaml` file (with default values in
 the `CONST_vars.yaml`). This will make future upgrades easier and increase configuration possibilities
 in the simple application mode, see the documentation
 <https://camptocamp.github.io/c2cgeoportal/${MAIN_BRANCH}/integrator/create_application.html#simple-application>.
 
 
-When you apply the `ngeo.diff` you should first apply the changes in the `geoportal/vars.yaml` file.
+When you apply the `ngeo.diff` you will have to remove lines of configuration from your `*.html.ejs` and
+`Controler*.js` files. You must compare each removed line of configuration with its default value newly
+defined in the section `vars/interface_config` of your `geoporal/CONST_vars.yaml` file. If you use a custom
+configuration, you have to override the default value by adding a new one in your `geoportal/vars.yaml`.
 
-For the next step, you should consult the documentation about:
-- The interfaces_config documentation
+
+In the `vars/interface_config` section of `geoportal/vars.yaml` and `geoporal/CONST_vars.yaml` files, you
+define configuration per `interface` and then mainly per `constants` and `routes` (for paths). See all
+possibility in the `Dynamic.json view` part of the documentation
 <https://camptocamp.github.io/c2cgeoportal/${MAIN_BRANCH}/integrator/ngeo.html?highlight=ngeo#dynamic-json-view>
+
+
+You can find a list of existing options in the `geoporal/CONST_vars.yaml` and here with descriptions:
 - GMF constants definitions <https://camptocamp.github.io/ngeo/master/jsdoc/module-contribs_gmf_src_options.html>
 - ngeo constants definitions <https://camptocamp.github.io/ngeo/master/jsdoc/module-src_options.html>
 
 
-Then configure the `vars/srid`, `vars/alternate_projections`, `vars/resolutions` and `vars/extent` they will
-be dispatched using `c2ctemplate` or YAML link.
+In the following examples, we show typical examples of necessary changes:
 
-In the following, we show typical examples of necessary changes:
+Standard example in controller
+..............................
+
+In the ngeo.diff:
+```
+-    this.elevationLayers = ['aster', 'srtm'];
+```
+
+But you have this custom config in your `geoportal/<project_package>_geoportal/static-ngeo/api/index.js` file:
+```
+   this.elevationLayers = ['mns', 'mnt', 'rayglobal'];
+```
+
+We have to remove the `elevationLayers` config. And we also see that the project settings do not correspond to
+the default settings, therefore you should have in your `geoportal/vars.yaml` file something like:
+```
+vars:
+  interfaces_config:
+    default:  # or interface name
+      constants:
+        gmfElevationOptions:
+          layers: [mns, mnt, rayglobal]
+```
+
+Again, you can find the `gmfElevationOptions` in the `geoporal/CONST_vars.yaml` and its composition and
+description in the GMF/ngeo constants definitions (see links above).
 
 Example in API
 ..............
 
 In the ngeo.diff:
 ```
---- a/geoportal/cartoriviera_geoportal/static-ngeo/api/index.js
-+++ b/geoportal/cartoriviera_geoportal/static-ngeo/api/index.js
+--- a/geoportal/<project_package>_geoportal/static-ngeo/api/index.js
++++ b/geoportal/<project_package>_geoportal/static-ngeo/api/index.js
 ...
 -// The URL to the search service.
 -config.searchUrl = '{FULL_ENTRY_POINT}search?interface=api&limit=15';
 ```
 
-And in your `geoportal/cartoriviera_geoportal/static-ngeo/api/index.js` file:
+And in your `geoportal/<project_package>_geoportal/static-ngeo/api/index.js` file:
 ```
 // The URL to the search service.
-onfig.searchUrl = '{FULL_ENTRY_POINT}search?interface=api&limit=15';
+config.searchUrl = '{FULL_ENTRY_POINT}search?interface=api&limit=15';
 ```
 
 We see that the project settings didn't correspond to the previous default settings, therefore you should
@@ -64,6 +96,22 @@ update_paths:
   - interfaces_config.api.routes.searchUrl  # This one should already be present
 ```
 
+In this case you could have to add also this `update_paths`. It's because the default value in the
+`geoportal/CONST_vars.yaml` define the searchUrl like this:
+
+```
+searchUrl:
+  name: fulltextsearch
+  params:
+    limit: 15
+    partitionlimit: 5
+  dynamic_params:
+    interface: interface
+```
+
+You won't redefine the whole `searchUrl` configuration you only want to set the params. The `update_paths`
+Allows you to update the one part of the configuration. Without this entry in the `update_paths`, the
+whole `searchUrl` configuration would have been replaced.
 
 Example in controller constructor
 .................................
@@ -83,7 +131,7 @@ In the ngeo.diff:
 -    }, $scope, $injector);
 ```
 
-And in your `geoportal/cartoriviera_geoportal/static-ngeo/api/index.js` file:
+And in your `geoportal/<project_package>_geoportal/static-ngeo/api/index.js` file:
 ```
   constructor($scope, $injector) {
     super({
@@ -117,30 +165,6 @@ vars:
           geolocalisation: True
 ```
 
-Standard example in controller
-..............................
-
-In the ngeo.diff:
-```
--    this.elevationLayers = ['aster', 'srtm'];
-```
-
-And in your `geoportal/cartoriviera_geoportal/static-ngeo/api/index.js` file:
-```
-   this.elevationLayers = ['mns', 'mnt', 'rayglobal'];
-```
-
-We see that the project settings didn't correspond to the previous default settings, therefore you should
-have in your vars file something like:
-```
-vars:
-  interfaces_config:
-    default:  # or interface name
-      constants:
-        gmfElevationOptions:
-          layers: [mns, mnt, rayglobal]
-```
-
 Optional point
 ..............
 
@@ -156,7 +180,7 @@ The header can be in a separate file, diff in the `*.html.ejs` file:
     - </header>
     + <ng-include src="'desktop_alt/header.html'"></ng-include>
 
-  The content will be in the `geoportal/geomapfish_geoportal/static/header.html` file.
+The content will be in the `geoportal/<project_package>_geoportal/static/header.html` file.
 
 
 Information

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -16,23 +16,22 @@ the `CONST_vars.yaml`). This will make future upgrades easier and increase confi
 in the simple application mode, see the documentation
 <https://camptocamp.github.io/c2cgeoportal/${MAIN_BRANCH}/integrator/create_application.html#simple-application>.
 
+When you apply the `ngeo.diff` you should first apply the proposed changes concerning the
+`geoportal/vars.yaml` file itself.
 
-When you apply the `ngeo.diff` you will have to remove lines of configuration from your `*.html.ejs` and
-`Controler*.js` files. You must compare each removed line of configuration with its default value newly
-defined in the section `vars/interface_config` of your `geoporal/CONST_vars.yaml` file. If you use a custom
-configuration, you have to override the default value by adding a new one in your `geoportal/vars.yaml`.
+Then during applying the `ngeo.diff` you have to remove multiple lines of configuration from your
+`*.html.ejs` and `Controler*.js` files. for each configuration that diverge from the default configuration you
+have to override the default value (that are newly defined in the `geoportal/CONST_vars.yaml`) by adding
+a new value in the `vars/interface_config` section of your `geoportal/vars.yaml` file.
 
-
-In the `vars/interface_config` section of `geoportal/vars.yaml` and `geoporal/CONST_vars.yaml` files, you
-define configuration per `interface` and then mainly per `constants` and `routes` (for paths). See all
+In the `vars/interface_config` section of the `geoportal/vars.yaml` and the `geoporal/CONST_vars.yaml` files,
+you define configuration per `interface`, and then mainly per `constants` and `routes` (for paths). See all
 possibility in the `Dynamic.json view` part of the documentation
 <https://camptocamp.github.io/c2cgeoportal/${MAIN_BRANCH}/integrator/ngeo.html?highlight=ngeo#dynamic-json-view>
-
 
 You can find a list of existing options in the `geoporal/CONST_vars.yaml` and here with descriptions:
 - GMF constants definitions <https://camptocamp.github.io/ngeo/master/jsdoc/module-contribs_gmf_src_options.html>
 - ngeo constants definitions <https://camptocamp.github.io/ngeo/master/jsdoc/module-src_options.html>
-
 
 In the following examples, we show typical examples of necessary changes:
 
@@ -44,7 +43,7 @@ In the ngeo.diff:
 -    this.elevationLayers = ['aster', 'srtm'];
 ```
 
-But you have this custom config in your `geoportal/<project_package>_geoportal/static-ngeo/api/index.js` file:
+But you have this custom config in your `geoportal/{{package}}_geoportal/static-ngeo/api/index.js` file:
 ```
    this.elevationLayers = ['mns', 'mnt', 'rayglobal'];
 ```
@@ -68,14 +67,14 @@ Example in API
 
 In the ngeo.diff:
 ```
---- a/geoportal/<project_package>_geoportal/static-ngeo/api/index.js
-+++ b/geoportal/<project_package>_geoportal/static-ngeo/api/index.js
+--- a/geoportal/{{package}}_geoportal/static-ngeo/api/index.js
++++ b/geoportal/{{package}}_geoportal/static-ngeo/api/index.js
 ...
 -// The URL to the search service.
 -config.searchUrl = '{FULL_ENTRY_POINT}search?interface=api&limit=15';
 ```
 
-And in your `geoportal/<project_package>_geoportal/static-ngeo/api/index.js` file:
+And in your `geoportal/{{package}}_geoportal/static-ngeo/api/index.js` file:
 ```
 // The URL to the search service.
 config.searchUrl = '{FULL_ENTRY_POINT}search?interface=api&limit=15';
@@ -131,7 +130,7 @@ In the ngeo.diff:
 -    }, $scope, $injector);
 ```
 
-And in your `geoportal/<project_package>_geoportal/static-ngeo/api/index.js` file:
+And in your `geoportal/{{package}}_geoportal/static-ngeo/api/index.js` file:
 ```
   constructor($scope, $injector) {
     super({
@@ -165,6 +164,12 @@ vars:
           geolocalisation: True
 ```
 
+Other configuration
+...................
+
+You also have to configure the `vars/srid`, `vars/alternate_projections`, `vars/resolutions` and
+`vars/extent` they will be dispatched using `c2ctemplate` or YAML link.
+
 Optional point
 ..............
 
@@ -180,7 +185,7 @@ The header can be in a separate file, diff in the `*.html.ejs` file:
     - </header>
     + <ng-include src="'desktop_alt/header.html'"></ng-include>
 
-The content will be in the `geoportal/<project_package>_geoportal/static/header.html` file.
+The content will be in the `geoportal/{{package}}_geoportal/static/header.html` file.
 
 
 Information


### PR DESCRIPTION
For GSGMF-1526

I've tried to improve the explanation of the relocation of the config to the vars.yaml file.
I'm a little bit less concise, with some repetitions but if think that's more logical for a less experimented user.

Questions:
 - I use `geoportal/<project_package>_geoportal/` syntaxe, can we do better ? (like `geoportal/${project_package}_geoportal/` ?)
 - Could we add a link to a doc that explain yaml section template`&mysection`, `*mysection`

The only section I've removed is this one, thinking it's too technical and not necessary in the changelog:
```
Then configure the `vars/srid`, `vars/alternate_projections`, `vars/resolutions` and `vars/extent` they will
be dispatched using `c2ctemplate` or YAML link.
```