### PR TITLE
Fix CVE

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -76,7 +76,7 @@ requirements-detector = "==0.7"
 rsa = "==3.4.2"
 s3transfer = "==0.4.2"
 selenium = "==3.141.0"
-setoptconf = "==0.2.0"
+setoptconf = "==0.3.0"
 six = "==1.14.0"
 smmap = "==4.0.0"
 snowballstemmer = "==2.1.0"
@@ -88,7 +88,7 @@ typing = "==3.7.4.3"
 typing-extensions = "==3.10.0.0"
 unidecode = "==1.2.0"
 urllib3 = "==1.25.9"
-waitress = "==1.4.3"
+waitress = "==2.0.0"
 webob = "==1.8.6"
 wrapt = "==1.11.2"
 zipp = "==3.4.1"
@@ -102,7 +102,7 @@ ColanderAlchemy = "==0.3.4"  # commons
 deform = "==2.0.10"  # commons, admin
 defusedxml = "==0.6.0"  # geoportal
 "dogpile.cache" = "==0.9.0"  # geoportal
-Fiona = "==1.8.13.post1"  # geoportal raster
+Fiona = "==1.8.21"  # geoportal raster
 GeoAlchemy2 = "==0.7.0"  # commons, geoportal
 geojson = "==2.5.0"  # geoportal
 getitfixed = "==1.0.20"  # geoportal
@@ -123,7 +123,7 @@ pyramid_multiauth = "==0.9.0"  # geoportal
 pyramid_tm = "==2.4"  # geoportal
 python-dateutil = "==2.8.1"  # geoportal
 PyYAML = "==5.4.1"  # geoportal
-rasterio = "==1.1.3"  # geoportal raster
+rasterio = "==1.2.10"  # geoportal raster
 requests = "==2.27.1"  # geoportal
 redis = "==3.4.1"  # geoportal cache
 Shapely = "==1.7.0"  # geoportal
@@ -143,9 +143,9 @@ bottle = "==0.12.19"
 "certifi" = "==2020.4.5.1"
 "chameleon" = "==3.8.1"
 "chardet" = "==3.0.4"
-"click" = "==7.1.1"
+"click" = "==8.0.0"
 "click-plugins" = "==1.1.1"
-"cligj" = "==0.5.0"
+"cligj" = "==0.7.2"
 "decorator" = "==4.4.2"
 "hupper" = "==1.10.2"
 "idna" = "==2.9"
@@ -178,4 +178,4 @@ jinja2 = "==2.11.3"
 "zope.sqlalchemy" = "==1.3"
 
 [requires]
-python_version = "3.6"
+python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8073e6bdd540740ec78496e83e06ee15490393e3b839b93a6508c14b2ea5bcb6"
+            "sha256": "cfad94ad783509b6360d4504569964e702832259038f775c7d9c258e76cca7e2"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.6"
+            "python_version": "3.7"
         },
         "sources": [
             {
@@ -119,19 +119,19 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:2842d8f5e82a1f6aa437380934d5e1cd4fcf2003b06fed6940769c164a480a45",
-                "sha256:98398a9d69ee80548c762ba991a4728bfc3836768ed226b3945908d1a688371c"
+                "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
+                "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.11"
+            "version": "==2.0.12"
         },
         "click": {
             "hashes": [
-                "sha256:8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc",
-                "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"
+                "sha256:7d8c289ee437bcb0316820ccee14aefcb056e58d31830ecab8e47eda6540e136",
+                "sha256:e90e62ced43dc8105fb9a26d62f0d9340b5c8db053a814e25d95c19873ae87db"
             ],
             "index": "pypi",
-            "version": "==7.1.1"
+            "version": "==8.0.0"
         },
         "click-plugins": {
             "hashes": [
@@ -143,12 +143,11 @@
         },
         "cligj": {
             "hashes": [
-                "sha256:20f24ce9abfde3f758aec3399e6811b936b6772f360846c662c19bf5537b4f14",
-                "sha256:60c93dda4499562eb87509a8ff3535a7441053b766c9c26bcf874a732f939c7c",
-                "sha256:6c7d52d529a78712491974f975c33473f430c0f7beb18c0d7a402a743dcb460a"
+                "sha256:a4bc13d623356b373c2c27c53dbd9c68cae5d526270bfa71f6c6fa69669c6b27",
+                "sha256:c1ca117dbce1fe20a5809dc96f01e1c2840f6dcc939b3ddbb1111bf330ba82df"
             ],
             "index": "pypi",
-            "version": "==0.5.0"
+            "version": "==0.7.2"
         },
         "colander": {
             "hashes": [
@@ -199,20 +198,20 @@
         },
         "fiona": {
             "hashes": [
-                "sha256:1a432bf9fd56f089256c010da009c90d4a795c531a848132c965052185336600",
-                "sha256:1c9c6e883e82298293042f7b7f51a5680f50d5a3bb1a61ad179b2d5f7f4d6952",
-                "sha256:3c236a8f9ddfc23ac746f4988526cbed73b43f8f86613a0001c62feb415daadc",
-                "sha256:6d30d755e9041a3380d85c1b2e09003f657c03a749fb02a3d36b191296f57f5d",
-                "sha256:6d6200a64f0f6fad431a767dd2da62706bf9f683be77bb157b6d0459bb263b7f",
-                "sha256:7598ed3ce7a88941a2eab5ffa90b39f8f44113355c39abcbda6920eecdba26b4",
-                "sha256:781d29c21714da4c1c0f118b56bef936a1a935fead8878c22ab57a0d3875e412",
-                "sha256:79c3b80e00c9d055d20aead5d74319f54cdd1384e0d9e1a9e67446da2d74d89c",
-                "sha256:923a64bded457adee795b4f926b8cbb87d58bbafaabded77bc1d47abb2bba5c6",
-                "sha256:b8ad562b77c76dbff5a9298e1032c87714f079fc80752ca7c9c85edef52039aa",
-                "sha256:c6e99bf596c2322e134833490611a612a8cce35a39c4c6499b7df919e24b482b"
+                "sha256:085f18d943097ac3396f3f9664ac1ae04ad0ff272f54829f03442187f01b6116",
+                "sha256:11532ccfda1073d3f5f558e4bb78d45b268e8680fd6e14993a394c564ddbd069",
+                "sha256:315e186cb880a8128e110312eb92f5956bbc54d7152af999d3483b463758d6f9",
+                "sha256:3789523c811809a6e2e170cf9c437631f959f4c7a868f024081612d30afab468",
+                "sha256:388acc9fa07ba7858d508dfe826d4b04d813818bced16c4049de19cc7ca322ef",
+                "sha256:39c656421e25b4d0d73d0b6acdcbf9848e71f3d9b74f44c27d2d516d463409ae",
+                "sha256:3a0edca2a7a070db405d71187214a43d2333a57b4097544a3fcc282066a58bfc",
+                "sha256:40b4eaf5b88407421d6c9e707520abd2ff16d7cd43efb59cd398aa41d2de332c",
+                "sha256:43b1d2e45506e56cf3a9f59ba5d6f7981f3f75f4725d1e6cb9a33ba856371ebd",
+                "sha256:9fb2407623c4f44732a33b3f056f8c58c54152b51f0324bf8f10945e711eb549",
+                "sha256:b69054ed810eb7339d7effa88589afca48003206d7627d0b0b149715fc3fde41"
             ],
             "index": "pypi",
-            "version": "==1.8.13.post1"
+            "version": "==1.8.21"
         },
         "geoalchemy2": {
             "hashes": [
@@ -711,20 +710,18 @@
         },
         "rasterio": {
             "hashes": [
-                "sha256:0870ad5bf3e55fc4e80802516f1316c247afbc476c84b910c40b7cb0500825fd",
-                "sha256:1e9477d83f76dbb012d348ca668b33ec5688f3a39cce62bfb31b557fe42e179d",
-                "sha256:30e3ab057c5151553ec3e755971afaa6a89bae4162ed11864df4fd1b9f9af105",
-                "sha256:3fbb623949a1ba6040aa7eeb71c7c622bd2003f9e2c20a49bde7fdbe5ec58bd1",
-                "sha256:6c2abb5a5986e7627e7579fadebdcb4ead55a230afab6e0d2762acc0983a53d8",
-                "sha256:6ee8df0cb49512f72eca8ba4fd50f9fb9da9944808a4acc4b15f95f11298b850",
-                "sha256:715faac2b4b29d97694547ace235219f4fd3ea3c3c5ba7f01c849962fcebbcb2",
-                "sha256:71e57edc156b0debac71200f245ca607a384762be382e73c2389988920218204",
-                "sha256:739e2d72f136e7c432324fa4df9f1ee2420124454d44b6da22e8458042f75574",
-                "sha256:c273378fa6541f49d76a94e1465bf02f7331501da0240fc5f853451184de2370",
-                "sha256:fe2eac942ae4f8a97246c8cd3977723997817b53a9058cf1959551026c6177e7"
+                "sha256:1572003273225162933d4c88729076ac39050e7becd9de7d31988d1dd40942c1",
+                "sha256:2394ce0ae1e7b49b456ddc6bbf00ce6840656e926046c1a5a54cd0f66ea67dc4",
+                "sha256:42a1a6364313c384fcd631d850792621301e930449b47f72ced048c415c9c84e",
+                "sha256:6062456047ba6494fe18bd0da98a383b6fad5306b16cd52a22e76c59172a2b5f",
+                "sha256:831b6dbefb409c3ece23fa219d8446a7534e30c69a075fd366e72742b1f94c58",
+                "sha256:8f9867a3b6663396260fc5bdfbea372cac9202074b709478db741767f40dfffc",
+                "sha256:ba95aa3221814e364ef49cf8dd8ca4a73e2ea702bd9228a3a845e197091792ae",
+                "sha256:c73248b4ba0564798bf64df869834821a7b823a4c9ceda3de9b772d69c3f5405",
+                "sha256:f86efb0e4989201f244d6818575d442b716ce81af6cd969c3caead76b9690837"
             ],
             "index": "pypi",
-            "version": "==1.1.3"
+            "version": "==1.2.10"
         },
         "redis": {
             "hashes": [
@@ -1019,19 +1016,19 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:2842d8f5e82a1f6aa437380934d5e1cd4fcf2003b06fed6940769c164a480a45",
-                "sha256:98398a9d69ee80548c762ba991a4728bfc3836768ed226b3945908d1a688371c"
+                "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
+                "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.11"
+            "version": "==2.0.12"
         },
         "click": {
             "hashes": [
-                "sha256:8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc",
-                "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"
+                "sha256:7d8c289ee437bcb0316820ccee14aefcb056e58d31830ecab8e47eda6540e136",
+                "sha256:e90e62ced43dc8105fb9a26d62f0d9340b5c8db053a814e25d95c19873ae87db"
             ],
             "index": "pypi",
-            "version": "==7.1.1"
+            "version": "==8.0.0"
         },
         "colorama": {
             "hashes": [
@@ -1653,10 +1650,11 @@
         },
         "setoptconf": {
             "hashes": [
-                "sha256:5b0b5d8e0077713f5d5152d4f63be6f048d9a1bb66be15d089a11c898c3cf49c"
+                "sha256:1fa613dc4a6fbfbaab9a52319d1e369d030e8ed80455b151574ccf3390ec86c6",
+                "sha256:d2ecbd27c0c7d0d53990e2df98d9aad6490df8b75b71c621d8c441d6e91e3161"
             ],
-            "index": "pypi",
-            "version": "==0.2.0"
+            "markers": "python_version >= '3.0'",
+            "version": "==0.3.0"
         },
         "setuptools": {
             "hashes": [


### PR DESCRIPTION
```
  +==============================================================================+
  |                                                                              |
  |                               /$$$$$$            /$$                         |
  |                              /$$__  $$          | $$                         |
  |           /$$$$$$$  /$$$$$$ | $$  \__//$$$$$$  /$$$$$$   /$$   /$$           |
  |          /$$_____/ |____  $$| $$$$   /$$__  $$|_  $$_/  | $$  | $$           |
  |         |  $$$$$$   /$$$$$$$| $$_/  | $$$$$$$$  | $$    | $$  | $$           |
  |          \____  $$ /$$__  $$| $$    | $$_____/  | $$ /$$| $$  | $$           |
  |          /$$$$$$$/|  $$$$$$$| $$    |  $$$$$$$  |  $$$$/|  $$$$$$$           |
  |         |_______/  \_______/|__/     \_______/   \___/   \____  $$           |
  |                                                          /$$  | $$           |
  |                                                         |  $$$$$$/           |
  |  by pyup.io                                              \______/            |
  |                                                                              |
  +==============================================================================+
  | REPORT                                                                       |
  | checked 82 packages, using free DB (updated once a month)                    |
  +============================+===========+==========================+==========+
  | package                    | installed | affected                 | ID       |
  +============================+===========+==========================+==========+
  | click                      | 7.1.1     | <8.0.0                   | 47833    |
  +==============================================================================+
  | Click 8.0.0 uses 'mkstemp()' instead of the deprecated & insecure            |
  | 'mktemp()'.                                                                  |
  | https://github.com/pallets/click/issues/1752                                 |
  +==============================================================================+
  | waitress                   | 1.4.3     | <2.1.1                   | 46436    |
  +==============================================================================+
  | Waitress is a Web Server Gateway Interface server for Python 2 and 3. When   |
  | using Waitress versions 2.1.0 and prior behind a proxy that does not         |
  | properly validate the incoming HTTP request matches the RFC7230 standard,    |
  | Waitress and the frontend proxy may disagree on where one request starts and |
  | where it ends. This would allow requests to be smuggled via the front-end    |
  | proxy to waitress and later behavior. There are two classes of vulnerability |
  | that may lead to request smuggling that are addressed by this advisory: The  |
  | use of Python's 'int()' to parse strings into integers, leading to '+10' to  |
  | be parsed as '10', or '0x01' to be parsed as '1', where as the standard      |
  | specifies that the string should contain only digits or hex digits; and      |
  | Waitress does not support chunk extensions, however it was discarding them   |
  | without validating that they did not contain illegal characters. This        |
  | vulnerability has been patched in Waitress 2.1.1. A workaround is available. |
  | When deploying a proxy in front of waitress, turning on any and all          |
  | functionality to make sure that the request matches the RFC7230 standard.    |
  | Certain proxy servers may not have this functionality though and users are   |
  | encouraged to upgrade to the latest version of waitress instead.             |
  +==============================================================================+
```