### PR TITLE
Fix Open Redirect, simplify and uniformize the checks

### DIFF
--- a/admin/c2cgeoportal_admin/__init__.py
+++ b/admin/c2cgeoportal_admin/__init__.py
@@ -95,7 +95,7 @@ def main(_, **settings):
         property=True,
     )
 
-    config.add_route("ogc_server_clear_cache", "/ogc_server_clear_cache/{id}")
+    config.add_route("ogc_server_clear_cache", "/admin/ogc_server_clear_cache/{id}")
 
     config.add_subscriber(add_renderer_globals, BeforeRender)
     config.add_subscriber(add_localizer, NewRequest)

--- a/doc/integrator/authentication.rst
+++ b/doc/integrator/authentication.rst
@@ -1,6 +1,7 @@
 Authentication
 --------------
 
+~~~~~~~~~~~~~~~~~~~
 Supported standards
 ~~~~~~~~~~~~~~~~~~~
 
@@ -9,6 +10,7 @@ Supported standards
   authentication, even if it was initially implemented to be able to connect from QGIS desktop on an
   application that requires two factor authentication.
 
+~~~~~~~~~~~~~~~~~~
 The default policy
 ~~~~~~~~~~~~~~~~~~
 
@@ -39,6 +41,7 @@ In the file ``env.project``, you can configure the policy with the following var
 See also `the official documentation <https://docs.pylonsproject.org/projects/pyramid/en/latest/api/authentication.html#pyramid.authentication.AuthTktAuthenticationPolicy>`_.
 
 
+~~~~~~~~~~~~~~~~~~~~
 Using another policy
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -47,6 +50,7 @@ set in the request for the user to be identified. In some applications, using
 a custom identification mechanism may be needed instead, for instance to use SSO.
 Our knowledge base has an example of how this can be achieved.
 
+~~~~~~~~~~~~~~~
 User validation
 ~~~~~~~~~~~~~~~
 
@@ -56,6 +60,7 @@ table. If a c2cgeoportal application should work with another user information
 source, like LDAP, a custom *client validation* mechanism can be set up.
 Our knowledge base has an example of how this can be achieved.
 
+~~~~~~~~~~
 Basic auth
 ~~~~~~~~~~
 
@@ -69,6 +74,7 @@ in your query string.
 
    For security reasons, basic authentication and two factor authentication should not be enabled together.
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 Two factors authentication
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -91,6 +97,7 @@ should uncheck the 'The user changed his password' field on the user in the admi
    For security reasons, basic authentication and two factor authentication should not be enabled together,
    you should use :ref:`OAuth2<integrator_authentication_oauth2>` for that.
 
+~~~~~~~~~~~~~~~
 Account lockout
 ~~~~~~~~~~~~~~~
 
@@ -105,6 +112,7 @@ To lock an account after a certain number of authentication failures, set the fo
 To unlock a user, the administrator should uncheck the 'Deactivated' field on the user in the
 admin interface.
 
+~~~~~~~~
 Intranet
 ~~~~~~~~
 
@@ -131,6 +139,7 @@ See `Python documentation <https://docs.python.org/3.4/library/ipaddress.html#ip
 
    A user can easily manually set the `Forwarded` or `X-Forwarded-For` header to spoof his IP.
 
+~~~~~~~~~~~~~~~~~~~
 Lost admin password
 ~~~~~~~~~~~~~~~~~~~
 
@@ -139,3 +148,33 @@ You can generate a new admin password the following command:
 .. argparse::
    :ref: c2cgeoportal_geoportal.scripts.manage_users.get_argparser
    :prog: docker-compose exec geoportal manage-users
+
+~~~~~~~~~~~~~~~~~~~~
+External application
+~~~~~~~~~~~~~~~~~~~~
+
+Some service of GeoMapFish has some host restriction if you mix the domain.
+
+Application authentication
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To be considered as authenticated we should have the correct `Cookie` header,
+we also check the `Referrer` header to be sure that the user is coming from the same domain.
+If he is equals to the `Host` header, we consider that the user is coming from the same domain.
+If your server and client application are not on the same domain, to make the login working,
+you should add the client application domain name (with port) in the vars in `vars/authorized_referers`.
+
+This check is also done on the `came_from` parameter during the login process.
+
+Shortener
+~~~~~~~~~
+
+If you use the shortener service to create link on application on another domain name, you should add
+this domain name in the vars in `vars/shortener/allowed_hosts`.
+
+Admin
+~~~~~
+
+We provide a view for the admin interface, to be able to clear the cache per OGC server.
+If for an unknown reason you have not the same host in the `Host` header and `came_from` parameter, you should
+add the domain of the `came_from` parameter in the vars in `vars/admin_interface/allowed_hosts`.

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/geoportal/vars.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/geoportal/vars.yaml
@@ -342,7 +342,6 @@ update_paths:
   - admin_interface.functionalities
   - admin_interface.available_in_templates
   - api
-  - authorized_referers
   - cache.std.arguments
   - cache.ogc-server.arguments
   - cache.obj

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/CONST_CHANGELOG.txt
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/CONST_CHANGELOG.txt
@@ -1,5 +1,25 @@
 This file includes migration steps for each release of c2cgeoportal.
 
+=============
+Version 2.9.0
+=============
+
+Information to know before starting the upgrade
+===============================================
+
+
+Information
+===========
+
+1. Hostname check:
+   We add a hostname check on the `came_from` parameter, in the oauth2 login, allowed by
+   `vars.authentication.allowed_hosts` and in the OGC server clear cache, allowed by `vars.allowed_hosts`.
+   The behavior change a little bit in the `shortener.allowed_hosts` and in the `authorized_referers`.
+   Now everywhere:
+   - If the hostname (with port) of the candidate URL equals to the request's header "Host", then it's OK.
+   - If the hostname (with port) of the candidate URL is in the allowed list, then it's OK.
+   And they should be netloc (hostname with port) without schema or path.
+
 
 =============
 Version 2.8.0

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_config-schema.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_config-schema.yaml
@@ -409,6 +409,11 @@ mapping:
                   model:
                     type: str
                     required: True
+          # Host allowed in the OGC server clear cache
+          allowed_hosts:
+            type: seq
+            sequence:
+              - type: str
 
       getitfixed:
         type: map

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_vars.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_vars.yaml
@@ -934,8 +934,6 @@ vars:
   shortener:
     # The base of created URL
     base_url: '{VISIBLE_WEB_PROTOCOL}://{VISIBLE_WEB_HOST}{VISIBLE_ENTRY_POINT}s/'
-    allowed_hosts:
-      - '{VISIBLE_WEB_HOST}'
     length: 4
 
   # Define whether the MapServer proxy should hide the OGC capabilities.
@@ -1243,8 +1241,7 @@ vars:
     level: 10
 
   # What web page is authorized to use the API
-  authorized_referers:
-    - '{VISIBLE_WEB_PROTOCOL}://{VISIBLE_WEB_HOST}/'
+  authorized_referers: []
 
   metrics:
     memory_maps_rss: False

--- a/geoportal/c2cgeoportal_geoportal/views/shortener.py
+++ b/geoportal/c2cgeoportal_geoportal/views/shortener.py
@@ -39,6 +39,7 @@ from pyramid.view import view_config
 from c2cgeoportal_commons.lib.email_ import send_email_config
 from c2cgeoportal_commons.models import DBSession
 from c2cgeoportal_commons.models.static import Shorturl
+from c2cgeoportal_geoportal import is_allowed_url
 from c2cgeoportal_geoportal.lib.common_headers import Cache, set_common_headers
 
 logger = logging.getLogger(__name__)
@@ -79,23 +80,20 @@ class Shortener:
         if len(url) > 8190:
             raise HTTPBadRequest(f"The parameter url is too long ({len(url)} > {8190})")
 
-        # Check that it is an internal URL...
-        uri_parts = urlparse(url)
-        if "allowed_hosts" in self.settings:
-            if uri_parts.netloc not in self.settings["allowed_hosts"]:
-                raise HTTPBadRequest(
-                    f"The requested host '{uri_parts.netloc}' is not part of allowed hosts: "
-                    f"{', '.join(self.settings['allowed_hosts'])}"
-                )
-        else:
-            hostname = uri_parts.hostname
-            if hostname != self.request.server_name:
-                raise HTTPBadRequest(
-                    f"The requested host '{hostname!s}' should be '{self.request.server_name!s}'"
-                )
+        allowed_hosts = self.settings.get("allowed_hosts", [])
+        url_hostname, ok = is_allowed_url(self.request, url, allowed_hosts)
+        if not ok:
+            message = (
+                f"Invalid requested host '{url_hostname}', "
+                f"is not the current host '{self.request.host}' "
+                f"or part of allowed hosts: {', '.join(allowed_hosts)}"
+            )
+            logging.debug(message)
+            raise HTTPBadRequest(message)
 
         shortened = False
 
+        uri_parts = urlparse(url)
         for base in self.short_bases:
             base_parts = urlparse(base)
             if uri_parts.path.startswith(base_parts.path):

--- a/geoportal/tests/functional/__init__.py
+++ b/geoportal/tests/functional/__init__.py
@@ -243,6 +243,8 @@ def create_dummy_request(
         *args,
         **kargs,
     )
+    request.host = "example.com"
+    request.referrer = "example.com"
 
     global config
     config = pyramid.testing.setUp(

--- a/geoportal/tests/functional/conftest.py
+++ b/geoportal/tests/functional/conftest.py
@@ -28,9 +28,15 @@
 from unittest.mock import patch
 
 import pytest
+import sqlalchemy.orm
+import transaction
 from c2c.template.config import config as configuration
 from pyramid.testing import DummyRequest
 from tests.functional import setup_common as setup_module
+
+from c2cgeoportal_geoportal.lib import caching
+
+mapserv_url = "http://mapserver:8080/"
 
 
 @pytest.fixture
@@ -73,3 +79,17 @@ def dummy_request(dbsession):
     request.dbsession = dbsession
 
     return request
+
+
+@pytest.fixture
+def default_ogcserver(dbsession, transact):
+    from c2cgeoportal_commons.models.main import OGCServer
+
+    del transact
+
+    ogcserver = OGCServer(name="__test_ogc_server")
+    ogcserver.url = mapserv_url
+    dbsession.add(ogcserver)
+    dbsession.flush()
+
+    yield ogcserver

--- a/geoportal/tests/functional/test_login.py
+++ b/geoportal/tests/functional/test_login.py
@@ -115,12 +115,12 @@ class TestLoginView(TestCase):
             params={"came_from": "/came_from"}, POST={"login": "__test_user1", "password": "__test_user1"}
         )
         response = Login(request).login()
-        assert response.status_int == 302
+        assert response.status_int == 302, response.body
         assert response.headers["Location"] == "/came_from"
 
         request = self._create_request_obj(POST={"login": "__test_user1", "password": "__test_user1"})
         response = Login(request).login()
-        assert response.status_int == 200
+        assert response.status_int == 200, response.body
         assert json.loads(response.body.decode("utf-8")) == {
             "username": "__test_user1",
             "email": "__test_user1@example.com",
@@ -152,14 +152,14 @@ class TestLoginView(TestCase):
         request = self._create_request_obj(path="/")
         request.user = DBSession.query(User).filter_by(username="__test_user1").one()
         response = Login(request).logout()
-        assert response.status_int == 200
+        assert response.status_int == 200, response.body
         assert response.body.decode("utf-8") == "true"
 
         request = self._create_request_obj(path="/")
         request.route_url = lambda url: "/dummy/route/url"
         request.user = DBSession.query(User).filter_by(username="__test_user1").one()
         response = Login(request).logout()
-        assert response.status_int == 200
+        assert response.status_int == 200, response.body
         assert response.body.decode("utf-8") == "true"
 
     def test_reset_password(self):
@@ -175,7 +175,7 @@ class TestLoginView(TestCase):
 
         request = self._create_request_obj(POST={"login": username, "password": password})
         response = Login(request).login()
-        assert response.status_int == 200
+        assert response.status_int == 200, response.body
         assert json.loads(response.body.decode("utf-8")) == {
             "username": "__test_user1",
             "is_password_changed": False,

--- a/geoportal/tests/functional/test_oauth2.py
+++ b/geoportal/tests/functional/test_oauth2.py
@@ -127,6 +127,7 @@ class TestLoginView(TestCase):
             "type": "oauth2",
         }
         request.method = "POST"
+        request.host = "127.0.0.1:7070"
         request.body = ""
         with pytest.raises(pyramid.httpexceptions.HTTPFound) as exc_info:
             Login(request).login()
@@ -145,6 +146,7 @@ class TestLoginView(TestCase):
             "grant_type": "authorization_code",
             "redirect_uri": "http://127.0.0.1:7070/",
         }
+        request.host = "127.0.0.1:7070"
         request.body = urllib.parse.urlencode(request.POST)
         request.method = "POST"
         response = Login(request).oauth2token()
@@ -185,6 +187,7 @@ class TestLoginView(TestCase):
             "response_type": "code",
             "type": "oauth2",
         }
+        request.host = "127.0.0.1:7070"
         request.method = "POST"
         request.body = ""
         with pytest.raises(pyramid.httpexceptions.HTTPFound) as exc_info:
@@ -204,6 +207,7 @@ class TestLoginView(TestCase):
             "grant_type": "authorization_code",
             "redirect_uri": "http://127.0.0.1:7070/",
         }
+        request.host = "127.0.0.1:7070"
         request.body = urllib.parse.urlencode(request.POST)
         request.method = "POST"
         with pytest.raises(pyramid.httpexceptions.HTTPUnauthorized):
@@ -221,6 +225,7 @@ class TestLoginView(TestCase):
             "grant_type": "authorization_code",
             "redirect_uri": "http://127.0.0.1:7070/",
         }
+        request.host = "127.0.0.1:7070"
         request.body = urllib.parse.urlencode(request.POST)
         request.method = "POST"
         with pytest.raises(pyramid.httpexceptions.HTTPBadRequest):
@@ -239,6 +244,7 @@ class TestLoginView(TestCase):
             "response_type": "code",
             "type": "oauth2",
         }
+        request.host = "127.0.0.1:7070"
         request.method = "POST"
         request.body = ""
         with pytest.raises(pyramid.httpexceptions.HTTPFound) as exc_info:
@@ -258,6 +264,7 @@ class TestLoginView(TestCase):
             "grant_type": "authorization_code",
             "redirect_uri": "http://127.0.0.1:7070/",
         }
+        request.host = "127.0.0.1:7070"
         request.body = urllib.parse.urlencode(request.POST)
         request.method = "POST"
         response = Login(request).oauth2token()
@@ -319,6 +326,7 @@ class TestLoginView(TestCase):
             "response_type": "code",
             "type": "oauth2",
         }
+        request.host = "127.0.0.1:7070"
         request.method = "POST"
         request.body = ""
         with pytest.raises(pyramid.httpexceptions.HTTPFound) as exc_info:
@@ -339,6 +347,7 @@ class TestLoginView(TestCase):
             "grant_type": "authorization_code",
             "redirect_uri": "http://127.0.0.1:7070/",
         }
+        request.host = "127.0.0.1:7070"
         request.body = urllib.parse.urlencode(request.POST)
         request.method = "POST"
         response = Login(request).oauth2token()
@@ -400,6 +409,7 @@ class TestLoginView(TestCase):
             "response_type": "code",
             "type": "oauth2",
         }
+        request.host = "127.0.0.1:7070"
         request.method = "POST"
         request.body = ""
         with pytest.raises(pyramid.httpexceptions.HTTPFound) as exc_info:
@@ -420,6 +430,7 @@ class TestLoginView(TestCase):
             "grant_type": "authorization_code",
             "redirect_uri": "http://127.0.0.1:7070/",
         }
+        request.host = "127.0.0.1:7070"
         request.body = urllib.parse.urlencode(request.POST)
         request.method = "POST"
         with pytest.raises(pyramid.httpexceptions.HTTPBadRequest):
@@ -438,6 +449,7 @@ class TestLoginView(TestCase):
             "response_type": "code",
             "type": "oauth2",
         }
+        request.host = "127.0.0.1:7070"
         request.method = "POST"
         request.body = ""
         with pytest.raises(pyramid.httpexceptions.HTTPFound) as exc_info:
@@ -457,6 +469,7 @@ class TestLoginView(TestCase):
             "grant_type": "authorization_code",
             "redirect_uri": "http://127.0.0.1:7070/",
         }
+        request.host = "127.0.0.1:7070"
         request.body = urllib.parse.urlencode(request.POST)
         request.method = "POST"
         response = Login(request).oauth2token()
@@ -524,6 +537,7 @@ class TestLoginView(TestCase):
             "response_type": "code",
             "type": "oauth2",
         }
+        request.host = "127.0.0.1:7070"
         request.method = "POST"
         request.body = ""
         pyramid.testing.setUp(request=request, registry=init_registry())
@@ -566,6 +580,7 @@ class TestLoginView(TestCase):
             "code_challenge": code_challenge,
             "code_challenge_method": "S256",
         }
+        request.host = "127.0.0.1:7070"
         request.method = "POST"
         request.body = ""
         with pytest.raises(pyramid.httpexceptions.HTTPFound) as exc_info:
@@ -586,6 +601,7 @@ class TestLoginView(TestCase):
             "grant_type": "authorization_code",
             "redirect_uri": "http://127.0.0.1:7070/",
         }
+        request.host = "127.0.0.1:7070"
         request.body = urllib.parse.urlencode(request.POST)
         request.method = "POST"
         response = Login(request).oauth2token()
@@ -659,6 +675,7 @@ class TestLoginView(TestCase):
             "code_challenge": code_challenge,
             "code_challenge_method": "S256",
         }
+        request.host = "127.0.0.1:7070"
         request.method = "POST"
         request.body = ""
         with pytest.raises(pyramid.httpexceptions.HTTPFound) as exc_info:
@@ -680,6 +697,7 @@ class TestLoginView(TestCase):
             "grant_type": "authorization_code",
             "redirect_uri": "http://127.0.0.1:7070/",
         }
+        request.host = "127.0.0.1:7070"
         request.body = urllib.parse.urlencode(request.POST)
         request.method = "POST"
         response = Login(request).oauth2token()
@@ -739,6 +757,7 @@ class TestLoginView(TestCase):
             "response_type": "code",
             "type": "oauth2",
         }
+        request.host = "127.0.0.1:7070"
         request.method = "POST"
         request.body = ""
         with pytest.raises(pyramid.httpexceptions.HTTPBadRequest) as exc_info:
@@ -757,6 +776,7 @@ class TestLoginView(TestCase):
             "response_type": "code",
             "type": "oauth2",
         }
+        request.host = "127.0.0.1:7070"
         request.method = "POST"
         request.body = ""
         with pytest.raises(pyramid.httpexceptions.HTTPFound) as exc_info:
@@ -785,6 +805,7 @@ class TestLoginView(TestCase):
             "code_challenge": code_challenge,
             "code_challenge_method": "S256",
         }
+        request.host = "127.0.0.1:7070"
         request.method = "POST"
         request.body = ""
         with pytest.raises(pyramid.httpexceptions.HTTPBadRequest) as exc_info:
@@ -815,6 +836,7 @@ class TestLoginView(TestCase):
             "code_challenge": code_challenge,
             "code_challenge_method": "S256",
         }
+        request.host = "127.0.0.1:7070"
         request.method = "POST"
         request.body = ""
         with pytest.raises(pyramid.httpexceptions.HTTPFound) as exc_info:
@@ -835,6 +857,7 @@ class TestLoginView(TestCase):
             "grant_type": "authorization_code",
             "redirect_uri": "http://127.0.0.1:7070/",
         }
+        request.host = "127.0.0.1:7070"
         request.body = urllib.parse.urlencode(request.POST)
         request.method = "POST"
         with pytest.raises(pyramid.httpexceptions.HTTPBadRequest) as exc_info:

--- a/geoportal/tests/functional/test_shortener.py
+++ b/geoportal/tests/functional/test_shortener.py
@@ -60,7 +60,7 @@ class TestshortenerView(TestCase):
 
         request = DummyRequest()
         request.user = None
-        request.host = "example.com:443"
+        request.host = "example.com"
         request.server_name = "example.com"
         request.route_url = route_url
         request.registry.settings["shortener"] = {"base_url": "https://example.com/s/"}
@@ -88,7 +88,7 @@ class TestshortenerView(TestCase):
 
         request = DummyRequest()
         request.user = None
-        request.host = "example.com:443"
+        request.host = "example.com"
         request.server_name = "example.com"
         request.route_url = route_url
         request.registry.settings["shortener"] = {"base_url": "https://example.com/s/"}
@@ -116,7 +116,7 @@ class TestshortenerView(TestCase):
 
         request = DummyRequest()
         request.user = None
-        request.host = "example.com:443"
+        request.host = "example.com"
         request.server_name = "example.com"
         request.route_url = route_url
         request.registry.settings["shortener"] = {}
@@ -145,7 +145,7 @@ class TestshortenerView(TestCase):
 
         request = DummyRequest()
         request.user = None
-        request.host = "example.com:443"
+        request.host = "example.com"
         request.server_name = "example.com"
         request.route_url = route_url
         request.registry.settings["shortener"] = {"base_url": "https://example.com/s/"}
@@ -165,7 +165,7 @@ class TestshortenerView(TestCase):
 
         request = DummyRequest()
         request.user = None
-        request.host = "example.com:443"
+        request.host = "example.com"
         request.server_name = "example.com"
         request.route_url = route_url
         request.registry.settings["shortener"] = {"base_url": "https://example.com/s/"}
@@ -185,7 +185,7 @@ class TestshortenerView(TestCase):
 
         request = DummyRequest()
         request.user = None
-        request.host = "example.com:443"
+        request.host = "example.com"
         request.server_name = "example.com"
         request.route_url = route_url
         request.registry.settings["shortener"] = {"base_url": "http://my_host/my_short/"}


### PR DESCRIPTION
✗ [Medium] Open Redirect
Path: geoportal/c2cgeoportal_geoportal/views/login.py, line 196
Info: Unsanitized input from an HTTP parameter flows into pyramid.httpexceptions.HTTPFound, where it is used as an URL to redirect the user. This may result in an Open Redirect vulnerability.

✗ [Medium] Open Redirect
Path: geoportal/c2cgeoportal_geoportal/views/login.py, line 240
Info: Unsanitized input from an HTTP parameter flows into pyramid.httpexceptions.HTTPFound, where it is used as an URL to redirect the user. This may result in an Open Redirect vulnerability.

✗ [Medium] Open Redirect
Path: geoportal/c2cgeoportal_geoportal/views/theme.py, line 1206
Info: Unsanitized input from an HTTP parameter flows into pyramid.httpexceptions.HTTPFound, where it is used as an URL to redirect the user. This may result in an Open Redirect vulnerability.

See also: https://jira.camptocamp.com/browse/GSGMF-1909