### PR TITLE
Remove unused vars section

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/geoportal/vars.yaml_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/geoportal/vars.yaml_tmpl
@@ -164,9 +164,6 @@ vars:
       de: german
       it: italian
 
-  # proxies:
-  #   http: https://someproxy
-
   shortener:
     # Used to send a confirmation email
     email_from: info@example.com


### PR DESCRIPTION
It seems this is not used in c2cgeoportal, therefore it should be removed from the template.