### PR TITLE
Fix CVE

### DIFF
--- a/docker/qgisserver/python/3.6/Pipfile
+++ b/docker/qgisserver/python/3.6/Pipfile
@@ -3,11 +3,6 @@ name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 
-[dev-packages]
-mypy = "==0.790"  # lint
-prospector = {extras = ["with_mypy", "with_bandit"],version = "==1.3.1"}
-flake8 = "==3.8.4"
-
 [packages]
 c2cwsgiutils = {extras = ["broadcast"],version = "==4.0.1"}
 papyrus = "==2.4"  # commons
@@ -20,7 +15,7 @@ SQLAlchemy = "==1.3.20"  # commons
 shapely = "==1.7.1"
 cee-syslog-handler = "==0.6.0"
 # Lock
-bottle = "==0.12.19"
+bottle = "==0.12.20"
 geojson = "==2.5.0"
 hupper = "==1.10.2"
 jinja2 = "==2.11.3"
@@ -38,6 +33,47 @@ venusian = "==3.0.0"
 webob = "==1.8.6"
 "zope.deprecation" = "==4.4.0"
 "zope.interface" = "==5.2.0"
+setuptools = "==45.2.0"
+
+[dev-packages]
+mypy = "==0.790"  # lint
+prospector = {extras = ["with_mypy", "with_bandit"],version = "==1.3.1"}
+flake8 = "==3.8.4"
+
+# Lock dependencies
+astroid = "==2.4.1"
+bandit = "==1.7.0"
+dodgy = "==0.2.1"
+flake8-polyfill = "==1.0.2"
+gitdb = "==4.0.5"
+gitpython = "==3.1.12"
+importlib-metadata = "==3.4.0"
+isort = "==4.3.21"
+lazy-object-proxy = "==1.4.3"
+mccabe = "==0.6.1"
+mypy-extensions = "==0.4.3"
+pbr = "==5.5.1"
+pep8-naming = "==0.10.0"
+pycodestyle = "==2.6.0"
+pydocstyle = "==5.1.1"
+pyflakes = "==2.2.0"
+pylint = "==2.5.3"
+pylint-celery = "==0.3"
+pylint-django = "==2.1.0"
+pylint-flask = "==0.6"
+pylint-plugin-utils = "==0.6"
+pyyaml = "==5.3.1"
+requirements-detector = "==0.7"
+setoptconf = "==0.3.0"
+six = "==1.15.0"
+smmap = "==3.0.4"
+snowballstemmer = "==2.0.0"
+stevedore = "==3.3.0"
+toml = "==0.10.2"
+typed-ast = "==1.4.2"
+typing-extensions = "==3.7.4.3"
+wrapt = "==1.12.1"
+zipp = "==3.4.0"
 
 [requires]
 python_version = "3.6"

--- a/docker/qgisserver/python/3.6/Pipfile.lock
+++ b/docker/qgisserver/python/3.6/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4e10931ea4e198570c5acd6bd22259f75315890ba580b194981834b42989401f"
+            "sha256": "83bb0598b297864207b6c0b9567646c53e0e220fcd4d3cffdf1929c4323bbe96"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,11 +18,11 @@
     "default": {
         "bottle": {
             "hashes": [
-                "sha256:a9d73ffcbc6a1345ca2d7949638db46349f5b2b77dac65d6494d45c23628da2c",
-                "sha256:f6b8a34fe9aa406f9813c02990db72ca69ce6a158b5b156d2c41f345016a723d"
+                "sha256:3c97e1e955c11e4ad2d73a60cdf83c4f4cf7b8b73c8344fc4b72f985432605cb",
+                "sha256:544023cd2cd6d382ebf9675fa0544d4d20e19d3a13b6932a812d099fb2f6cb84"
             ],
             "index": "pypi",
-            "version": "==0.12.19"
+            "version": "==0.12.20"
         },
         "c2c.template": {
             "hashes": [
@@ -417,7 +417,7 @@
                 "sha256:4c17cea3e592c21b6e222f673868961bad77e1f985cb1694ed077475a89229c1",
                 "sha256:d8506842a3faf734b81599c8b98dcc423de863adcc1999248480b18bd31a0f38"
             ],
-            "markers": "python_version >= '3.5'",
+            "index": "pypi",
             "version": "==2.4.1"
         },
         "bandit": {
@@ -425,6 +425,7 @@
                 "sha256:216be4d044209fa06cf2a3e51b319769a51be8318140659719aa7a115c35ed07",
                 "sha256:8a4c7415254d75df8ff3c3b15cfe9042ecee628a1e40b44c15a98890fbfc2608"
             ],
+            "index": "pypi",
             "version": "==1.7.0"
         },
         "dodgy": {
@@ -432,6 +433,7 @@
                 "sha256:28323cbfc9352139fdd3d316fa17f325cc0e9ac74438cbba51d70f9b48f86c3a",
                 "sha256:51f54c0fd886fa3854387f354b19f429d38c04f984f38bc572558b703c0542a6"
             ],
+            "index": "pypi",
             "version": "==0.2.1"
         },
         "flake8": {
@@ -447,6 +449,7 @@
                 "sha256:12be6a34ee3ab795b19ca73505e7b55826d5f6ad7230d31b18e106400169b9e9",
                 "sha256:e44b087597f6da52ec6393a709e7108b2905317d0c0b744cdca6208e670d8eda"
             ],
+            "index": "pypi",
             "version": "==1.0.2"
         },
         "gitdb": {
@@ -454,7 +457,7 @@
                 "sha256:91f36bfb1ab7949b3b40e23736db18231bf7593edada2ba5c3a174a7b23657ac",
                 "sha256:c9e1f2d0db7ddb9a704c2a0217be31214e91a4fe1dea1efad19ae42ba0c285c9"
             ],
-            "markers": "python_version >= '3.4'",
+            "index": "pypi",
             "version": "==4.0.5"
         },
         "gitpython": {
@@ -462,7 +465,7 @@
                 "sha256:42dbefd8d9e2576c496ed0059f3103dcef7125b9ce16f9d5f9c834aed44a1dac",
                 "sha256:867ec3dfb126aac0f8296b19fb63b8c4a399f32b4b6fafe84c4b10af5fa9f7b5"
             ],
-            "markers": "python_version >= '3.4'",
+            "index": "pypi",
             "version": "==3.1.12"
         },
         "importlib-metadata": {
@@ -470,7 +473,7 @@
                 "sha256:ace61d5fc652dc280e7b6b4ff732a9c2d40db2c0f92bc6cb74e07b73d53a1771",
                 "sha256:fa5daa4477a7414ae34e95942e4dd07f62adf589143c875c133c1e53c4eff38d"
             ],
-            "markers": "python_version < '3.8'",
+            "index": "pypi",
             "version": "==3.4.0"
         },
         "isort": {
@@ -478,7 +481,7 @@
                 "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1",
                 "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "index": "pypi",
             "version": "==4.3.21"
         },
         "lazy-object-proxy": {
@@ -505,7 +508,7 @@
                 "sha256:efa1909120ce98bbb3777e8b6f92237f5d5c8ea6758efea36a473e1d38f7d3e4",
                 "sha256:f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "index": "pypi",
             "version": "==1.4.3"
         },
         "mccabe": {
@@ -513,6 +516,7 @@
                 "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
                 "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
             ],
+            "index": "pypi",
             "version": "==0.6.1"
         },
         "mypy": {
@@ -540,6 +544,7 @@
                 "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
                 "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
             ],
+            "index": "pypi",
             "version": "==0.4.3"
         },
         "pbr": {
@@ -547,7 +552,7 @@
                 "sha256:5fad80b613c402d5b7df7bd84812548b2a61e9977387a80a5fc5c396492b13c9",
                 "sha256:b236cde0ac9a6aedd5e3c34517b423cd4fd97ef723849da6b0d2231142d89c00"
             ],
-            "markers": "python_version >= '2.6'",
+            "index": "pypi",
             "version": "==5.5.1"
         },
         "pep8-naming": {
@@ -555,6 +560,7 @@
                 "sha256:5d9f1056cb9427ce344e98d1a7f5665710e2f20f748438e308995852cfa24164",
                 "sha256:f3b4a5f9dd72b991bf7d8e2a341d2e1aa3a884a769b5aaac4f56825c1763bf3a"
             ],
+            "index": "pypi",
             "version": "==0.10.0"
         },
         "prospector": {
@@ -573,7 +579,7 @@
                 "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367",
                 "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "index": "pypi",
             "version": "==2.6.0"
         },
         "pydocstyle": {
@@ -581,7 +587,7 @@
                 "sha256:19b86fa8617ed916776a11cd8bc0197e5b9856d5433b777f51a3defe13075325",
                 "sha256:aca749e190a01726a4fb472dd4ef23b5c9da7b9205c0a7857c06533de13fd678"
             ],
-            "markers": "python_version >= '3.5'",
+            "index": "pypi",
             "version": "==5.1.1"
         },
         "pyflakes": {
@@ -589,7 +595,7 @@
                 "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92",
                 "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "index": "pypi",
             "version": "==2.2.0"
         },
         "pylint": {
@@ -597,13 +603,14 @@
                 "sha256:7dd78437f2d8d019717dbf287772d0b2dbdfd13fc016aa7faa08d67bccc46adc",
                 "sha256:d0ece7d223fe422088b0e8f13fa0a1e8eb745ebffcb8ed53d3e95394b6101a1c"
             ],
-            "markers": "python_version >= '3.5'",
+            "index": "pypi",
             "version": "==2.5.3"
         },
         "pylint-celery": {
             "hashes": [
                 "sha256:41e32094e7408d15c044178ea828dd524beedbdbe6f83f712c5e35bde1de4beb"
             ],
+            "index": "pypi",
             "version": "==0.3"
         },
         "pylint-django": {
@@ -611,12 +618,14 @@
                 "sha256:b7756844dba0cecd3471056a1ef4154439defedaba38bf3ced9f848d2bf6297c",
                 "sha256:ca32277c77878dd3c2d9e75f3f3f7f0c0712f053f10ff1b946cdc27367a6c911"
             ],
+            "index": "pypi",
             "version": "==2.1.0"
         },
         "pylint-flask": {
             "hashes": [
                 "sha256:f4d97de2216bf7bfce07c9c08b166e978fe9f2725de2a50a9845a97de7e31517"
             ],
+            "index": "pypi",
             "version": "==0.6"
         },
         "pylint-plugin-utils": {
@@ -624,6 +633,7 @@
                 "sha256:2f30510e1c46edf268d3a195b2849bd98a1b9433229bb2ba63b8d776e1fc4d0a",
                 "sha256:57625dcca20140f43731311cd8fd879318bf45a8b0fd17020717a8781714a25a"
             ],
+            "index": "pypi",
             "version": "==0.6"
         },
         "pyyaml": {
@@ -649,20 +659,23 @@
             "hashes": [
                 "sha256:0d1e13e61ed243f9c3c86e6cbb19980bcb3a0e0619cde2ec1f3af70fdbee6f7b"
             ],
+            "index": "pypi",
             "version": "==0.7"
         },
         "setoptconf": {
             "hashes": [
-                "sha256:5b0b5d8e0077713f5d5152d4f63be6f048d9a1bb66be15d089a11c898c3cf49c"
+                "sha256:1fa613dc4a6fbfbaab9a52319d1e369d030e8ed80455b151574ccf3390ec86c6",
+                "sha256:d2ecbd27c0c7d0d53990e2df98d9aad6490df8b75b71c621d8c441d6e91e3161"
             ],
-            "version": "==0.2.0"
+            "index": "pypi",
+            "version": "==0.3.0"
         },
         "six": {
             "hashes": [
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "index": "pypi",
             "version": "==1.15.0"
         },
         "smmap": {
@@ -670,7 +683,7 @@
                 "sha256:54c44c197c819d5ef1991799a7e30b662d1e520f2ac75c9efbeb54a742214cf4",
                 "sha256:9c98bbd1f9786d22f14b3d4126894d56befb835ec90cef151af566c7e19b5d24"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "index": "pypi",
             "version": "==3.0.4"
         },
         "snowballstemmer": {
@@ -678,6 +691,7 @@
                 "sha256:209f257d7533fdb3cb73bdbd24f436239ca3b2fa67d56f6ff88e86be08cc5ef0",
                 "sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"
             ],
+            "index": "pypi",
             "version": "==2.0.0"
         },
         "stevedore": {
@@ -685,7 +699,7 @@
                 "sha256:3a5bbd0652bf552748871eaa73a4a8dc2899786bc497a2aa1fcb4dcdb0debeee",
                 "sha256:50d7b78fbaf0d04cd62411188fa7eedcb03eb7f4c4b37005615ceebe582aa82a"
             ],
-            "markers": "python_version >= '3.6'",
+            "index": "pypi",
             "version": "==3.3.0"
         },
         "toml": {
@@ -693,7 +707,7 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "index": "pypi",
             "version": "==0.10.2"
         },
         "typed-ast": {
@@ -729,7 +743,7 @@
                 "sha256:d746a437cdbca200622385305aedd9aef68e8a645e385cc483bdc5e488f07166",
                 "sha256:e683e409e5c45d5c9082dc1daf13f6374300806240719f95dc783d1fc942af10"
             ],
-            "markers": "python_version < '3.8' and implementation_name == 'cpython'",
+            "index": "pypi",
             "version": "==1.4.2"
         },
         "typing-extensions": {
@@ -738,13 +752,14 @@
                 "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c",
                 "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"
             ],
-            "markers": "python_version < '3.8'",
+            "index": "pypi",
             "version": "==3.7.4.3"
         },
         "wrapt": {
             "hashes": [
                 "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"
             ],
+            "index": "pypi",
             "version": "==1.12.1"
         },
         "zipp": {
@@ -752,7 +767,7 @@
                 "sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108",
                 "sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb"
             ],
-            "markers": "python_version >= '3.6'",
+            "index": "pypi",
             "version": "==3.4.0"
         }
     }


### PR DESCRIPTION
```
  +==============================================================================+
  |                                                                              |
  |                               /$$$$$$            /$$                         |
  |                              /$$__  $$          | $$                         |
  |           /$$$$$$$  /$$$$$$ | $$  \__//$$$$$$  /$$$$$$   /$$   /$$           |
  |          /$$_____/ |____  $$| $$$$   /$$__  $$|_  $$_/  | $$  | $$           |
  |         |  $$$$$$   /$$$$$$$| $$_/  | $$$$$$$$  | $$    | $$  | $$           |
  |          \____  $$ /$$__  $$| $$    | $$_____/  | $$ /$$| $$  | $$           |
  |          /$$$$$$$/|  $$$$$$$| $$    |  $$$$$$$  |  $$$$/|  $$$$$$$           |
  |         |_______/  \_______/|__/     \_______/   \___/   \____  $$           |
  |                                                          /$$  | $$           |
  |                                                         |  $$$$$$/           |
  |  by pyup.io                                              \______/            |
  |                                                                              |
  +==============================================================================+
  | REPORT                                                                       |
  | checked 110 packages, using free DB (updated once a month)                   |
  +============================+===========+==========================+==========+
  | package                    | installed | affected                 | ID       |
  +============================+===========+==========================+==========+
  | bottle                     | 0.12.19   | <0.12.20                 | 49258    |
  +==============================================================================+
  | Bottle before 0.12.20 mishandles errors during early request binding.        |
  +==============================================================================+
  | waitress                   | 2.1.1     | >=2.1.0,<2.1.2           | 49257    |
  +==============================================================================+
  | Waitress 2.1.2 includes a fix for CVE-2022-31015: Waitress versions 2.1.0    |
  | and 2.1.1 may terminate early due to a thread closing a socket while the     |
  | main thread is about to call select(). This will lead to the main thread     |
  | raising an exception that is not handled and then causing the entire         |
  | application to be killed. This issue has been fixed in Waitress 2.1.2 by no  |
  | longer allowing the WSGI thread to close the socket. Instead, that is always |
  | delegated to the main thread. There is no workaround for this issue,         |
  | however, users using waitress behind a reverse proxy server are less likely  |
  | to have issues if the reverse proxy always reads the full response.          |
  | https://github.com/Pylons/waitress/security/advisories/GHSA-f5x9-8jwc-25rw   |
  +==============================================================================+
```