### PR TITLE
Various small fix for mvt

### DIFF
--- a/admin/c2cgeoportal_admin/static/theme.css
+++ b/admin/c2cgeoportal_admin/static/theme.css
@@ -45,6 +45,9 @@
 .icon-l_wmts:before {
   content: '\e011';
 }
+.icon-mvt:before {
+  content: '\e011';
+}
 .icon-user:before {
   content: '\e008';
 }

--- a/doc/integrator/admin_interface.rst
+++ b/doc/integrator/admin_interface.rst
@@ -33,11 +33,7 @@ The active default tabs (route urls) are:
 Optional tabs/modules
 ~~~~~~~~~~~~~~~~~~~~~
 
-There are optional tabs, not available if not explicitly included.
-
-The list is:
-- layers_vectortiles
-
+It's possible to have optional tabs, not available if not explicitly included.
 
 Include a new page
 ~~~~~~~~~~~~~~~~~~

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/geoportal/vars.yaml_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/geoportal/vars.yaml_tmpl
@@ -267,6 +267,7 @@ vars:
     apihelp: *header
     profile: *header
     raster: *header
+    vector_tiles: *header
     error: *header
     themes: &auth_header {}
     config: *auth_header
@@ -307,6 +308,7 @@ update_paths:
   - headers.apihelp.headers
   - headers.profile.headers
   - headers.raster.headers
+  - headers.vector_tiles.headers
   - headers.error.headers
   - headers.themes.headers
   - headers.config.headers


### PR DESCRIPTION
> admin/c2cgeoportal_admin/static/theme.css 

For mvt, I choose to use the same icon as for **tile** layers. Do you have a better idea ? Available choices: https://getbootstrap.com/docs/3.3/components/ (Or we have to switch to bootstrap 4 or use font-awesome or another lib)

> geoportal/c2cgeoportal_geoportal/scaffolds/create/geoportal/vars.yaml_tmpl

It is enough to fix the CORS problemes ? 