### PR TITLE
Move the interface based on a canvas to the config Docker image

### DIFF
--- a/admin/docker-compose.yaml
+++ b/admin/docker-compose.yaml
@@ -1,7 +1,7 @@
 ---
 # Used for development: please do not remove this file
 
-version: '2'
+version: '2.3'
 
 services:
   db:

--- a/bin/import-ngeo-apps
+++ b/bin/import-ngeo-apps
@@ -31,11 +31,10 @@
 import re
 import sys
 from argparse import ArgumentParser
-from json import dumps
-from urllib.parse import parse_qsl
+from typing import Any
 
 
-def _sub(pattern, repl, string, count=0, flags=0, required=True):
+def _sub(pattern: str, repl: str, string: str, count: int = 0, flags: Any = 0, required: bool = True) -> str:
     new_string = re.sub(pattern, repl, string, count=count, flags=flags)
     if required and new_string == string:
         print("Unable to find the pattern:")
@@ -46,112 +45,150 @@ def _sub(pattern, repl, string, count=0, flags=0, required=True):
     return new_string
 
 
-def _subs(subs, string):
-    for pattern, repl in subs:
-        if repl is False:
-            if re.search(pattern, string) is not None:
-                return string
-        else:
-            new_string = re.sub(pattern, repl, string)
-            if new_string != string:
-                return new_string
-    print("Unable to find the patterns:")
-    print("\n".join([p for p, r in subs]))
-    print("in")
-    print(string)
-    sys.exit(1)
-
-
-class _RouteDest:
-    def __init__(self, constant, route):
-        self.constant = constant
-        self.route = route
-
-    def __call__(self, matches):
-        query_string = matches.group(1)
-        query = ""
-        if len(query_string) > 0:
-            query = f", _query={dumps(dict(parse_qsl(query_string)))!s}"
-        return r"module.constant('{0!s}', '${{request.route_url('{1!s}'{2!s}) | n}}');".format(
-            self.constant, self.route, query
-        )
-
-
-def main():
-    """
-    Import the ngeo apps files
-    """
+def main() -> None:
+    """Import the ngeo apps files."""
 
     parser = ArgumentParser(description="Import ngeo apps files")
 
     parser.add_argument("--html", action="store_true", help="Import the html template")
     parser.add_argument("--js", action="store_true", help="Import the javascript controller")
+    # Replace the dynamicUrl and interface meta by dynamically generated variable.
+    # Replace the CSS and Javascript entrypints by dynamically generate variable.
+    # Replace the spinner.svg and the background-layer-button.png by dynamically generate variable.
+    parser.add_argument("--canvas", action="store_true", help="Import interface base on canvas")
     parser.add_argument("interface", metavar="INTERFACE", help="The interface we import")
     parser.add_argument("src", metavar="SRC", help="The ngeo source file")
     parser.add_argument("dst", metavar="DST", help="The destination file")
 
     args = parser.parse_args()
 
-    with open(args.src) as src:
+    with open(args.src, encoding="utf-8") as src:
         data = src.read()
         data = re.sub(r"{{", r"\\{\\{", data)
         data = re.sub(r"}}", r"\\}\\}", data)
 
         if args.html:
-            data = _sub(
-                re.escape(
-                    '<link rel="shortcut icon" href="<%=require("./image/favicon.ico")%>" crossorigin="anonymous" />'
-                ),
-                r'<link rel="shortcut icon" href="{entry_point}static/{cache_version}/images/'
-                r'favicon.ico" crossorigin="anonymous">'.format(
-                    entry_point="<%= htmlWebpackPlugin.options.vars.entry_point %>",
-                    cache_version="<%= htmlWebpackPlugin.options.vars.cache_version %>",
-                ),
-                data,
-            )
-            data = _sub(
-                re.escape('<script src="../../../dist/vendor.js') + r".*",
-                r'<script src="{entry_point}static-ngeo/vendor.js?{cache_version}" crossorigin="anonymous"></script>'.format(
-                    entry_point="<%= htmlWebpackPlugin.options.vars.entry_point %>",
-                    cache_version="<%= htmlWebpackPlugin.options.vars.cache_version %>",
-                ),
-                data,
-                required=False,
-            )
-            data = _sub(
-                re.escape('<meta name="dynamicUrl" content="https://geomapfish-demo-')
-                + ".*"
-                + re.escape('.camptocamp.com/dynamic.json">'),
-                '<meta name="dynamicUrl" content="{entry_point}dynamic.json">'.format(
-                    entry_point="<%= htmlWebpackPlugin.options.vars.entry_point %>",
-                ),
-                data,
-            )
-            data = _sub(
-                re.escape("</head>"),
-                '  <link href="{entry_point}static/{cache_version}/css/{interface}.css" rel="stylesheet" crossorigin="anonymous">\n'
-                "  </head>".format(
-                    entry_point="<%= htmlWebpackPlugin.options.vars.entry_point %>",
-                    cache_version="<%= htmlWebpackPlugin.options.vars.cache_version %>",
-                    interface=args.interface,
-                ),
-                data,
-            )
-            data = _sub(
-                re.escape('<gmf-header gmf-header-template-url="desktop')
-                + "(_alt)?"
-                + re.escape('/header.html"></gmf-header>'),
-                '<gmf-header gmf-header-template-url="{entry_point}static/{cache_version}/header.html"></gmf-header>'.format(
-                    entry_point="<%= htmlWebpackPlugin.options.vars.entry_point %>",
-                    cache_version="<%= htmlWebpackPlugin.options.vars.cache_version %>",
-                ),
-                data,
-                required=False,
-            )
+            if args.canvas:
+                data = _sub(
+                    '<meta name="dynamicUrl" .*</head>$',
+                    "\n".join(
+                        [
+                            '<link rel="shortcut icon" '
+                            "href=\"${request.static_url('/etc/geomapfish/static/images/favicon.ico')}\" "
+                            'crossorigin="anonymous" />',
+                            "<style>",
+                            "  .spinner-loading-mask {",
+                            "    width: 1em;",
+                            "  }",
+                            "</style>",
+                            "    ${header |n}",
+                            "  </head>",
+                        ]
+                    ),
+                    data,
+                    flags=re.MULTILINE | re.DOTALL,
+                )
+                data = _sub(
+                    "</gmf-([a-z]+)-canvas>.*</body>$",
+                    "\n".join(
+                        [
+                            "</gmf-\\1-canvas>",
+                            "    <script nomodule>",
+                            "      alert(",
+                            "        'Your browser is not supported, please use a recent version of "
+                            "Firefox, Chrome or Edge.\\n\\n' +",
+                            "        \"Votre navigateur n'est pas supporté, veuillez utiliser une version "
+                            'récente de Firefox, Chrome or Edge.\\n\\n" +',
+                            "        'Ihr Browser wird nicht unterstützt, bitte verwenden Sie eine aktuelle "
+                            "Version von Firefox, Chrome oder Edge.'",
+                            "      );",
+                            "    </script>",
+                            "    ${footer |n}",
+                            "  </body>",
+                        ]
+                    ),
+                    data,
+                    flags=re.MULTILINE | re.DOTALL,
+                )
+                data = _sub(
+                    re.escape("<%=require('gmf/icons/spinner.svg?viewbox&height=1em')%>"),
+                    "${static['spinner'] |n}",
+                    data,
+                )
+                data = _sub(
+                    re.escape("<%=require('./image/background-layer-button.png')%>"),
+                    "${static['background-layer-button']}",
+                    data,
+                )
+
+            else:
+                data = _sub(
+                    re.escape(
+                        '<link rel="shortcut icon" href="<%=require("./image/favicon.ico")%>" '
+                        'crossorigin="anonymous" />'
+                    ),
+                    (
+                        r'<link rel="shortcut icon" href="{entry_point}static/{cache_version}/images/'
+                        r'favicon.ico" crossorigin="anonymous">'
+                    ).format(
+                        entry_point="<%= htmlWebpackPlugin.options.vars.entry_point %>",
+                        cache_version="<%= htmlWebpackPlugin.options.vars.cache_version %>",
+                    ),
+                    data,
+                )
+                data = _sub(
+                    re.escape('<script src="../../../dist/vendor.js') + r".*",
+                    (
+                        r'<script src="{entry_point}static-ngeo/vendor.js?{cache_version}" '
+                        r'crossorigin="anonymous"></script>'
+                    ).format(
+                        entry_point="<%= htmlWebpackPlugin.options.vars.entry_point %>",
+                        cache_version="<%= htmlWebpackPlugin.options.vars.cache_version %>",
+                    ),
+                    data,
+                    required=False,
+                )
+                data = _sub(
+                    re.escape('<meta name="dynamicUrl" content="https://geomapfish-demo-')
+                    + ".*"
+                    + re.escape('.camptocamp.com/dynamic.json">'),
+                    '<meta name="dynamicUrl" content="{entry_point}dynamic.json">'.format(
+                        entry_point="<%= htmlWebpackPlugin.options.vars.entry_point %>",
+                    ),
+                    data,
+                )
+                data = _sub(
+                    re.escape("</head>"),
+                    (
+                        '  <link href="{entry_point}static/{cache_version}/css/{interface}.css" '
+                        'rel="stylesheet" crossorigin="anonymous">\n'
+                        "  </head>"
+                    ).format(
+                        entry_point="<%= htmlWebpackPlugin.options.vars.entry_point %>",
+                        cache_version="<%= htmlWebpackPlugin.options.vars.cache_version %>",
+                        interface=args.interface,
+                    ),
+                    data,
+                )
+                data = _sub(
+                    re.escape('<gmf-header gmf-header-template-url="desktop')
+                    + "(_alt)?"
+                    + re.escape('/header.html"></gmf-header>'),
+                    (
+                        '<gmf-header gmf-header-template-url="{entry_point}static/{cache_version}/'
+                        'header.html"></gmf-header>'
+                    ).format(
+                        entry_point="<%= htmlWebpackPlugin.options.vars.entry_point %>",
+                        cache_version="<%= htmlWebpackPlugin.options.vars.cache_version %>",
+                    ),
+                    data,
+                    required=False,
+                )
+
         else:
             data = re.sub("app", "{{package}}", data)
 
-        with open(args.dst, "wt") as dst:
+        with open(args.dst, "wt", encoding="utf-8") as dst:
             dst.write(data)
 
 

--- a/build.mk
+++ b/build.mk
@@ -22,7 +22,7 @@ APPS_FILES = $(APPS_HTML_FILES) $(APPS_JS_FILES) $(APPS_SASS_FILES) \
 	$(APPS_PACKAGE_PATH)/static-ngeo/js/apps/image/logo.svg \
 	$(STATIC_PATH)/images/favicon.ico
 
-APPS_ALT += desktop_alt mobile_alt oeedit
+APPS_ALT += mobile_alt oeedit
 APPS_PACKAGE_PATH_ALT = geoportal/c2cgeoportal_geoportal/scaffolds/advance_update/CONST_create_template/geoportal/+package+_geoportal
 APPS_HTML_FILES_ALT = $(addprefix $(APPS_PACKAGE_PATH_ALT)/static-ngeo/js/apps/, $(addsuffix .html.ejs_tmpl, $(APPS_ALT)))
 APPS_JS_FILES_ALT += $(addprefix $(APPS_PACKAGE_PATH_ALT)/static-ngeo/js/apps/Controller, $(addsuffix .js_tmpl, $(APPS_ALT)))

--- a/ci/create-new-project
+++ b/ci/create-new-project
@@ -58,8 +58,7 @@ echo 'PGPASSWORD=www-data' >> env.project
 
 if [ $BASE_APP == true ]
 then
-    find -name *desktop_alt*
-    for interface in desktop_alt mobile_alt oeedit
+    for interface in mobile_alt oeedit
     do
         for file in \
             geoportal/${PACKAGE}_geoportal/static-ngeo/js/apps/${interface}.html.ejs \
@@ -69,8 +68,8 @@ then
         do
             cp CONST_create_template/${file} ${file}
         done
-        sed -i '1iNGEO_INTERFACES ?= desktop mobile iframe_api desktop_alt mobile_alt oeedit' geoportal/Makefile
     done
+    sed -i '1iNGEO_INTERFACES ?= desktop mobile iframe_api mobile_alt oeedit' geoportal/Makefile
 fi
 
 # Init Git repository
@@ -86,7 +85,6 @@ c2cciutils-checks --fix --check=black
 c2cciutils-checks --fix --check=prettier
 mv ci/config.yaml{_,}
 
-git diff
 git add --all
 git commit --quiet --message='Initial commit'
 git clean -fX

--- a/ci/docker-compose.override.yaml
+++ b/ci/docker-compose.override.yaml
@@ -1,7 +1,7 @@
 ---
 # The project Docker compose file for development.
 
-version: '2.0'
+version: '2.3'
 
 services:
   geoportal:
@@ -28,7 +28,7 @@ services:
       file: docker-compose-lib.yaml
       service: db
     ports:
-      - 5432:5432
+      - 54321:5432
     volumes:
       - postgresql_data:/var/lib/postgresql/data
       - ./ci/test-app-db:/docker-entrypoint-initdb.d

--- a/ci/test-app
+++ b/ci/test-app
@@ -11,11 +11,15 @@ cp -r ci/test-external-db ${HOME}/workspace/testgeomapfishapp/ci/
 PROJECT_DIR=$(pwd)
 
 cd ${HOME}/workspace/testgeomapfishapp/
+
+folder=geoportal/interfaces
+cp -r CONST_create_template/${folder} ${folder}
+
 c2cciutils-checks
 cp ${PROJECT_DIR}/ci/project-config.yaml ci/config.yaml
 c2cciutils-checks
-./build
-docker-compose down
+CI=true ./build
+docker-compose down --volumes
 docker-compose up -d
 docker-compose exec -T geoportal bash -c 'PGHOST=externaldb PGDATABASE=test wait-db;'
 docker-compose exec -T geoportal wait-db
@@ -26,27 +30,24 @@ docker-compose exec -T geoportal create-demo-theme
 make update-po
 docker-compose exec -T geoportal theme2fts
 
-# Commit the l10n files modifications
-# To prevent fail on modification files check
-#git diff
-#git add geoportal/testgeomapfishapp_geoportal/locale/*/LC_MESSAGES/testgeomapfishapp_geoportal-*.po
-#git commit -m "Upgrade the po files"
-
 ci/run-dc-logs docker-compose exec -T geoportal ci/waitwsgi https://front/themes
 for path in c2c/health_check c2c/health_check?max_level=9 c2c/health_check?checks=check_collector "layers/test/values/type enum" admin/layertree admin/layertree/children; do
     ci/run-dc-logs docker-compose exec -T geoportal ci/test-new-project https://front/${path}
-    #docker-compose exec -T geoportal curl --insecure https://front/c2c/debug/stacks?secret=c2c
 done
 ci/run-dc-logs docker-compose exec -T geoportal ci/test-new-project 'http://qgisserver:8080/mapserv_proxy?SERVICE=WMS&REQUEST=GetCapabilities'
 ci/run-dc-logs docker-compose exec -T geoportal curl --insecure https://front/admin/ | grep Login
 ci/run-dc-logs docker-compose exec -T geoportal curl --insecure 'https://front/dynamic.json?interface=desktop&query=&path=%2F'
 ci/run-dc-logs docker-compose exec -T geoportal curl --insecure https://front/static-geomapfish/0/locales/fr.json
+ci/run-dc-logs docker-compose exec -T geoportal curl --insecure https://front/desktop_alt
+ci/run-dc-logs docker-compose exec -T geoportal curl --insecure https://front/desktop_alt | \
+    grep '<script src="https://front/static-ngeo-dist/desktop\..*\.js" crossorigin="anonymous"></script>'
 docker-compose stop qgisserver
 ci/run-dc-logs docker-compose exec -T geoportal alembic --config=alembic.ini --name=static downgrade base
 ci/run-dc-logs docker-compose exec -T geoportal alembic --config=alembic.ini --name=main downgrade base
 
 cp .env env.int
 echo PGHOST_SLAVE=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+') >> env.int
+echo PGPORT_SLAVE=54321 >> env.int
 ci/run-dc-logs scripts/db-backup --env=env.int dump.backup
 ci/run-dc-logs scripts/db-backup --env=env.int --arg=--schema=main dump.backup
 ci/run-dc-logs docker-compose exec -T tools psql --command="ALTER SCHEMA main RENAME TO main_old"

--- a/ci/vars.yaml
+++ b/ci/vars.yaml
@@ -2,6 +2,15 @@
 extends: vars_origin.yaml
 
 vars:
+  interfaces:
+    - name: desktop
+      default: True
+    - name: mobile
+    - name: iframe_api
+    - name: desktop_alt
+      type: canvas
+      layout: desktop
+
   dbsessions:
     ci_test:
       url: postgresql://{PGUSER}:{PGPASSWORD}@externaldb:{PGPORT}/test

--- a/doc/integrator/extend_application.rst
+++ b/doc/integrator/extend_application.rst
@@ -1,0 +1,57 @@
+.. _extend_application:
+
+Extend the application
+======================
+
+To add an additional component in the project in simple mode we should:
+- use an interface in canvas mode
+- add a custom docker-compose service
+- add a custom JavaScript file
+
+Interface in canvas mode
+------------------------
+
+Get the files from the ``CONST_create_template``:
+
+prompt:: bash
+
+    mkdir -p geoportal/interfaces/
+    cp CONST_create_template/geoportal/interfaces/desktop_alt.html.mako \
+        geoportal/interfaces/desktop.html.mako
+    mkdir -p geoportal/<package>_geoportal/static/images/
+    cp CONST_create_template/geoportal/<package>_geoportal/static/images/background-layer-button.png \
+        geoportal/<package>_geoportal/static/images/
+
+In the file ``geoportal/interfaces/desktop.html.mako`` your can see that there is some HTML tags that
+have an attribute slot. The slot says where the component should be added::
+
+- ``header`` -> in the header part of the page.
+- ``data`` -> in the data panel on the left of the map.
+- ``tool-button`` -> in the tools on the right of the map.
+- ``tool-button-separate`` -> in the tools on the right of the map, for the shared button.
+- ``tool-<panel-name>`` -> in the tools panel on the right of the map, when the tool is activated.
+- ``footer-<panel-name>`` -> in the footer part of the page, when the panel is activated.
+
+In the ``vars.yaml`` file your interface should be declared like that:
+
+.. code:: yaml
+
+   interfaces:
+     - name: desktop
+       type: canvas
+       default: true
+
+Custom docker-compose service
+-----------------------------
+
+Will be filled later.
+
+Custom JavaScript file
+----------------------
+
+Will be filled later.
+
+Extend the geoportal image
+--------------------------
+
+Will be filled later.

--- a/doc/integrator/features.rst
+++ b/doc/integrator/features.rst
@@ -20,3 +20,4 @@ Features that require additional steps (most of the time):
    routing
    multi_organization
    vector_tiles
+   extend_application

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,5 @@
 ---
-version: '2.1'
+version: '2.3'
 
 services:
   db:

--- a/docker/qgisserver/docker-compose.yaml
+++ b/docker/qgisserver/docker-compose.yaml
@@ -1,5 +1,5 @@
 ---
-version: '2.1'
+version: '2.3'
 
 services:
   db:

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/advance_create/geoportal/+package+_geoportal/__init__.py_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/advance_create/geoportal/+package+_geoportal/__init__.py_tmpl
@@ -3,7 +3,7 @@ import distutils.core
 from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.config import Configurator
 
-from c2cgeoportal_geoportal import INTERFACE_TYPE_NGEO, add_interface, locale_negotiator
+from c2cgeoportal_geoportal import INTERFACE_TYPE_NGEO, add_interface_config, locale_negotiator
 from c2cgeoportal_geoportal.lib.authentication import create_authentication
 from c2cgeoportal_geoportal.lib.i18n import LOCALE_PATH
 from {{package}}_geoportal.resources import Root
@@ -38,12 +38,7 @@ def main(global_config, **settings):
 
     # Add the interfaces
     for interface in config.get_settings().get("interfaces", []):
-        add_interface(
-            config,
-            interface["name"],
-            interface.get("type", INTERFACE_TYPE_NGEO),
-            default=interface.get("default", False),
-        )
+        add_interface_config(config, interface)
 
     try:
         import ptvsd  # pylint: disable=import-error,import-outside-toplevel

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/+dot+dockerignore_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/+dot+dockerignore_tmpl
@@ -6,6 +6,7 @@
 !haproxy/
 !print/print-apps/
 !geoportal/vars*.yaml
+!geoportal/interfaces/
 !geoportal/CONST_vars.yaml
 !geoportal/CONST_config-schema.yaml
 !geoportal/{{package}}_geoportal/static

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/Dockerfile_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/Dockerfile_tmpl
@@ -53,6 +53,7 @@ RUN \
     mkdir --parent /usr/local/tomcat/webapps/ROOT/ && \
     if [ -e /tmp/config/print ]; then mv /tmp/config/print/print-apps /usr/local/tomcat/webapps/ROOT/; fi && \
     mv /tmp/config/geoportal/{{package}}_geoportal/ /etc/geomapfish/ && \
+    mv /tmp/config/geoportal/* /etc/geomapfish/ | true && \
     chmod g+w -R \
         /etc/geomapfish \
         /etc/mapserver \

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/+dot+upgrade.yaml_tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/+dot+upgrade.yaml_tmpl
@@ -34,18 +34,16 @@ no_diff:
 # Files that will be present in the CONST_create_template but will not be considered in the upgrade.
 # Used to provide the alt applications => does not disturb the user during upgrade.
 extra:
-  - geoportal/{{package}}_geoportal/static-ngeo/js/apps/desktop_alt\.html\.ejs
   - geoportal/{{package}}_geoportal/static-ngeo/js/apps/mobile_alt\.html\.ejs
   - geoportal/{{package}}_geoportal/static-ngeo/js/apps/oeedit\.html\.ejs
-  - geoportal/{{package}}_geoportal/static-ngeo/js/apps/Controllerdesktop_alt\.js
   - geoportal/{{package}}_geoportal/static-ngeo/js/apps/Controllermobile_alt\.js
   - geoportal/{{package}}_geoportal/static-ngeo/js/apps/Controlleroeedit\.js
-  - geoportal/{{package}}_geoportal/static-ngeo/js/apps/sass/desktop_alt\.scss
-  - geoportal/{{package}}_geoportal/static-ngeo/js/apps/sass/vars_desktop_alt\.scss
   - geoportal/{{package}}_geoportal/static-ngeo/js/apps/sass/mobile_alt\.scss
   - geoportal/{{package}}_geoportal/static-ngeo/js/apps/sass/vars_mobile_alt\.scss
   - geoportal/{{package}}_geoportal/static-ngeo/js/apps/sass/oeedit\.scss
   - geoportal/{{package}}_geoportal/static-ngeo/js/apps/sass/vars_oeedit\.scss
+  - geoportal/interfaces/desktop_alt\.html\.mako
+  - geoportal/{{package}}_geoportal/static/images/background-layer-button\.png
 
 # Automated file system operations:
 # Remove some files or directories:

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/geoportal/CONST_config-schema.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/geoportal/CONST_config-schema.yaml
@@ -116,6 +116,9 @@ mapping:
               type:
                 type: str
                 default: ngeo
+              layout:
+                type: str
+                default: ngeo
       interfaces_config:
         required: True
         type: map


### PR DESCRIPTION
The goal of this pull request is to be able to have the template of the desktop application base on the canvas (from desktop-alt) in the config container (for simple application).
The js and the css will come from ngeo directly.