### PR TITLE
Ujson used by fast_json didn't handle correctly the value infinity

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/views/dynamic.py
+++ b/geoportal/c2cgeoportal_geoportal/views/dynamic.py
@@ -98,7 +98,7 @@ class DynamicView:
 
         return constants
 
-    @view_config(route_name="dynamic", renderer="fast_json")
+    @view_config(route_name="dynamic", renderer="json")
     def dynamic(self):
         interface_name = self.request.get_organization_interface(self.request.params.get("interface"))
 


### PR DESCRIPTION
Fix GSGMF-1589

```python                                                                                                               
>>> import json                                                                                                
>>> import ujson                                                                                               
>>> json.dumps(float('inf'))                                                                                   
'Infinity'                                                                                                     
>>> ujson.dumps(float('inf'))                                                                                  
'Inf' 
```