### PR TITLE
Add alternative X-Forward headers in proxy

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/views/proxy.py
+++ b/geoportal/c2cgeoportal_geoportal/views/proxy.py
@@ -91,7 +91,7 @@ class Proxy:
         # Forward the request tracking ID to the other service. This will allow to follow the logs belonging
         # to a single request coming from the user
         headers.setdefault("X-Request-ID", self.request.c2c_request_id)
-        # If we realy want to respect the specification, we should chain with the content of the previous
+        # If we really want to respect the specification, we should chain with the content of the previous
         # proxy, see also:
         # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
         forwarded = {"for": self.request.client_addr, "proto": self.request.scheme}
@@ -103,10 +103,10 @@ class Proxy:
         else:
             headers["Forwarded"] = forwarded_str
         # Set alternative "X-Forwarded" headers
-        for forwarded_elements in headers["Forwarded"].split(","):
+        for forwarded_elements in reversed(headers["Forwarded"].split(",")):
             for element in forwarded_elements.split(";"):
                 key, value = element.split("=")
-                header_key = "X-Forwarded-{0!s}".format(key.lower().capitalize())
+                header_key = "X-Forwarded-{}".format(key.capitalize())
                 header_value = headers.get(header_key)
                 headers[header_key] = value if header_value is None else ", ".join([header_value, value])
 

--- a/geoportal/c2cgeoportal_geoportal/views/proxy.py
+++ b/geoportal/c2cgeoportal_geoportal/views/proxy.py
@@ -91,7 +91,7 @@ class Proxy:
         # Forward the request tracking ID to the other service. This will allow to follow the logs belonging
         # to a single request coming from the user
         headers.setdefault("X-Request-ID", self.request.c2c_request_id)
-        # If we releay want to respect the specification, we should chain with the content of the previus
+        # If we realy want to respect the specification, we should chain with the content of the previous
         # proxy, see also:
         # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
         forwarded = {"for": self.request.client_addr, "proto": self.request.scheme}
@@ -102,6 +102,13 @@ class Proxy:
             headers["Forwarded"] = ",".join([headers["Forwarded"], forwarded_str])
         else:
             headers["Forwarded"] = forwarded_str
+        # Set alternative "X-Forwarded" headers
+        for forwarded_elements in headers["Forwarded"].split(","):
+            for element in forwarded_elements.split(";"):
+                key, value = element.split("=")
+                header_key = "X-Forwarded-{0!s}".format(key.lower().capitalize())
+                header_value = headers.get(header_key)
+                headers[header_key] = value if header_value is None else ", ".join([header_value, value])
 
         if not cache:
             headers["Cache-Control"] = "no-cache"


### PR DESCRIPTION
Clean fix for GEO-4666.

I'll backport it manually in 2.4 as some previous line interest me too.

I expect having `headers[Forwarded]` string like that:
`'by=0.0.0.0;for=134.12.1.1;host=123.12.1.1;proto=https,for=172.12.1.1'`

And transform them like that:

- `'X-Forwarded-By': '0.0.0.0`
- `'X-Forwarded-For': '134.12.14.2, 989.98.98.8'`
- `'X-Forwarded-Host': '123.12.12.12'`
- `'X-Forwarded-Proto': 'https'`

See also https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded