### PR TITLE
Fix duplicated arg name in build script

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/build_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/build_tmpl
@@ -25,7 +25,7 @@ def main() -> None:
     parser.add_argument(
         "--debug", help="Path to c2cgeoportal source folder to be able to debug the upgrade procedure"
     )
-    parser.add_argument("env", nargs="*", help="The environment config")
+    parser.add_argument("env_files", nargs="*", help="The environment config")
     args = parser.parse_args()
 
     if args.upgrade:
@@ -62,10 +62,10 @@ def main() -> None:
 
     with open("project.yaml", encoding="utf-8") as project_file:
         project_env = yaml.load(project_file, Loader=yaml.SafeLoader)["env"]
-    if len(args.env) != project_env["required_args"]:
+    if len(args.env_files) != project_env["required_args"]:
         print(project_env["help"])
         sys.exit(1)
-    env_files = [e.format(*args.env) for e in project_env["files"]]
+    env_files = [e.format(*args.env_files) for e in project_env["files"]]
     print("Use env files: {}".format(", ".join(env_files)))
     for env_file in env_files:
         if not os.path.exists(env_file):


### PR DESCRIPTION
`env` is used to only build env and for env files.
Rename last one to env_files.