### PR TITLE
Referrer, while orthographically correct, is not the parameter name a…

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/print/print-apps/{{cookiecutter.package}}/config.yaml.tmpl
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/print/print-apps/{{cookiecutter.package}}/config.yaml.tmpl
@@ -82,7 +82,6 @@ templates:
           - !forwardHeaders
             headers:
               - Referer
-              - Referrer
               - X-Request-ID
               - Forwarded
           - !restrictUris


### PR DESCRIPTION
…s defined in the http specification, which is 'referer'.