### PR TITLE
Fix CVE

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,1 +1,2 @@
 c2cciutils==1.1.37
+setuptools>=65.5.1


### PR DESCRIPTION
    Upgrade setuptools@60.10.0 to setuptools@65.5.1 to fix
    ✗ Regular Expression Denial of Service (ReDoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-SETUPTOOLS-3180412] in setuptools@60.10.0
      introduced by setuptools@60.10.0