### PR TITLE
[admin] Add missing order_by in layertree

### DIFF
--- a/admin/c2cgeoportal_admin/views/layertree.py
+++ b/admin/c2cgeoportal_admin/views/layertree.py
@@ -76,6 +76,7 @@ class LayerTreeViews:
                 self._dbsession.query(TreeItem)
                 .join(TreeItem.parents_relation)  # pylint: disable=no-member
                 .filter(LayergroupTreeitem.treegroup_id == group_id)
+                .order_by(LayergroupTreeitem.ordering)
             )
 
         return [


### PR DESCRIPTION
Groups and layers where not sorted in admin layer tree before this pull request.