### PR TITLE
Fix CVE

### DIFF
--- a/geoportal/.snyk
+++ b/geoportal/.snyk
@@ -1,0 +1,10 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JS-INFLIGHT-6095116:
+    - '*':
+        reason: Requires a new node version to fix (^18.18.0, ^20.9.0, or >=21.1.0)
+        expires: 2024-05-09T06:44:05.988Z
+        created: 2024-04-09T06:44:05.991Z
+patch: {}


### PR DESCRIPTION
    Upgrade eslint@8.33.0 to eslint@9.0.0 to fix
    ✗ Missing Release of Resource after Effective Lifetime [Medium Severity][https://security.snyk.io/vuln/SNYK-JS-INFLIGHT-6095116] in inflight@1.0.6
      introduced by eslint@8.33.0 > file-entry-cache@6.0.1 > flat-cache@3.2.0 > rimraf@3.0.2 > glob@7.2.3 > inflight@1.0.6