### PR TITLE
The `list4vrt` had a bug limiting list to 1000 keys.

### DIFF
--- a/bin/list4vrt
+++ b/bin/list4vrt
@@ -47,12 +47,14 @@ def main():
     while True:
         obj_list_metadata = s3_client.list_objects_v2(**kwargs)
 
-        for obj in obj_list_metadata['Contents']:
+        for obj in obj_list_metadata["Contents"]:
             if obj["Key"].endswith(postfix):
-                print(f"/vsis3/{args.bucket}/obj['Key']")
+                print(f"/vsis3/{args.bucket}/{obj['Key']}")
         try:
             kwargs["ContinuationToken"] = obj_list_metadata["NextContinuationToken"]
         except KeyError:
             break
-if __name__ == '__main__':
+
+
+if __name__ == "__main__":
     main()

--- a/bin/list4vrt
+++ b/bin/list4vrt
@@ -42,7 +42,7 @@ def main():
         region_name=os.environ["AWS_DEFAULT_REGION"],
     )
     # According to S3 https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.list_objects_v2
-    # doc this function return at most 1000 keys. To ensure we retreive all the key from the prefix, use continuation token.
+    # doc this function return at most 1000 keys. To ensure we retrieve all the key from the prefix, use continuation token.
     kwargs = {"Bucket": bucket, "Prefix": prefix}
     while True:
         obj_list_metadata = s3_client.list_objects_v2(**kwargs)

--- a/bin/list4vrt
+++ b/bin/list4vrt
@@ -41,10 +41,18 @@ def main():
         endpoint_url=f"https://{os.environ['AWS_S3_ENDPOINT']}/",
         region_name=os.environ["AWS_DEFAULT_REGION"],
     )
-    keys = [i["Key"] for i in s3_client.list_objects(Bucket=args.bucket, Prefix=args.prefix)["Contents"]]
-    filtered_keys = list(filter(lambda i: i.endswith(args.postfix), keys))
-    full_keys = [f"/vsis3/{args.bucket}/{i}" for i in filtered_keys]
-    print("\n".join(full_keys))
+    # According to S3 https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.list_objects_v2
+    # doc this function return at most 1000 keys. To ensure we retreive all the key from the prefix, use continuation token.
+    kwargs = {"Bucket": bucket, "Prefix": prefix}
+    while True:
+        obj_list_metadata = s3_client.list_objects_v2(**kwargs)
 
-
-main()
+        for obj in obj_list_metadata['Contents']:
+            if obj["Key"].endswith(postfix):
+                print(f"/vsis3/{args.bucket}/obj['Key']")
+        try:
+            kwargs["ContinuationToken"] = obj_list_metadata["NextContinuationToken"]
+        except KeyError:
+            break
+if __name__ == '__main__':
+    main()

--- a/bin/list4vrt
+++ b/bin/list4vrt
@@ -50,9 +50,9 @@ def main():
         for obj in obj_list_metadata["Contents"]:
             if obj["Key"].endswith(postfix):
                 print(f"/vsis3/{args.bucket}/{obj['Key']}")
-        try:
+        if "NextContinuationToken" in obj_list_metadata:
             kwargs["ContinuationToken"] = obj_list_metadata["NextContinuationToken"]
-        except KeyError:
+        else:
             break
 
 


### PR DESCRIPTION
Call to S3 api method "ListObjects(v2)" return, at most, 1000 keys. To
be sure you have all the key from the requested prefix, you need to
check for `IsTruncated` and `NextContinuationToken`. This commit fix
this edge case.