### PR TITLE
Add default values to avoid warning

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/geoportal/vars.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/geoportal/vars.yaml
@@ -365,6 +365,7 @@ update_paths:
   - resourceproxy
   - servers
   - shortener.allowed_hosts
+  - smtp
   - sqlalchemy
   - sqlalchemy_slave
   - tinyowsproxy

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_vars.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_vars.yaml
@@ -848,7 +848,9 @@ vars:
     geometry_validation: True
 
   # Used by reset_password and shortener to send emails
-  smtp: {}
+  smtp:
+    ssl: false
+    starttls: false
 
   # Used to send an email on password reset
   reset_password: {}


### PR DESCRIPTION
Current warning:
```
The key 'starttls' in '.smtp' is not present in: ['host', 'password', 'ssl', 'user']
```