### PR TITLE
Add missing space to script

### DIFF
--- a/scripts/clone_schema.sql
+++ b/scripts/clone_schema.sql
@@ -90,7 +90,7 @@ BEGIN
         || ' MAXVALUE ' || seq.maximum_value
         || ' START WITH ' || seq.start_value
         || ' RESTART ' || seq.minimum_value
-        || sq_cycled || ';';
+        || ' ' || sq_cycled || ';';
 
     buffer := quote_ident(dest_schema) || '.' || quote_ident(seq.sequence_name);
     IF include_recs


### PR DESCRIPTION
Add missing space to script. In some versions of PostgreSQL, the missing space is problematic (tested with PostgreSQL 15).