### PR TITLE
Fix mail sending when ssl is False

### DIFF
--- a/commons/c2cgeoportal_commons/lib/email_.py
+++ b/commons/c2cgeoportal_commons/lib/email_.py
@@ -77,11 +77,14 @@ def send_email(
     msg.attach(MIMEText(body, "plain", "utf-8"))
 
     # Connect to server
-    smtp = smtplib.SMTP(smtp_config["host"])
     if smtp_config.get("ssl", False):
-        smtp.ehlo()
+        smtp: smtplib.SMTP = smtplib.SMTP_SSL(smtp_config["host"])
+    else:
+        smtp = smtplib.SMTP(smtp_config["host"])
     if smtp_config.get("starttls", False):
         smtp.starttls()
+    else:
+        smtp.ehlo()
     if smtp_config.get("user", False):
         smtp.login(smtp_config["user"], smtp_config["password"])
 

--- a/commons/c2cgeoportal_commons/lib/email_.py
+++ b/commons/c2cgeoportal_commons/lib/email_.py
@@ -77,10 +77,9 @@ def send_email(
     msg.attach(MIMEText(body, "plain", "utf-8"))
 
     # Connect to server
+    smtp = smtplib.SMTP(smtp_config["host"])
     if smtp_config.get("ssl", False):
-        smtp: smtplib.SMTP = smtplib.SMTP_SSL(smtp_config["host"])
-    else:
-        smtp = smtplib.SMTP(smtp_config["host"])
+        smtp.ehlo()
     if smtp_config.get("starttls", False):
         smtp.starttls()
     if smtp_config.get("user", False):


### PR DESCRIPTION
I think the current code for mail sending has a bug when ssl is set to False. It uses SMTP_SSL when in fact ssl should not be used.
The proposed code change was tested successfully on a GMF 2.6 instance where ssl is set to False.