### PR TITLE
Remove wrong preload option 

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/advance_create/{{cookiecutter.project}}/geoportal/gunicorn.conf.py
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/advance_create/{{cookiecutter.project}}/geoportal/gunicorn.conf.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, Camptocamp SA
+# Copyright (c) 2019-2024, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without
@@ -49,8 +49,6 @@ max_requests = int(os.environ.get("GUNICORN_MAX_REQUESTS", 1000))
 max_requests_jitter = int(os.environ.get("GUNICORN_MAX_REQUESTS_JITTER", 100))
 worker_tmp_dir = "/dev/shm"  # nosec
 limit_request_line = int(os.environ.get("GUNICORN_LIMIT_REQUEST_LINE", 8190))
-
-preload = "true"
 
 accesslog = "-"
 access_log_format = os.environ.get(


### PR DESCRIPTION
The preload mode don't looks to works with the broadcasting of
c2cwsgiutils.

See: https://docs.gunicorn.org/en/stable/settings.html#preload-app