### PR TITLE
Admin - Set default default sort on logs to date desc

### DIFF
--- a/admin/c2cgeoportal_admin/views/logs.py
+++ b/admin/c2cgeoportal_admin/views/logs.py
@@ -51,6 +51,7 @@ class LogViews(AbstractViews):  # type: ignore
         _list_field("element_id", label=_("Element identifier")),
         _list_field("element_name", label=_("Element name")),
     ]
+    _list_ordered_fields = [AbstractLog.date.desc()]
 
     _id_field = "id"
     _model = AbstractLog

--- a/admin/tests/test_logs.py
+++ b/admin/tests/test_logs.py
@@ -83,10 +83,7 @@ class TestLog(AbstractViewsTests):
                 reverse=True,
             )
         ]
-        result_ids = [
-            int(row["_id_"])
-            for row in json["rows"]
-        ]
+        result_ids = [int(row["_id_"]) for row in json["rows"]]
         assert result_ids == expected_ids
 
     def test_grid_sort_on_element_type(self, test_app, logs_test_data):
@@ -98,10 +95,7 @@ class TestLog(AbstractViewsTests):
                 key=lambda log: (log.element_type, -log.date.timestamp()),
             )
         ]
-        result_ids = [
-            int(row["_id_"])
-            for row in json["rows"]
-        ]
+        result_ids = [int(row["_id_"]) for row in json["rows"]]
         assert result_ids == expected_ids
 
     def test_grid_search(self, test_app):

--- a/admin/tests/test_logs.py
+++ b/admin/tests/test_logs.py
@@ -73,12 +73,36 @@ class TestLog(AbstractViewsTests):
         ]
         self.check_grid_headers(resp, expected, new=False)
 
+    def test_grid_default_sort_on_date_desc(self, test_app, logs_test_data):
+        json = self.check_search(test_app)
+        expected_ids = [
+            log.id
+            for log in sorted(
+                logs_test_data["logs"],
+                key=lambda log: log.date,
+                reverse=True,
+            )
+        ]
+        result_ids = [
+            int(row["_id_"])
+            for row in json["rows"]
+        ]
+        assert result_ids == expected_ids
+
     def test_grid_sort_on_element_type(self, test_app, logs_test_data):
         json = self.check_search(test_app, sort="element_type")
-        for i, log in enumerate(sorted(logs_test_data["logs"], key=lambda log: (log.element_type, log.id))):
-            if i == 10:
-                break
-            assert str(log.id) == json["rows"][i]["_id_"]
+        expected_ids = [
+            log.id
+            for log in sorted(
+                logs_test_data["logs"],
+                key=lambda log: (log.element_type, -log.date.timestamp()),
+            )
+        ]
+        result_ids = [
+            int(row["_id_"])
+            for row in json["rows"]
+        ]
+        assert result_ids == expected_ids
 
     def test_grid_search(self, test_app):
         self.check_search(test_app, "role", total=5)


### PR DESCRIPTION
Follow testbook review.

I prefer to ask tester to check default sort is date desc instead of asking him to sort by date desc.