### PR TITLE
Fix for rename

### DIFF
--- a/bin/run-git
+++ b/bin/run-git
@@ -22,6 +22,6 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 git config --global user.name "$1"
-git config --global user.email $2
+git config --global user.email "$2"
 shift 2
 run "$@"

--- a/geoportal/c2cgeoportal_geoportal/scripts/c2cupgrade.py
+++ b/geoportal/c2cgeoportal_geoportal/scripts/c2cupgrade.py
@@ -401,11 +401,15 @@ class C2cUpgradeTool:
         def changed_files() -> List[str]:
             try:
                 status = [
-                    [s for s in status.split(" ") if s]
+                    [s for s in status.strip().split(" ", maxsplit=1) if s]
                     for status in check_git_status_output().strip().split("\n")
                     if status
                 ]
-                return [file for state, file in status if state == "M" and not file.startswith("CONST_")]
+                return [
+                    file.strip().split(" ")[-1]
+                    for state, file in status
+                    if state == "M" and not file.strip().startswith("CONST_")
+                ]
             except:  # pylint: disable=bare-except
                 self.print_step(
                     step,


### PR DESCRIPTION
Currently on the demo advance we have the following status:
```
M  CONST_create_template/.dockerignore
M  CONST_create_template/Dockerfile
M  CONST_create_template/geoportal/geomapfish_geoportal/__init__.py
M  CONST_create_template/geoportal/geomapfish_geoportal/locale/de/LC_MESSAGES/geomapfish_geoportal-client.po
M  CONST_create_template/geoportal/geomapfish_geoportal/locale/fr/LC_MESSAGES/geomapfish_geoportal-client.po
M  CONST_create_template/geoportal/geomapfish_geoportal/locale/it/LC_MESSAGES/geomapfish_geoportal-client.po
M  CONST_create_template/geoportal/geomapfish_geoportal/static-ngeo/js/apps/Controllerdesktop.js
D  CONST_create_template/geoportal/geomapfish_geoportal/static-ngeo/js/apps/Controllerdesktop_alt.js
M  CONST_create_template/geoportal/geomapfish_geoportal/static-ngeo/js/apps/Controlleriframe_api.js
M  CONST_create_template/geoportal/geomapfish_geoportal/static-ngeo/js/apps/Controllermobile.js
D  CONST_create_template/geoportal/geomapfish_geoportal/static-ngeo/js/apps/sass/desktop_alt.scss
D  CONST_create_template/geoportal/geomapfish_geoportal/static-ngeo/js/apps/sass/vars_desktop_alt.scss
A  CONST_create_template/geoportal/geomapfish_geoportal/static/images/background-layer-button.png
D  CONST_create_template/geoportal/geomapfish_geoportal/static/robot.txt
R  CONST_create_template/geoportal/geomapfish_geoportal/static-ngeo/js/apps/desktop_alt.html.ejs -> CONST_create_template/geoportal/interfaces/desktop_alt.html.mako
M  CONST_create_template/geoportal/tsconfig.json
M  CONST_create_template/geoportal/webpack.api.js
M  CONST_create_template/geoportal/webpack.apps.js
D  CONST_create_template/mapserver/tinyows.xml
D  CONST_create_template/print/print-apps/geomapfish/config.yaml
 M geoportal/CONST_config-schema.yaml
```
and it fail on the rename