### PR TITLE
Fix CVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "angular-gettext-tools": "2.5.3",
     "commander": "7.0.0",
-    "puppeteer": "5.5.0",
+    "puppeteer": "18.2.0",
     "url-parse": "1.5.10"
   }
 }


### PR DESCRIPTION
    Upgrade puppeteer@5.5.0 to puppeteer@18.2.0 to fix
    ✗ Missing Release of Resource after Effective Lifetime (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-JS-INFLIGHT-6095116] in inflight@1.0.6
      introduced by puppeteer@5.5.0 > rimraf@3.0.2 > glob@7.2.3 > inflight@1.0.6