### PR TITLE
Ignore CVE

### DIFF
--- a/docker/qgisserver/.snyk
+++ b/docker/qgisserver/.snyk
@@ -1,0 +1,9 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  'SNYK-PYTHON-WHEEL-3092128':
+    - '*':
+        reason: Patched version not available tor used Python version
+        created: 2022-11-02T08:46:52.047Z
+patch: {}


### PR DESCRIPTION
    Upgrade wheel@0.34.2 to wheel@0.38.0 to fix
    ✗ Regular Expression Denial of Service (ReDoS) (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-WHEEL-3092128] in wheel@0.34.2
      introduced by wheel@0.34.2