### PR TITLE
Fix the editing

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/views/layers.py
+++ b/geoportal/c2cgeoportal_geoportal/views/layers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2012-2021, Camptocamp SA
+# Copyright (c) 2012-2022, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without
@@ -502,8 +502,6 @@ def get_layer_class(layer, with_last_update_columns=False):
         last_update_user = Layers.get_metadata(layer, "lastUpdateUserColumn")
         if last_update_user is not None:
             exclude.append(last_update_user)
-    else:
-        exclude = []
 
     m = Layers.get_metadata(layer, "editingAttributesOrder")
     attributes_order = m.split(",") if m else None


### PR DESCRIPTION
The layer.exclude_properties should always be used to don't break the
Dogpile cache, and create tow SQLAlchemy Table on the same database table.