### PR TITLE
Typo changelog

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/CONST_CHANGELOG.txt_tmpl
@@ -263,7 +263,7 @@ some `docker build`, and `docker-compose` commands.
 Main Changes
 ------------
 
-Environement variables are now stored in the env.default and env.project files.
+Environment variables are now stored in the env.default and env.project files.
 
 The migration process will do the following UI-related changes (visible in the html diffs):
 1. Predefined values in editing form


### PR DESCRIPTION
Fix for 2.5.
It was fixed directly in the backports of 2.6/master in the previous PR  #8860.