### PR TITLE
PGSCHEMA can also be required in the build

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/Dockerfile_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/Dockerfile_tmpl
@@ -23,6 +23,9 @@ ENV SIMPLE=$SIMPLE
 
 RUN build-l10n "{{package}}"
 
+ARG PGSCHEMA
+ENV PGSCHEMA=$PGSCHEMA
+
 RUN \
     cd /tmp/config/geoportal/ && \
     c2c-template --vars ${VARS_FILE} \


### PR DESCRIPTION
 to correctly create the vars.yaml if the PGSCHEMA is interpreted at build time