### PR TITLE
Fix webpack_dev_server build with buildkit

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/docker-compose-lib.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/docker-compose-lib.yaml
@@ -434,6 +434,7 @@ services:
       target: builder
       args:
         GEOMAPFISH_VERSION: ${GEOMAPFISH_VERSION}
+        GEOMAPFISH_MAIN_VERSION: ${GEOMAPFISH_MAIN_VERSION}
     volumes:
       - ./geoportal/${PACKAGE}_geoportal/static-ngeo:/app/${PACKAGE}_geoportal/static-ngeo
     environment:


### PR DESCRIPTION
Already fixed in 2.8, not relevant in 2.6.