### PR TITLE
Add missing dependency for Transifex since requests 2.26

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -26,6 +26,7 @@ types-python-dateutil = "==0.1.4"
 types-requests = "==2.25.0"
 types-pkg-resources = "==0.1.3"
 mappyfile = "==0.9.1"
+chardet = "==4.0.0" # for Transifex
 
 [packages]
 alembic = "==1.6.5"  # geoportal

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1292,6 +1292,14 @@
             ],
             "version": "==2021.5.30"
         },
+        "chardet": {
+            "hashes": [
+                "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
+                "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
+            ],
+            "index": "pypi",
+            "version": "==4.0.0"
+        },
         "charset-normalizer": {
             "hashes": [
                 "sha256:3c502a35807c9df35697b0f44b1d65008f83071ff29c69677c7c22573bc5a45a",


### PR DESCRIPTION
Fix: tx ERROR: No module named 'chardet'