### PR TITLE
Add clean option in OGCServerSynchronizer

### DIFF
--- a/admin/c2cgeoportal_admin/templates/ogcserver_synchronize.jinja2
+++ b/admin/c2cgeoportal_admin/templates/ogcserver_synchronize.jinja2
@@ -63,6 +63,10 @@
             <input type="checkbox" name="force-parents" id="force-parents-field">
             <label for="force-parents-field" class="control-label">{{_("Force parents re-initialization.")}}</label>
         </div>
+        <div class="form-group">
+            <input type="checkbox" name="clean" id="clean">
+            <label for="clean" class="control-label">{{_("Remove unexisting layers and empty groups.")}}</label>
+        </div>
         <button type="submit" name="synchronize" class="btn btn-primary">{{_("Synchronize")}}</button>
       </form>
     </div>

--- a/admin/c2cgeoportal_admin/views/ogc_servers.py
+++ b/admin/c2cgeoportal_admin/views/ogc_servers.py
@@ -147,8 +147,15 @@ class OGCServerViews(AbstractViews):
             }
 
         if self._request.method == "POST":
-            force_parents = self._request.POST.get("force-parents", "false") == "true"
-            synchronizer = OGCServerSynchronizer(self._request, obj, force_parents=force_parents)
+            force_parents = self._request.POST.get("force-parents", "false") == "on"
+            clean = self._request.POST.get("clean", "false") == "on"
+
+            synchronizer = OGCServerSynchronizer(
+                self._request,
+                obj,
+                force_parents=force_parents,
+                clean=clean,
+            )
             if "check" in self._request.params:
                 synchronizer.check_layers()
             elif "dry-run" in self._request.params:


### PR DESCRIPTION
In OGCServer synchronize, add checkbox to remove layers which does not exist in WMS capabilities and all empty groups.