### PR TITLE
Fix QGIS server logging init

### DIFF
--- a/docker/qgisserver/logging.ini
+++ b/docker/qgisserver/logging.ini
@@ -47,7 +47,7 @@ formatter = generic
 
 [handler_json]
 class = geomapfish_qgisserver.gmf_logging.JsonLogHandler
-args = ()
+args = (sys.stderr,)
 level = NOTSET
 formatter = generic
 


### PR DESCRIPTION
If we do not manage to set stream as optional, this fix QGIS server logging init.

https://github.com/camptocamp/c2cgeoportal/pull/9400