### PR TITLE
Bump dependency with security issue

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ verify_ssl = true
 
 [dev-packages]
 awscli = "==1.19.84"  # Work with Object storage
-Babel = "==2.7.0"  # i18n
+Babel = "==2.9.1"  # i18n
 bandit = "==1.6.2"  # lint
 beautifulsoup4 = "==4.9.0"  # admin tests
 coverage = "==5.1"  # Build coverage XML for Codacy
@@ -23,6 +23,75 @@ transifex-client = "==0.13.9"  # Makefile
 WebTest = "==2.0.34"  # admin tests
 prospector = {extras = ["with_mypy"],version = "==1.2.0"}
 mypy = "==0.761"
+# Lock dependencies
+astroid = "==2.3.3"
+attrs = "==19.3.0"
+botocore = "==1.20.84"
+certifi = "==2020.4.5.1"
+chardet = "==3.0.4"
+click = "==7.1.1"
+colorama = "==0.4.3"
+docopt = "==0.6.2"
+docutils = "==0.15.2"
+dodgy = "==0.2.1"
+gitdb = "==4.0.7"
+gitpython = "==3.1.14"
+idna = "==2.9"
+importlib-metadata = "==4.0.1"
+iniconfig = "==1.1.1"
+jmespath = "==0.10.0"
+lazy-object-proxy = "==1.4.3"
+markupsafe = "==1.1.1"
+mccabe = "==0.6.1"
+mypy-extensions = "==0.4.3"
+packaging = "==20.9"
+paste = "==3.5.0"
+pastedeploy = "==2.1.0"
+pathmatch = "==0.2.2"
+pbr = "==5.6.0"
+pep8-naming = "==0.4.1"
+pluggy = "==0.13.1"
+py = "==1.10.0"
+pyasn1 = "==0.4.8"
+pycodestyle = "==2.4.0"
+pydocstyle = "==6.0.0"
+pyflakes = "==2.0.0"
+pylint = "==2.4.4"
+pylint-celery = "==0.3"
+pylint-django = "==2.0.12"
+pylint-flask = "==0.6"
+pylint-plugin-utils = "==0.6"
+pyparsing = "==2.4.7"
+pytest = "==6.2.4"
+pytest-base-url = "==1.4.2"
+pytest-html = "==3.1.1"
+pytest-metadata = "==1.11.0"
+pytest-variables = "==1.9.0"
+python-dateutil = "==2.8.1"
+python-slugify = "==1.2.6"
+pytz = "==2019.3"
+pyyaml = "==5.4.1"
+requests = "==2.23.0"
+requirements-detector = "==0.7"
+rsa = "==3.4.2"
+s3transfer = "==0.4.2"
+selenium = "==3.141.0"
+setoptconf = "==0.2.0"
+six = "==1.14.0"
+smmap = "==4.0.0"
+snowballstemmer = "==2.1.0"
+soupsieve = "==2.2.1"
+stevedore = "==3.3.0"
+toml = "==0.10.2"
+typed-ast = "==1.4.3"
+typing = "==3.7.4.3"
+typing-extensions = "==3.10.0.0"
+unidecode = "==1.2.0"
+urllib3 = "==1.25.9"
+waitress = "==1.4.3"
+webob = "==1.8.6"
+wrapt = "==1.11.2"
+zipp = "==3.4.1"
 
 [packages]
 alembic = "==1.4.2"  # geoportal
@@ -43,7 +112,7 @@ OWSLib = "==0.19.2"  # geoportal
 papyrus = "==2.4"  # commons, geoportal
 passwordgenerator = "==1.4"  # # geoportal
 psycopg2-binary = "==2.8.5"  # geoportal
-pycryptodome = "==3.10.3"  # geoportal
+pycryptodome = "==3.11.0"  # geoportal
 pyproj = "==2.6.0"  # admin, other?
 pyotp = "==2.3.0"  # geoportal
 pyramid = "==1.10.4"  # geoportal
@@ -66,7 +135,7 @@ translationstring = "==1.3"  # admin
 "affine" = "==2.3.0"
 "argparse" = "==1.4.0"
 "attrs" = "==19.3.0"
-"babel" = "==2.8.0"
+babel = "==2.9.1"
 "beaker" = "==1.11.0"
 "beaker-redis" = "==1.1.0"
 bottle = "==0.12.19"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "616912a324817d185d733b379d3c1138b8e9db3007f4b4d256559d27d448b656"
+            "sha256": "bd351054b05eaeb0cd2b49f62e1e06b371bbf1bf9ac95f8553b2f4d9dbe1ae17"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -49,11 +49,11 @@
         },
         "babel": {
             "hashes": [
-                "sha256:1aac2ae2d0d8ea368fa90906567f5c08463d98ade155c0c4bfedd6a0f7160e38",
-                "sha256:d670ea0b10f8b723672d3a6abeb87b565b244da220d76b4dba1b66269ec152d4"
+                "sha256:ab49e12b91d937cd11f0b67cb259a57ab4ad2b59ac7a3b41d6c06c0ac5b0def9",
+                "sha256:bc0c176f9f6a994582230df350aa6e05ba2ebe4b3ac317eab29d9be5d2768da0"
             ],
             "index": "pypi",
-            "version": "==2.8.0"
+            "version": "==2.9.1"
         },
         "beaker": {
             "hashes": [
@@ -482,39 +482,39 @@
         },
         "pycryptodome": {
             "hashes": [
-                "sha256:01983746d01c9f16514d08711b27ba599ef5f66f3928215804bfe9f011427b14",
-                "sha256:03a8b3b61eee27348ee45dfee9138a6ba997e8f4f222537ae4bbafa000b88379",
-                "sha256:3a26d7b7517822e68c2f08be6b78673c545be73ed5cb83698e53f18877223b05",
-                "sha256:41b7b0603b969b9c6caf748a969ffbab145145abe89ab340676c1d1339f97f2d",
-                "sha256:4a7d6f50104f9720e095949ebb650131ba87dcf728adac7ad7bc02653190d7bd",
-                "sha256:4cfd0b7d10ecba55a26fba88bec1bc002715dae1a9814677bc5fa2cb451584eb",
-                "sha256:587e775d9993d4fcfb6d75b80fdb5b216cc0e0505a047cd35da91072df4cafb5",
-                "sha256:5aa657b1e2a5323de420266f876472e6b1e2e565a1b32e117cdb71a11fecf809",
-                "sha256:5c2fb9e5b2bcd4b3eb144d7a6fa573376b6651f3d49d03a03989bdf51ae65aa1",
-                "sha256:5f35fac714e4b5faf6d8ba4121357d6d5918d29b39846c011c3ea4d6f7fcfe56",
-                "sha256:63c5c36095fed6300a2a839fb866203b391aadf2d51845f439ddc56519edd293",
-                "sha256:6ace02faf7428615fc76ecd8aaa995809d66d230f226b27dda30ea70fb2f8e27",
-                "sha256:6d6420786210348767ee494035151344cbca7dca565e39e7bff576cbcbf5c96c",
-                "sha256:79870ea4f14ea405e2f89b7351361cb32b2fbf1b9f4bd300e224d9e98c26cecc",
-                "sha256:82c26ceb052a41cf6a3a58b4aacf2b0cd25a51fba33fb6c75918bd34669969ac",
-                "sha256:87ecb556a0137d7f8e75e62baac7ae43804ebedcbef89301fe756369201b52f5",
-                "sha256:a20b53826ed71df7c805fd0c26415a77302405f81e3c630d55447380de66b840",
-                "sha256:a480aa37e72175ca4103fa9df1358e5b32a201f65749a99dad86295fc796a8bb",
-                "sha256:a4fe3a7c01c58dae879a12af8ffecd5471da2fbe166d97685dd2ee43553b6e79",
-                "sha256:a5a83d802d43c86898ce48e17fa6beb11bf2f3ca7cebf25e10b318ddbdb36b06",
-                "sha256:a6d47b268fa0cedc9d43239bfbed6abdee99028bdc77305e20465b91cd36d8e8",
-                "sha256:a723cdd7c9f5dd8bf2ce25583fde7baec0f3f4b5dc324756adaa698a87570595",
-                "sha256:aaa572c97970f215e7ebccaa835d4b8b176afba2791e405cbdaa983953c9a0d8",
-                "sha256:aac9fed6a528d5c1afb413b4fcc619d6e1349edf52a6ce84557d0aaa2ec2037a",
-                "sha256:bbf27d63e656b7333f17234bace91142a3bd30345f57eea670c34dcadd9db28a",
-                "sha256:c0c62d1dabb1c00220dda864a580ae9fb17a0ba39509b90369878fd8f08ab1bb",
-                "sha256:c13b363b168c74af37ca29fc138b29dcb58a934582986e1abcbb2b052f616ac6",
-                "sha256:cc0cc285e237b0fe10d06c7821e3cf341b4f72da55a3b0abcec1b9de005b2bd0",
-                "sha256:d8d04f2a4bcdcdef635c6d58a8647a76ef4d9a292cd537368d23b37f24052d7d",
-                "sha256:e286e0f4c1a558603573125ffdd3a7c52e18005c01ea4ab41e98adee1fc88c5d"
+                "sha256:014c758af7fa38cab85b357a496b76f4fc9dda1f731eb28358d66fef7ad4a3e1",
+                "sha256:06162fcfed2f9deee8383fd59eaeabc7b7ffc3af50d3fad4000032deb8f700b0",
+                "sha256:0ca7a6b4fc1f9fafe990b95c8cda89099797e2cfbf40e55607f2f2f5a3355dcb",
+                "sha256:2a4bcc8a9977fee0979079cd33a9e9f0d3ddba5660d35ffe874cf84f1dd399d2",
+                "sha256:3c7ed5b07274535979c730daf5817db5e983ea80b04c22579eee8da4ca3ae4f8",
+                "sha256:4169ed515742425ff21e4bd3fabbb6994ffb64434472fb72230019bdfa36b939",
+                "sha256:428096bbf7a77e207f418dfd4d7c284df8ade81d2dc80f010e92753a3e406ad0",
+                "sha256:4ce6b09547bf2c7cede3a017f79502eaed3e819c13cdb3cb357aea1b004e4cc6",
+                "sha256:53989477044be41fa4a63da09d5038c2a34b2f4554cfea2e3933b17186ee9e19",
+                "sha256:621a90147a5e255fdc2a0fec2d56626b76b5d72ea9e60164c9a5a8976d45b0c9",
+                "sha256:6db1f9fa1f52226621905f004278ce7bd90c8f5363ffd5d7ab3755363d98549a",
+                "sha256:6eda8a3157c91ba60b26a07bedd6c44ab8bda6cd79b6b5ea9744ba62c39b7b1e",
+                "sha256:75e78360d1dd6d02eb288fd8275bb4d147d6e3f5337935c096d11dba1fa84748",
+                "sha256:7ff701fc283412e651eaab4319b3cd4eaa0827e94569cd37ee9075d5c05fe655",
+                "sha256:8f3a60926be78422e662b0d0b18351b426ce27657101c8a50bad80300de6a701",
+                "sha256:a843350d08c3d22f6c09c2f17f020d8dcfa59496165d7425a3fba0045543dda7",
+                "sha256:ae29fcd56152f417bfba50a36a56a7a5f9fb74ff80bab98704cac704de6568ab",
+                "sha256:ae31cb874f6f0cedbed457c6374e7e54d7ed45c1a4e11a65a9c80968da90a650",
+                "sha256:b33c9b3d1327d821e28e9cc3a6512c14f8b17570ddb4cfb9a52247ed0fcc5d8b",
+                "sha256:b59bf823cfafde8ef1105d8984f26d1694dff165adb7198b12e3e068d7999b15",
+                "sha256:bc3c61ff92efdcc14af4a7b81da71d849c9acee51d8fd8ac9841a7620140d6c6",
+                "sha256:ce81b9c6aaa0f920e2ab05eb2b9f4ccd102e3016b2f37125593b16a83a4b0cc2",
+                "sha256:d7e5f6f692421e5219aa3b545eb0cffd832cd589a4b9dcd4a5eb4260e2c0d68a",
+                "sha256:da796e9221dda61a0019d01742337eb8a322de8598b678a4344ca0a436380315",
+                "sha256:ead516e03dfe062aefeafe4a29445a6449b0fc43bc8cb30194b2754917a63798",
+                "sha256:ed45ef92d21db33685b789de2c015e9d9a18a74760a8df1fc152faee88cdf741",
+                "sha256:f19edd42368e9057c39492947bb99570dc927123e210008f2af7cf9b505c6892",
+                "sha256:f9bad2220b80b4ed74f089db012ab5ab5419143a33fad6c8aedcc2a9341eac70",
+                "sha256:fce7e22d96030b35345637c563246c24d4513bd3b413e1c40293114837ab8912",
+                "sha256:ffd0cac13ff41f2d15ed39dc6ba1d2ad88dd2905d656c33d8235852f5d6151fd"
             ],
             "index": "pypi",
-            "version": "==3.10.3"
+            "version": "==3.11.0"
         },
         "pygments": {
             "hashes": [
@@ -925,7 +925,7 @@
                 "sha256:71ea07f44df9568a75d0f354c49143a4575d90645e9fead6dfb52c26a85ed13a",
                 "sha256:840947ebfa8b58f318d42301cf8c0a20fd794a33b61cc4638e28e9e61ba32f42"
             ],
-            "markers": "python_version >= '3.5'",
+            "index": "pypi",
             "version": "==2.3.3"
         },
         "attrs": {
@@ -946,11 +946,11 @@
         },
         "babel": {
             "hashes": [
-                "sha256:1aac2ae2d0d8ea368fa90906567f5c08463d98ade155c0c4bfedd6a0f7160e38",
-                "sha256:d670ea0b10f8b723672d3a6abeb87b565b244da220d76b4dba1b66269ec152d4"
+                "sha256:ab49e12b91d937cd11f0b67cb259a57ab4ad2b59ac7a3b41d6c06c0ac5b0def9",
+                "sha256:bc0c176f9f6a994582230df350aa6e05ba2ebe4b3ac317eab29d9be5d2768da0"
             ],
             "index": "pypi",
-            "version": "==2.8.0"
+            "version": "==2.9.1"
         },
         "bandit": {
             "hashes": [
@@ -974,7 +974,7 @@
                 "sha256:75e1397b80aa8757a26636b949eebd20b3cf67e8f1ed80dc01170907e06ea45d",
                 "sha256:bc59eb748fcb07835613ebea6dcc2600ae1a8be0fae30e40b9c1e81b73262296"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "index": "pypi",
             "version": "==1.20.84"
         },
         "certifi": {
@@ -1006,7 +1006,7 @@
                 "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff",
                 "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "index": "pypi",
             "version": "==0.4.3"
         },
         "coverage": {
@@ -1050,6 +1050,7 @@
             "hashes": [
                 "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
             ],
+            "index": "pypi",
             "version": "==0.6.2"
         },
         "docutils": {
@@ -1058,7 +1059,7 @@
                 "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827",
                 "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "index": "pypi",
             "version": "==0.15.2"
         },
         "dodgy": {
@@ -1066,6 +1067,7 @@
                 "sha256:28323cbfc9352139fdd3d316fa17f325cc0e9ac74438cbba51d70f9b48f86c3a",
                 "sha256:51f54c0fd886fa3854387f354b19f429d38c04f984f38bc572558b703c0542a6"
             ],
+            "index": "pypi",
             "version": "==0.2.1"
         },
         "flake8": {
@@ -1089,7 +1091,7 @@
                 "sha256:6c4cc71933456991da20917998acbe6cf4fb41eeaab7d6d67fbc05ecd4c865b0",
                 "sha256:96bf5c08b157a666fec41129e6d327235284cca4c81e92109260f353ba138005"
             ],
-            "markers": "python_version >= '3.4'",
+            "index": "pypi",
             "version": "==4.0.7"
         },
         "gitpython": {
@@ -1097,7 +1099,7 @@
                 "sha256:3283ae2fba31c913d857e12e5ba5f9a7772bbc064ae2bb09efafa71b0dd4939b",
                 "sha256:be27633e7509e58391f10207cd32b2a6cf5b908f92d9cd30da2e514e1137af61"
             ],
-            "markers": "python_version >= '3.4'",
+            "index": "pypi",
             "version": "==3.1.14"
         },
         "idna": {
@@ -1113,7 +1115,7 @@
                 "sha256:8c501196e49fb9df5df43833bdb1e4328f64847763ec8a50703148b73784d581",
                 "sha256:d7eb1dea6d6a6086f8be21784cc9e3bcfa55872b52309bc5fad53a8ea444465d"
             ],
-            "markers": "python_version < '3.8'",
+            "index": "pypi",
             "version": "==4.0.1"
         },
         "iniconfig": {
@@ -1121,6 +1123,7 @@
                 "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
                 "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
             ],
+            "index": "pypi",
             "version": "==1.1.1"
         },
         "isort": {
@@ -1144,7 +1147,7 @@
                 "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9",
                 "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "index": "pypi",
             "version": "==0.10.0"
         },
         "lazy-object-proxy": {
@@ -1171,7 +1174,7 @@
                 "sha256:efa1909120ce98bbb3777e8b6f92237f5d5c8ea6758efea36a473e1d38f7d3e4",
                 "sha256:f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "index": "pypi",
             "version": "==1.4.3"
         },
         "lingua": {
@@ -1245,6 +1248,7 @@
                 "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
                 "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
             ],
+            "index": "pypi",
             "version": "==0.6.1"
         },
         "mypy": {
@@ -1272,6 +1276,7 @@
                 "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
                 "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
             ],
+            "index": "pypi",
             "version": "==0.4.3"
         },
         "packaging": {
@@ -1279,7 +1284,7 @@
                 "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5",
                 "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "index": "pypi",
             "version": "==20.9"
         },
         "paste": {
@@ -1287,6 +1292,7 @@
                 "sha256:1b095c42dc91d426f3ae85101796b14d265887f8f36f3aad143a5f29effdc39d",
                 "sha256:8e08200a570f7e29dfafd4eea0e1b38a6193cfda6446bb515db74250b632c53b"
             ],
+            "index": "pypi",
             "version": "==3.5.0"
         },
         "pastedeploy": {
@@ -1309,6 +1315,7 @@
             "hashes": [
                 "sha256:ea020e5e20114b2587eba2c9f909a0b9aa449e55522ce80bfac7da0fe695984d"
             ],
+            "index": "pypi",
             "version": "==0.2.2"
         },
         "pbr": {
@@ -1316,7 +1323,7 @@
                 "sha256:42df03e7797b796625b1029c0400279c7c34fd7df24a7d7818a1abb5b38710dd",
                 "sha256:c68c661ac5cc81058ac94247278eeda6d2e6aecb3e227b0387c30d277e7ef8d4"
             ],
-            "markers": "python_version >= '2.6'",
+            "index": "pypi",
             "version": "==5.6.0"
         },
         "pep8-naming": {
@@ -1324,6 +1331,7 @@
                 "sha256:1b419fa45b68b61cd8c5daf4e0c96d28915ad14d3d5f35fcc1e7e95324a33a2e",
                 "sha256:4eedfd4c4b05e48796f74f5d8628c068ff788b9c2b08471ad408007fc6450e5a"
             ],
+            "index": "pypi",
             "version": "==0.4.1"
         },
         "pluggy": {
@@ -1331,7 +1339,7 @@
                 "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
                 "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "index": "pypi",
             "version": "==0.13.1"
         },
         "polib": {
@@ -1357,7 +1365,7 @@
                 "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
                 "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "index": "pypi",
             "version": "==1.10.0"
         },
         "pyasn1": {
@@ -1376,6 +1384,7 @@
                 "sha256:e89bf84b5437b532b0803ba5c9a5e054d21fec423a89952a74f87fa2c9b7bce2",
                 "sha256:fec3e9d8e36808a28efb59b489e4528c10ad0f480e57dcc32b4de5c9d8c9fdf3"
             ],
+            "index": "pypi",
             "version": "==0.4.8"
         },
         "pycodestyle": {
@@ -1384,6 +1393,7 @@
                 "sha256:cbc619d09254895b0d12c2c691e237b2e91e9b2ecf5e84c26b35400f93dcfb83",
                 "sha256:cbfca99bd594a10f674d0cd97a3d802a1fdef635d4361e1a2658de47ed261e3a"
             ],
+            "index": "pypi",
             "version": "==2.4.0"
         },
         "pydocstyle": {
@@ -1391,7 +1401,7 @@
                 "sha256:164befb520d851dbcf0e029681b91f4f599c62c5cd8933fd54b1bfbd50e89e1f",
                 "sha256:d4449cf16d7e6709f63192146706933c7a334af7c0f083904799ccb851c50f6d"
             ],
-            "markers": "python_version >= '3.6'",
+            "index": "pypi",
             "version": "==6.0.0"
         },
         "pyflakes": {
@@ -1399,6 +1409,7 @@
                 "sha256:9a7662ec724d0120012f6e29d6248ae3727d821bba522a0e6b356eff19126a49",
                 "sha256:f661252913bc1dbe7fcfcbf0af0db3f42ab65aabd1a6ca68fe5d466bace94dae"
             ],
+            "index": "pypi",
             "version": "==2.0.0"
         },
         "pykwalify": {
@@ -1414,13 +1425,14 @@
                 "sha256:3db5468ad013380e987410a8d6956226963aed94ecb5f9d3a28acca6d9ac36cd",
                 "sha256:886e6afc935ea2590b462664b161ca9a5e40168ea99e5300935f6591ad467df4"
             ],
-            "markers": "python_version >= '3.5'",
+            "index": "pypi",
             "version": "==2.4.4"
         },
         "pylint-celery": {
             "hashes": [
                 "sha256:41e32094e7408d15c044178ea828dd524beedbdbe6f83f712c5e35bde1de4beb"
             ],
+            "index": "pypi",
             "version": "==0.3"
         },
         "pylint-django": {
@@ -1428,12 +1440,14 @@
                 "sha256:9bdb0e022b19881218a25ffb8ad05e83b83bc5cdbc58e5ee8ffbe99965193f6c",
                 "sha256:9eea6a026eaa5ecfad5fed7a33faf77ef55a43cc78afbcaf2f6ddd071156b3f8"
             ],
+            "index": "pypi",
             "version": "==2.0.12"
         },
         "pylint-flask": {
             "hashes": [
                 "sha256:f4d97de2216bf7bfce07c9c08b166e978fe9f2725de2a50a9845a97de7e31517"
             ],
+            "index": "pypi",
             "version": "==0.6"
         },
         "pylint-plugin-utils": {
@@ -1441,6 +1455,7 @@
                 "sha256:2f30510e1c46edf268d3a195b2849bd98a1b9433229bb2ba63b8d776e1fc4d0a",
                 "sha256:57625dcca20140f43731311cd8fd879318bf45a8b0fd17020717a8781714a25a"
             ],
+            "index": "pypi",
             "version": "==0.6"
         },
         "pyparsing": {
@@ -1456,7 +1471,7 @@
                 "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b",
                 "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"
             ],
-            "markers": "python_version >= '3.6'",
+            "index": "pypi",
             "version": "==6.2.4"
         },
         "pytest-base-url": {
@@ -1464,6 +1479,7 @@
                 "sha256:7f1f32e08c2ee751e59e7f5880235b46e83496adc5cba5a01ca218c6fe81333d",
                 "sha256:8b6523a1a3af73c317bdae97b722dfb55a7336733d1ad411eb4a4931347ba77a"
             ],
+            "index": "pypi",
             "version": "==1.4.2"
         },
         "pytest-cov": {
@@ -1479,7 +1495,7 @@
                 "sha256:3ee1cf319c913d19fe53aeb0bc400e7b0bc2dbeb477553733db1dad12eb75ee3",
                 "sha256:b7f82f123936a3f4d2950bc993c2c1ca09ce262c9ae12f9ac763a2401380b455"
             ],
-            "markers": "python_version >= '3.6'",
+            "index": "pypi",
             "version": "==3.1.1"
         },
         "pytest-metadata": {
@@ -1487,7 +1503,7 @@
                 "sha256:576055b8336dd4a9006dd2a47615f76f2f8c30ab12b1b1c039d99e834583523f",
                 "sha256:71b506d49d34e539cc3cfdb7ce2c5f072bea5c953320002c95968e0238f8ecf1"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "index": "pypi",
             "version": "==1.11.0"
         },
         "pytest-selenium": {
@@ -1503,6 +1519,7 @@
                 "sha256:ccf4afcd70de1f5f18b4463758a19f24647a9def1805f675e80db851c9e00ac0",
                 "sha256:f79851e4c92a94c93d3f1d02377b5ac97cc8800392e87d108d2cbfda774ecc2a"
             ],
+            "index": "pypi",
             "version": "==1.9.0"
         },
         "python-dateutil": {
@@ -1517,6 +1534,7 @@
             "hashes": [
                 "sha256:7723daf30996db26573176bddcdf5fcb98f66dc70df05c9cb29f2c79b8193245"
             ],
+            "index": "pypi",
             "version": "==1.2.6"
         },
         "pytz": {
@@ -1575,6 +1593,7 @@
             "hashes": [
                 "sha256:0d1e13e61ed243f9c3c86e6cbb19980bcb3a0e0619cde2ec1f3af70fdbee6f7b"
             ],
+            "index": "pypi",
             "version": "==0.7"
         },
         "rsa": {
@@ -1582,26 +1601,30 @@
                 "sha256:25df4e10c263fb88b5ace923dd84bf9aa7f5019687b5e55382ffcdb8bede9db5",
                 "sha256:43f682fea81c452c98d09fc316aae12de6d30c4b5c84226642cf8f8fd1c93abd"
             ],
+            "index": "pypi",
             "version": "==3.4.2"
         },
         "s3transfer": {
             "hashes": [
-                "sha256:35627b86af8ff97e7ac27975fe0a98a312814b46c6333d8a6b889627bcd80994",
-                "sha256:efa5bd92a897b6a8d5c1383828dca3d52d0790e0756d49740563a3fb6ed03246"
+                "sha256:9b3752887a2880690ce628bc263d6d13a3864083aeacff4890c1c9839a5eb0bc",
+                "sha256:cb022f4b16551edebbb31a377d3f09600dbada7363d8c5db7976e7f47732e1b2"
             ],
-            "version": "==0.3.7"
+            "index": "pypi",
+            "version": "==0.4.2"
         },
         "selenium": {
             "hashes": [
                 "sha256:2d7131d7bc5a5b99a2d9b04aaf2612c411b03b8ca1b1ee8d3de5845a9be2cb3c",
                 "sha256:deaf32b60ad91a4611b98d8002757f29e6f2c2d5fcaf202e1c9ad06d6772300d"
             ],
+            "index": "pypi",
             "version": "==3.141.0"
         },
         "setoptconf": {
             "hashes": [
                 "sha256:5b0b5d8e0077713f5d5152d4f63be6f048d9a1bb66be15d089a11c898c3cf49c"
             ],
+            "index": "pypi",
             "version": "==0.2.0"
         },
         "six": {
@@ -1617,7 +1640,7 @@
                 "sha256:7e65386bd122d45405ddf795637b7f7d2b532e7e401d46bbe3fb49b9986d5182",
                 "sha256:a9a7479e4c572e2e775c404dcd3080c8dc49f39918c2cf74913d30c4c478e3c2"
             ],
-            "markers": "python_version >= '3.5'",
+            "index": "pypi",
             "version": "==4.0.0"
         },
         "snowballstemmer": {
@@ -1625,6 +1648,7 @@
                 "sha256:b51b447bea85f9968c13b650126a888aabd4cb4463fca868ec596826325dedc2",
                 "sha256:e997baa4f2e9139951b6f4c631bad912dfd3c792467e2f03d7239464af90e914"
             ],
+            "index": "pypi",
             "version": "==2.1.0"
         },
         "soupsieve": {
@@ -1632,7 +1656,7 @@
                 "sha256:052774848f448cf19c7e959adf5566904d525f33a3f8b6ba6f6f8f26ec7de0cc",
                 "sha256:c2c1c2d44f158cdbddab7824a9af8c4f83c76b1e23e049479aa432feb6c4c23b"
             ],
-            "markers": "python_version >= '3.6'",
+            "index": "pypi",
             "version": "==2.2.1"
         },
         "stevedore": {
@@ -1640,7 +1664,7 @@
                 "sha256:3a5bbd0652bf552748871eaa73a4a8dc2899786bc497a2aa1fcb4dcdb0debeee",
                 "sha256:50d7b78fbaf0d04cd62411188fa7eedcb03eb7f4c4b37005615ceebe582aa82a"
             ],
-            "markers": "python_version >= '3.6'",
+            "index": "pypi",
             "version": "==3.3.0"
         },
         "toml": {
@@ -1648,7 +1672,7 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "index": "pypi",
             "version": "==0.10.2"
         },
         "transifex-client": {
@@ -1691,7 +1715,7 @@
                 "sha256:f8afcf15cc511ada719a88e013cec87c11aff7b91f019295eb4530f96fe5ef2f",
                 "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"
             ],
-            "markers": "python_version < '3.8' and implementation_name == 'cpython'",
+            "index": "pypi",
             "version": "==1.4.3"
         },
         "typing": {
@@ -1699,7 +1723,7 @@
                 "sha256:1187fb9c82fd670d10aa07bbb6cfcfe4bdda42d6fab8d5134f04e8c4d0b71cc9",
                 "sha256:283d868f5071ab9ad873e5e52268d611e851c870a2ba354193026f2dfb29d8b5"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "index": "pypi",
             "version": "==3.7.4.3"
         },
         "typing-extensions": {
@@ -1708,7 +1732,7 @@
                 "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342",
                 "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"
             ],
-            "markers": "python_version < '3.8'",
+            "index": "pypi",
             "version": "==3.10.0.0"
         },
         "unidecode": {
@@ -1716,6 +1740,7 @@
                 "sha256:12435ef2fc4cdfd9cf1035a1db7e98b6b047fe591892e81f34e94959591fad00",
                 "sha256:8d73a97d387a956922344f6b74243c2c6771594659778744b2dbdaad8f6b727d"
             ],
+            "index": "pypi",
             "version": "==1.2.0"
         },
         "urllib3": {
@@ -1754,6 +1779,7 @@
             "hashes": [
                 "sha256:565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1"
             ],
+            "index": "pypi",
             "version": "==1.11.2"
         },
         "zipp": {
@@ -1761,7 +1787,7 @@
                 "sha256:3607921face881ba3e026887d8150cca609d517579abe052ac81fc5aeffdbd76",
                 "sha256:51cb66cc54621609dd593d1787f286ee42a5c0adbb4b29abea5a63edc3e03098"
             ],
-            "markers": "python_version >= '3.6'",
+            "index": "pypi",
             "version": "==3.4.1"
         }
     }


### PR DESCRIPTION
```
  +==============================================================================+
  |                                                                              |
  |                               /$$$$$$            /$$                         |
  |                              /$$__  $$          | $$                         |
  |           /$$$$$$$  /$$$$$$ | $$  \__//$$$$$$  /$$$$$$   /$$   /$$           |
  |          /$$_____/ |____  $$| $$$$   /$$__  $$|_  $$_/  | $$  | $$           |
  |         |  $$$$$$   /$$$$$$$| $$_/  | $$$$$$$$  | $$    | $$  | $$           |
  |          \____  $$ /$$__  $$| $$    | $$_____/  | $$ /$$| $$  | $$           |
  |          /$$$$$$$/|  $$$$$$$| $$    |  $$$$$$$  |  $$$$/|  $$$$$$$           |
  |         |_______/  \_______/|__/     \_______/   \___/   \____  $$           |
  |                                                          /$$  | $$           |
  |                                                         |  $$$$$$/           |
  |  by pyup.io                                              \______/            |
  |                                                                              |
  +==============================================================================+
  | REPORT                                                                       |
  | checked 80 packages, using free DB (updated once a month)                    |
  +============================+===========+==========================+==========+
  | package                    | installed | affected                 | ID       |
  +============================+===========+==========================+==========+
  | babel                      | 2.8.0     | <2.9.1                   | 42203    |
  +==============================================================================+
  | Babel 2.9.1 includes a fix for CVE-2021-42771: Babel.Locale in Babel before  |
  | 2.9.1 allows attackers to load arbitrary locale .dat files (containing       |
  | serialized Python objects) via directory traversal, leading to code          |
  | execution.                                                                   |
  | https://github.com/python-babel/babel/pull/782                               |
  | https://lists.debian.org/debian-lts/2021/10/msg00040.html                    |
  | https://www.tenable.com/security/research/tra-2021-14                        |
  | https://lists.debian.org/debian-lts-announce/2021/10/msg00018.html           |
  +==============================================================================+
  | pycryptodome               | 3.10.3    | <3.11.0                  | 42084    |
  +==============================================================================+
  | Pycryptodome version 3.11.0 includes a fix for the DSA construction          |
  | algorithm. Modulus "p" primality check wasn't working.                       |
  | https://github.com/Legrandin/pycryptodome/pull/557/commits/183f8d1c7a5e145e7 |
  | 8b86fb54da7e327a277d9c6                                                      |
  +==============================================================================+
```