### PR TITLE
Revert: get_ngeo_index_vars is still used

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/views/entry.py
+++ b/geoportal/c2cgeoportal_geoportal/views/entry.py
@@ -48,6 +48,10 @@ class Entry:
         _ = self.request.translate
         return {"title": _("title i18n")}
 
+    def get_ngeo_index_vars(self) -> Dict[str, Any]:
+        set_common_headers(self.request, "index", Cache.PUBLIC_NO, content_type="text/html")
+        return {}
+
     def apijs(self) -> Dict[str, Any]:
         set_common_headers(self.request, "api", Cache.PUBLIC, content_type="application/javascript")
         return {}


### PR DESCRIPTION
Was removed here: https://github.com/camptocamp/c2cgeoportal/pull/8727/files
See also: https://sentry.io/organizations/camptocamp/issues/2708901269/?environment=prod-2-7&project=1851011&referrer=alert_email