### PR TITLE
Add configuration for i18next

### DIFF
--- a/.tx/config.mako
+++ b/.tx/config.mako
@@ -37,3 +37,10 @@ type = PO
 % for lang in tx_languages.split():
 trans.${lang} = geoportal/c2cgeoportal_geoportal/locale/${lang}/LC_MESSAGES/gmf.po
 % endfor
+
+[ngeo.webcomponent-${tx_version.strip()}]
+source_lang = en
+type = KEYVALUEJSON
+% for lang in tx_languages.split():
+trans.${lang} = geoportal/c2cgeoportal_geoportal/static/locales/${lang}.json
+% endfor

--- a/ci/test-app
+++ b/ci/test-app
@@ -39,6 +39,8 @@ for path in c2c/health_check c2c/health_check?max_level=9 c2c/health_check?check
 done
 ci/run-dc-logs docker-compose exec -T geoportal ci/test-new-project 'http://qgisserver:8080/mapserv_proxy?SERVICE=WMS&REQUEST=GetCapabilities'
 ci/run-dc-logs docker-compose exec -T geoportal curl --insecure https://front/admin/ | grep Login
+ci/run-dc-logs docker-compose exec -T geoportal curl --insecure 'https://front/dynamic.json?interface=desktop&query=&path=%2F'
+ci/run-dc-logs docker-compose exec -T geoportal curl --insecure https://front/static-geomapfish/0/locales/fr.json
 docker-compose stop qgisserver
 ci/run-dc-logs docker-compose exec -T geoportal alembic --config=alembic.ini --name=static downgrade base
 ci/run-dc-logs docker-compose exec -T geoportal alembic --config=alembic.ini --name=main downgrade base

--- a/dependencies.mk
+++ b/dependencies.mk
@@ -10,9 +10,10 @@ NGEO_PO_FILES = $(addprefix geoportal/c2cgeoportal_geoportal/locale/,$(addsuffix
 GMF_PO_FILES = $(addprefix geoportal/c2cgeoportal_geoportal/locale/,$(addsuffix /LC_MESSAGES/gmf.po, $(LANGUAGES)))
 ADMIN_PO_FILES = $(addprefix admin/c2cgeoportal_admin/locale/,$(addsuffix /LC_MESSAGES/c2cgeoportal_admin.po, $(LANGUAGES)))
 APPLICATION_PO_FILES = $(addprefix geoportal/c2cgeoportal_geoportal/scaffolds/create/geoportal/+package+_geoportal/locale/,$(addsuffix /LC_MESSAGES/+package+_geoportal-client.po, $(ALL_LANGUAGES)))
+WEBCOMPONENTS_L10N_FILES = $(addprefix geoportal/c2cgeoportal_geoportal/static/locales/,$(addsuffix .json, $(ALL_LANGUAGES)))
 PYTHON_PO_FILES = $(GEOPORTAL_PO_FILES) $(ADMIN_PO_FILES)
 JAVASCRIPT_PO_FILES = $(NGEO_PO_FILES) $(GMF_PO_FILES) $(APPLICATION_PO_FILES)
-TRANSIFEX_PO_FILES = $(PYTHON_PO_FILES) $(JAVASCRIPT_PO_FILES)
+TRANSIFEX_PO_FILES = $(PYTHON_PO_FILES) $(JAVASCRIPT_PO_FILES) ${WEBCOMPONENTS_L10N_FILES}
 
 .PHONY: dependencies
 dependencies: $(TRANSIFEX_PO_FILES)
@@ -84,6 +85,11 @@ geoportal/c2cgeoportal_geoportal/scaffolds/create/geoportal/+package+_geoportal/
 	tx pull --language $* --resource ngeo.gmf-apps-$(TX_VERSION) --force
 	sed -i 's/[[:space:]]\+$$//' $@
 	test -s $@
+
+.PRECIOUS: geoportal/c2cgeoportal_geoportal/static/locales/%.json
+geoportal/c2cgeoportal_geoportal/static/locales/%.json: $(TX_DEPENDENCIES)
+	mkdir --parent $(dir $@)
+	tx pull --language $* --resource ngeo.webcomponent-$(TX_VERSION) --force
 
 geoportal/c2cgeoportal_geoportal/scaffolds/create/geoportal/+package+_geoportal/locale/en/LC_MESSAGES/+package+_geoportal-client.po:
 	@echo "Nothing to be done for $@"

--- a/doc/integrator/internationalization.rst
+++ b/doc/integrator/internationalization.rst
@@ -35,7 +35,7 @@ The files to translate are:
 .. note::
 
    All the ``#, fuzzy`` strings should be verified and the line should be removed
-   (if the line is not removed, the localisation will not be used).
+   (if the line is not removed, the localization will not be used).
 
 To update your ``po`` files, you should proceed as follows.
 
@@ -47,7 +47,7 @@ To update your ``po`` files, you should proceed as follows.
 
    You should run this command when you change something in the following:
 
-     * layer in mapfile (new or modified)
+     * layer in MapFile (new or modified)
      * layer in administration (new or modified)
      * raster layer in the vars file (new or modified)
      * print template
@@ -59,7 +59,7 @@ To update your ``po`` files, you should proceed as follows.
 
 .. note::
 
-   In mapfiles, attributes added by mapserver substitution will not be collected
+   In MapFiles, attributes added by mapserver substitution will not be collected
    for translation.
 
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -79,11 +79,20 @@ one of your JavaScript application controllers:
     const gettextCatalog = $injector.get('gettextCatalog');
     gettextCatalog.getString('My previously not collected string');
 
+~~~~~~~~~~~~~~~~~~~~~
+I18next configuration
+~~~~~~~~~~~~~~~~~~~~~
+
+In the ``vars`` in ``i18next`` you can override the default ``i18next`` configuration.
+If not provided the ``backend/loadPath`` is automatically generated.
+
+Seel also `i18next Configuration Options <https://www.i18next.com/overview/configuration-options>`_.
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Different localisation sets
+Different localization sets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you use the application with different database that contain tow different layertree you should
+If you use the application with different database that contain tow different layer tree you should
 have a suffix on your po files.
 
 Before calling the `update-po` command you should rename the po files you want to update without the suffix,

--- a/geoportal/c2cgeoportal_geoportal/__init__.py
+++ b/geoportal/c2cgeoportal_geoportal/__init__.py
@@ -413,7 +413,7 @@ def includeme(config: pyramid.config.Configurator) -> None:
 
     # Register a tween to get back the cache buster path.
     if "cache_path" not in config.get_settings():
-        config.get_settings()["cache_path"] = ["static"]
+        config.get_settings()["cache_path"] = ["static", "static-geomapfish"]
     config.add_tween("c2cgeoportal_geoportal.lib.cacheversion.CachebusterTween")
     config.add_tween("c2cgeoportal_geoportal.lib.headers.HeadersTween")
 
@@ -610,6 +610,14 @@ def includeme(config: pyramid.config.Configurator) -> None:
         path="/etc/static-ngeo",
         cache_max_age=int(config.get_settings()["default_max_age"]),
     )
+
+    # Add the c2cgeoportal static view with cache buster
+    config.add_static_view(
+        name="static-geomapfish",
+        path="c2cgeoportal_geoportal:static",
+        cache_max_age=int(config.get_settings()["default_max_age"]),
+    )
+    config.add_cache_buster("c2cgeoportal_geoportal:static", version_cache_buster)
 
     # Handles the other HTTP errors raised by the views. Without that,
     # the client receives a status=200 without content.

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/Dockerfile_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/Dockerfile_tmpl
@@ -14,7 +14,7 @@ ENV CONFIG_VARS sqlalchemy.url sqlalchemy.pool_recycle sqlalchemy.pool_size sqla
     dbsessions urllogin host_forward_host headers_whitelist headers_blacklist \
     smtp c2c.base_path welcome_email \
     lingua_extractor interfaces_config interfaces devserver_url api authentication intranet metrics pdfreport \
-    vector_tiles
+    vector_tiles i18next
 
 COPY . /tmp/config/
 

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/geoportal/CONST_config-schema.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/geoportal/CONST_config-schema.yaml
@@ -820,3 +820,4 @@ mapping:
             type: seq
             sequence:
               - type: scalar
+      i18next: *free_dict

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/geoportal/CONST_vars.yaml_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/geoportal/CONST_vars.yaml_tmpl
@@ -47,6 +47,16 @@ vars:
   intranet:
     networks: []
 
+  i18next:
+    ns:
+      - gmf
+    defaultNS: gmf
+    debug: true
+    fallbackLng: false
+    interpolation:
+      escapeValue: false
+    backend: {}
+
   interfaces_config:
     default:
       constants:
@@ -252,6 +262,7 @@ vars:
         interface: interface
         cacheVersion: cache_version
         langUrls: lang_urls
+        gmfI18nextConfiguration: i18next_configuration
         gmfTwoFactorAuth: two_factor
         gmfSearchGroups: fulltextsearch_groups
       static:

--- a/geoportal/c2cgeoportal_geoportal/views/dynamic.py
+++ b/geoportal/c2cgeoportal_geoportal/views/dynamic.py
@@ -129,6 +129,18 @@ class DynamicView:
         interface_config = self.interfaces_config[interface_name]
         lang_urls_suffix = interface_config.get("lang_urls_suffix", "")
 
+        i18next_configuration = self.settings.get("i18next", {})
+        i18next_configuration.setdefault("backend", {})
+        if "loadPath" not in i18next_configuration["backend"]:
+            path: List[str] = [
+                self.request.route_url("base").rstrip("/"),
+                "static-{{ns}}",
+                get_cache_version(),
+                "locales",
+                "{{lng}}.json",
+            ]
+            i18next_configuration["backend"]["loadPath"] = "/".join(path)
+
         dynamic = {
             "interface": interface_name,
             "cache_version": get_cache_version(),
@@ -139,6 +151,7 @@ class DynamicView:
                 )
                 for lang in self.request.registry.settings["available_locale_names"]
             },
+            "i18next_configuration": i18next_configuration,
             "fulltextsearch_groups": self._fulltextsearch_groups(),
         }
 

--- a/geoportal/tests/functional/test_dynamicview.py
+++ b/geoportal/tests/functional/test_dynamicview.py
@@ -249,6 +249,7 @@ class TestDynamicView(TestCase):
             )
         ) as config:
             config.add_static_view(name="static", path="/etc/geomapfish/static")
+            config.add_route("base", "/", static=True)
             config.add_route("test", "/test")
             config.add_route("route_with_keywords", "/test/{key1}/{key2}")
             request = DummyRequest({"interface": "test"})
@@ -267,6 +268,7 @@ class TestDynamicView(TestCase):
             )
         ) as config:
             config.add_static_view(name="static", path="/etc/geomapfish/static")
+            config.add_route("base", "/", static=True)
             config.add_route("test", "/test")
             config.add_route("route_with_segments", "/test")
             request = DummyRequest({"interface": "test"})
@@ -296,6 +298,7 @@ class TestDynamicView(TestCase):
             )
         ) as config:
             config.add_static_view(name="static", path="/etc/geomapfish/static")
+            config.add_route("base", "/", static=True)
             config.add_route("test", "/test")
             config.add_route("route_with_all", "/test/{key1}/{key2}")
             request = DummyRequest({"interface": "test"})


### PR DESCRIPTION
The idea is to offer the i18next configuration from `dynamic.json`.

With the project, can create a static view on '/static-project' with some locales file in the namespace project.

ngeo part: https://github.com/camptocamp/ngeo/pull/7646

- [x] add documentation