### PR TITLE
Fix CVE

### DIFF
--- a/docker/qgisserver/python/3.8/Pipfile
+++ b/docker/qgisserver/python/3.8/Pipfile
@@ -3,24 +3,19 @@ name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 
-[dev-packages]
-mypy = "==0.790"  # lint
-prospector = {extras = ["with_mypy", "with_bandit"],version = "==1.3.1"}
-flake8 = "==3.8.4"
-
 [packages]
-c2cwsgiutils = {extras = ["broadcast"],version = "==4.0.1"}
-papyrus = "==2.4"  # commons
-transaction = "==3.0.1"  # commons
+c2cwsgiutils = { extras = ["broadcast"], version = "==4.0.1" }
+papyrus = "==2.4" # commons
+transaction = "==3.0.1" # commons
 "c2c.template" = "==2.1.0"
 GeoAlchemy2 = "==0.8.4"
-SQLAlchemy = "==1.3.20"  # commons
-"zope.event" = "==4.4"  # commons
-"zope.sqlalchemy" = "==1.2"  # commons
+SQLAlchemy = "==1.3.20" # commons
+"zope.event" = "==4.4" # commons
+"zope.sqlalchemy" = "==1.2" # commons
 shapely = "==1.7.1"
 cee-syslog-handler = "==0.6.0"
 # Lock
-bottle = "==0.12.19"
+bottle = "==0.12.20"
 geojson = "==2.5.0"
 hupper = "==1.10.2"
 jinja2 = "==2.11.3"
@@ -38,6 +33,44 @@ venusian = "==3.0.0"
 webob = "==1.8.6"
 "zope.deprecation" = "==4.4.0"
 "zope.interface" = "==5.2.0"
+setuptools = "==45.2.0"
+
+[dev-packages]
+mypy = "==0.790" # lint
+prospector = { extras = ["with_mypy", "with_bandit"], version = "==1.3.1" }
+flake8 = "==3.8.4"
+# Lock dependencies
+astroid = "==2.4.1"
+bandit = "==1.7.0"
+dodgy = "==0.2.1"
+flake8-polyfill = "==1.0.2"
+gitdb = "==4.0.7"
+gitpython = "==3.1.14"
+isort = "==4.3.21"
+lazy-object-proxy = "==1.4.3"
+mccabe = "==0.6.1"
+mypy-extensions = "==0.4.3"
+pbr = "==5.6.0"
+pep8-naming = "==0.10.0"
+pycodestyle = "==2.6.0"
+pydocstyle = "==6.0.0"
+pyflakes = "==2.2.0"
+pylint = "==2.5.3"
+pylint-celery = "==0.3"
+pylint-django = "==2.1.0"
+pylint-flask = "==0.6"
+pylint-plugin-utils = "==0.6"
+pyyaml = "==5.4.1"
+requirements-detector = "==0.7"
+setoptconf = "==0.3.0"
+six = "==1.15.0"
+smmap = "==4.0.0"
+snowballstemmer = "==2.1.0"
+stevedore = "==3.3.0"
+toml = "==0.10.2"
+typed-ast = "==1.4.3"
+typing-extensions = "==3.10.0.0"
+wrapt = "==1.12.1"
 
 [requires]
 python_version = "3.8"

--- a/docker/qgisserver/python/3.8/Pipfile.lock
+++ b/docker/qgisserver/python/3.8/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ac505c2072059aef802e5c109be7dcd6f1ff95db2da799a956f9e375b695ffdb"
+            "sha256": "61b9a6cdd7e6468be5c094d544d7287d92bca25bdd20cdcdff5be7aef6997bd5"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,11 +18,11 @@
     "default": {
         "bottle": {
             "hashes": [
-                "sha256:a9d73ffcbc6a1345ca2d7949638db46349f5b2b77dac65d6494d45c23628da2c",
-                "sha256:f6b8a34fe9aa406f9813c02990db72ca69ce6a158b5b156d2c41f345016a723d"
+                "sha256:3c97e1e955c11e4ad2d73a60cdf83c4f4cf7b8b73c8344fc4b72f985432605cb",
+                "sha256:544023cd2cd6d382ebf9675fa0544d4d20e19d3a13b6932a812d099fb2f6cb84"
             ],
             "index": "pypi",
-            "version": "==0.12.19"
+            "version": "==0.12.20"
         },
         "c2c.template": {
             "hashes": [
@@ -433,7 +433,7 @@
                 "sha256:4c17cea3e592c21b6e222f673868961bad77e1f985cb1694ed077475a89229c1",
                 "sha256:d8506842a3faf734b81599c8b98dcc423de863adcc1999248480b18bd31a0f38"
             ],
-            "markers": "python_version >= '3.5'",
+            "index": "pypi",
             "version": "==2.4.1"
         },
         "bandit": {
@@ -441,6 +441,7 @@
                 "sha256:216be4d044209fa06cf2a3e51b319769a51be8318140659719aa7a115c35ed07",
                 "sha256:8a4c7415254d75df8ff3c3b15cfe9042ecee628a1e40b44c15a98890fbfc2608"
             ],
+            "index": "pypi",
             "version": "==1.7.0"
         },
         "dodgy": {
@@ -448,6 +449,7 @@
                 "sha256:28323cbfc9352139fdd3d316fa17f325cc0e9ac74438cbba51d70f9b48f86c3a",
                 "sha256:51f54c0fd886fa3854387f354b19f429d38c04f984f38bc572558b703c0542a6"
             ],
+            "index": "pypi",
             "version": "==0.2.1"
         },
         "flake8": {
@@ -463,6 +465,7 @@
                 "sha256:12be6a34ee3ab795b19ca73505e7b55826d5f6ad7230d31b18e106400169b9e9",
                 "sha256:e44b087597f6da52ec6393a709e7108b2905317d0c0b744cdca6208e670d8eda"
             ],
+            "index": "pypi",
             "version": "==1.0.2"
         },
         "gitdb": {
@@ -470,7 +473,7 @@
                 "sha256:6c4cc71933456991da20917998acbe6cf4fb41eeaab7d6d67fbc05ecd4c865b0",
                 "sha256:96bf5c08b157a666fec41129e6d327235284cca4c81e92109260f353ba138005"
             ],
-            "markers": "python_version >= '3.4'",
+            "index": "pypi",
             "version": "==4.0.7"
         },
         "gitpython": {
@@ -478,7 +481,7 @@
                 "sha256:3283ae2fba31c913d857e12e5ba5f9a7772bbc064ae2bb09efafa71b0dd4939b",
                 "sha256:be27633e7509e58391f10207cd32b2a6cf5b908f92d9cd30da2e514e1137af61"
             ],
-            "markers": "python_version >= '3.4'",
+            "index": "pypi",
             "version": "==3.1.14"
         },
         "isort": {
@@ -486,7 +489,7 @@
                 "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1",
                 "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "index": "pypi",
             "version": "==4.3.21"
         },
         "lazy-object-proxy": {
@@ -513,7 +516,7 @@
                 "sha256:efa1909120ce98bbb3777e8b6f92237f5d5c8ea6758efea36a473e1d38f7d3e4",
                 "sha256:f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "index": "pypi",
             "version": "==1.4.3"
         },
         "mccabe": {
@@ -521,6 +524,7 @@
                 "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
                 "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
             ],
+            "index": "pypi",
             "version": "==0.6.1"
         },
         "mypy": {
@@ -548,6 +552,7 @@
                 "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
                 "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
             ],
+            "index": "pypi",
             "version": "==0.4.3"
         },
         "pbr": {
@@ -555,7 +560,7 @@
                 "sha256:42df03e7797b796625b1029c0400279c7c34fd7df24a7d7818a1abb5b38710dd",
                 "sha256:c68c661ac5cc81058ac94247278eeda6d2e6aecb3e227b0387c30d277e7ef8d4"
             ],
-            "markers": "python_version >= '2.6'",
+            "index": "pypi",
             "version": "==5.6.0"
         },
         "pep8-naming": {
@@ -563,6 +568,7 @@
                 "sha256:5d9f1056cb9427ce344e98d1a7f5665710e2f20f748438e308995852cfa24164",
                 "sha256:f3b4a5f9dd72b991bf7d8e2a341d2e1aa3a884a769b5aaac4f56825c1763bf3a"
             ],
+            "index": "pypi",
             "version": "==0.10.0"
         },
         "prospector": {
@@ -581,7 +587,7 @@
                 "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367",
                 "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "index": "pypi",
             "version": "==2.6.0"
         },
         "pydocstyle": {
@@ -589,7 +595,7 @@
                 "sha256:164befb520d851dbcf0e029681b91f4f599c62c5cd8933fd54b1bfbd50e89e1f",
                 "sha256:d4449cf16d7e6709f63192146706933c7a334af7c0f083904799ccb851c50f6d"
             ],
-            "markers": "python_version >= '3.6'",
+            "index": "pypi",
             "version": "==6.0.0"
         },
         "pyflakes": {
@@ -597,7 +603,7 @@
                 "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92",
                 "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "index": "pypi",
             "version": "==2.2.0"
         },
         "pylint": {
@@ -605,13 +611,14 @@
                 "sha256:7dd78437f2d8d019717dbf287772d0b2dbdfd13fc016aa7faa08d67bccc46adc",
                 "sha256:d0ece7d223fe422088b0e8f13fa0a1e8eb745ebffcb8ed53d3e95394b6101a1c"
             ],
-            "markers": "python_version >= '3.5'",
+            "index": "pypi",
             "version": "==2.5.3"
         },
         "pylint-celery": {
             "hashes": [
                 "sha256:41e32094e7408d15c044178ea828dd524beedbdbe6f83f712c5e35bde1de4beb"
             ],
+            "index": "pypi",
             "version": "==0.3"
         },
         "pylint-django": {
@@ -619,12 +626,14 @@
                 "sha256:b7756844dba0cecd3471056a1ef4154439defedaba38bf3ced9f848d2bf6297c",
                 "sha256:ca32277c77878dd3c2d9e75f3f3f7f0c0712f053f10ff1b946cdc27367a6c911"
             ],
+            "index": "pypi",
             "version": "==2.1.0"
         },
         "pylint-flask": {
             "hashes": [
                 "sha256:f4d97de2216bf7bfce07c9c08b166e978fe9f2725de2a50a9845a97de7e31517"
             ],
+            "index": "pypi",
             "version": "==0.6"
         },
         "pylint-plugin-utils": {
@@ -632,6 +641,7 @@
                 "sha256:2f30510e1c46edf268d3a195b2849bd98a1b9433229bb2ba63b8d776e1fc4d0a",
                 "sha256:57625dcca20140f43731311cd8fd879318bf45a8b0fd17020717a8781714a25a"
             ],
+            "index": "pypi",
             "version": "==0.6"
         },
         "pyyaml": {
@@ -673,13 +683,16 @@
             "hashes": [
                 "sha256:0d1e13e61ed243f9c3c86e6cbb19980bcb3a0e0619cde2ec1f3af70fdbee6f7b"
             ],
+            "index": "pypi",
             "version": "==0.7"
         },
         "setoptconf": {
             "hashes": [
-                "sha256:5b0b5d8e0077713f5d5152d4f63be6f048d9a1bb66be15d089a11c898c3cf49c"
+                "sha256:1fa613dc4a6fbfbaab9a52319d1e369d030e8ed80455b151574ccf3390ec86c6",
+                "sha256:d2ecbd27c0c7d0d53990e2df98d9aad6490df8b75b71c621d8c441d6e91e3161"
             ],
-            "version": "==0.2.0"
+            "index": "pypi",
+            "version": "==0.3.0"
         },
         "six": {
             "hashes": [
@@ -694,7 +707,7 @@
                 "sha256:7e65386bd122d45405ddf795637b7f7d2b532e7e401d46bbe3fb49b9986d5182",
                 "sha256:a9a7479e4c572e2e775c404dcd3080c8dc49f39918c2cf74913d30c4c478e3c2"
             ],
-            "markers": "python_version >= '3.5'",
+            "index": "pypi",
             "version": "==4.0.0"
         },
         "snowballstemmer": {
@@ -702,6 +715,7 @@
                 "sha256:b51b447bea85f9968c13b650126a888aabd4cb4463fca868ec596826325dedc2",
                 "sha256:e997baa4f2e9139951b6f4c631bad912dfd3c792467e2f03d7239464af90e914"
             ],
+            "index": "pypi",
             "version": "==2.1.0"
         },
         "stevedore": {
@@ -709,7 +723,7 @@
                 "sha256:3a5bbd0652bf552748871eaa73a4a8dc2899786bc497a2aa1fcb4dcdb0debeee",
                 "sha256:50d7b78fbaf0d04cd62411188fa7eedcb03eb7f4c4b37005615ceebe582aa82a"
             ],
-            "markers": "python_version >= '3.6'",
+            "index": "pypi",
             "version": "==3.3.0"
         },
         "toml": {
@@ -717,7 +731,7 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "index": "pypi",
             "version": "==0.10.2"
         },
         "typed-ast": {
@@ -753,6 +767,7 @@
                 "sha256:f8afcf15cc511ada719a88e013cec87c11aff7b91f019295eb4530f96fe5ef2f",
                 "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"
             ],
+            "index": "pypi",
             "version": "==1.4.3"
         },
         "typing-extensions": {
@@ -761,12 +776,14 @@
                 "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342",
                 "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"
             ],
+            "index": "pypi",
             "version": "==3.10.0.0"
         },
         "wrapt": {
             "hashes": [
                 "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"
             ],
+            "index": "pypi",
             "version": "==1.12.1"
         }
     }


### PR DESCRIPTION
```
  +==============================================================================+
  |                                                                              |
  |                               /$$$$$$            /$$                         |
  |                              /$$__  $$          | $$                         |
  |           /$$$$$$$  /$$$$$$ | $$  \__//$$$$$$  /$$$$$$   /$$   /$$           |
  |          /$$_____/ |____  $$| $$$$   /$$__  $$|_  $$_/  | $$  | $$           |
  |         |  $$$$$$   /$$$$$$$| $$_/  | $$$$$$$$  | $$    | $$  | $$           |
  |          \____  $$ /$$__  $$| $$    | $$_____/  | $$ /$$| $$  | $$           |
  |          /$$$$$$$/|  $$$$$$$| $$    |  $$$$$$$  |  $$$$/|  $$$$$$$           |
  |         |_______/  \_______/|__/     \_______/   \___/   \____  $$           |
  |                                                          /$$  | $$           |
  |                                                         |  $$$$$$/           |
  |  by pyup.io                                              \______/            |
  |                                                                              |
  +==============================================================================+
  | REPORT                                                                       |
  | checked 110 packages, using free DB (updated once a month)                   |
  +============================+===========+==========================+==========+
  | package                    | installed | affected                 | ID       |
  +============================+===========+==========================+==========+
  | bottle                     | 0.12.19   | <0.12.20                 | 49258    |
  +==============================================================================+
  | Bottle before 0.12.20 mishandles errors during early request binding.        |
  +==============================================================================+
  | waitress                   | 2.1.1     | >=2.1.0,<2.1.2           | 49257    |
  +==============================================================================+
  | Waitress 2.1.2 includes a fix for CVE-2022-31015: Waitress versions 2.1.0    |
  | and 2.1.1 may terminate early due to a thread closing a socket while the     |
  | main thread is about to call select(). This will lead to the main thread     |
  | raising an exception that is not handled and then causing the entire         |
  | application to be killed. This issue has been fixed in Waitress 2.1.2 by no  |
  | longer allowing the WSGI thread to close the socket. Instead, that is always |
  | delegated to the main thread. There is no workaround for this issue,         |
  | however, users using waitress behind a reverse proxy server are less likely  |
  | to have issues if the reverse proxy always reads the full response.          |
  | https://github.com/Pylons/waitress/security/advisories/GHSA-f5x9-8jwc-25rw   |
  +==============================================================================+
```