### PR TITLE
Add blacklist whitelist for headers

### DIFF
--- a/doc/integrator/headers.rst
+++ b/doc/integrator/headers.rst
@@ -3,6 +3,9 @@
 Headers
 =======
 
+Global headers
+--------------
+
 ``c2cgeoportal`` adds some HTTP headers on its responses with certain default values.
 You may wish to override the values being written. All this is done in the configuration with the
 ``global _headers`` section in the vars file with the following syntax:
@@ -26,3 +29,34 @@ Where ``<path>`` can be: ``main``, ``admin``, ``apihelp`` or ``c2c``,
 ``<directive>`` can be: ``default_src``, ``script_src``, `style_src``, ``img_src``,
 ``connect_src`` or ``worker_src``,
 ``[_extra]`` is a suffix to be able to extend a directive instance of completely overriding it.
+
+Forward host
+------------
+
+Requests passing through the c2cgeoportal proxy will have their host set with the host
+of the server. It's possible to keep the original host by adding the host value to preserve
+in the `host_forward_host` array of strings.
+
+.. code:: yaml
+
+    vars:
+      host_forward_host:
+        - <host.one>
+        - <host.two>
+
+Headers whitelist and blacklist
+-------------------------------
+
+It's possible to filter the headers of requests with a whitelist or a blacklist.
+
+.. code:: yaml
+
+    vars:
+      headers_whitelist: []
+      headers_blacklist:
+        - <header-one>
+        - <header-two>
+
+The whitelist is applied before the blacklist.
+These lists are applied on each request passing through the c2cgeoportal proxy.
+Pyramid will still add back its default headers.

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/Dockerfile_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/Dockerfile_tmpl
@@ -9,7 +9,8 @@ ENV CONFIG_VARS sqlalchemy.url sqlalchemy.pool_recycle sqlalchemy.pool_size sqla
     raster shortener hide_capabilities tinyowsproxy resourceproxy print_url print_get_redirect \
     checker check_collector default_max_age package srid \
     reset_password fulltextsearch global_headers headers authorized_referers hooks stats db_chooser \
-    dbsessions urllogin host_forward_host smtp c2c.base_path welcome_email \
+    dbsessions urllogin host_forward_host headers_whitelist headers_blacklist \
+    smtp c2c.base_path welcome_email \
     lingua_extractor interfaces_config interfaces devserver_url api authentication intranet metrics pdfreport
 
 COPY . /tmp/config/

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/geoportal/CONST_config-schema.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/geoportal/CONST_config-schema.yaml
@@ -516,6 +516,14 @@ mapping:
         type: seq
         sequence:
           - type: str
+      headers_whitelist:
+        type: seq
+        sequence:
+          - type: str
+      headers_blacklist:
+        type: seq
+        sequence:
+          - type: str
       raster:
         <<: *free_dict
         required: True

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/geoportal/CONST_vars.yaml_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/geoportal/CONST_vars.yaml_tmpl
@@ -392,6 +392,8 @@ vars:
     qgisserver: '{QGISSERVER_URL}'
 
   host_forward_host: []
+  headers_whitelist: []
+  headers_blacklist: []
 
   # The "raster web services" configuration. See the "raster"
   # chapter in the integrator documentation.

--- a/geoportal/c2cgeoportal_geoportal/views/proxy.py
+++ b/geoportal/c2cgeoportal_geoportal/views/proxy.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2011-2020, Camptocamp SA
+# Copyright (c) 2011-2021, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without
@@ -103,7 +103,7 @@ class Proxy:
             headers["Forwarded"] = forwarded_str
 
         if not cache:
-           headers["Cache-Control"] = "no-cache"
+            headers["Cache-Control"] = "no-cache"
 
         if method in ("POST", "PUT") and body is None:  # pragma: no cover
             body = self.request.body
@@ -111,15 +111,11 @@ class Proxy:
         # Filters headers with a whitelist.
         # Some default pyramid headers will be added back by pyramid.
         if len(self.headers_whitelist) > 0:
-            for header in list(headers):
-                if header not in self.headers_whitelist:
-                    headers.pop(header)
+            headers = {key: value for key, value in headers.items() if key in self.headers_whitelist}
 
         # Filters headers with a blacklist.
         # Some default pyramid headers will be added back by pyramid.
-        for header in list(headers):
-            if header in self.headers_blacklist:
-                headers.pop(header)
+        headers = {key: value for key, value in headers.items() if key not in self.headers_blacklist}
 
         try:
             if method in ("POST", "PUT"):

--- a/geoportal/tests/functional/__init__.py
+++ b/geoportal/tests/functional/__init__.py
@@ -167,7 +167,6 @@ def create_dummy_request(additional_settings=None, authentication=True, user=Non
 
     request = tests.create_dummy_request(
         {
-            "host_forward_host": [],
             "functionalities": {"available_in_templates": []},
             "layers": {"geometry_validation": True},
             "admin_interface": {

--- a/geoportal/tests/functional/test_themes_mixed.py
+++ b/geoportal/tests/functional/test_themes_mixed.py
@@ -215,7 +215,8 @@ class TestThemesView(TestCase):
         themes = theme_view.themes()
         self.assertEqual(
             self._get_filtered_errors(themes),
-            {"WARNING! an error 'The WMS version (1.0.0) you requested is not implemented. Please use 1.1.1 or 1.3"}
+            {"WARNING! an error 'The WMS version (1.0.0) you requested is not implemented. Please use 1.1.1 or 1.3",
+            'DescribeFeatureType from URL http://wms.geo.admin.ch/?SERVICE=WFS&VERSION=1.0.0&REQUEST=DescribeFeat'}
             )
         self.assertEqual(
             [self._only_name(t, ["name", "mixed"]) for t in themes["themes"]],


### PR DESCRIPTION
For GEO-4639

Add blacklist/whitelist system for headers.
Add docs.

@sbrunner Are you sure you don't want to add this feature per url like the global_header system ? 

```
vars:
  global_headers:
    - pattern: <regex>
      headers:
        <header>: <value>
```
It looks risky, or possibly problematic to apply these lists on all request going through the proxy.
(@jwkaltz it's for Agrola, but I add you especially to review the documentation)