### PR TITLE
Don't do 2 SQL updates per editing

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/lib/dbreflection.py
+++ b/geoportal/c2cgeoportal_geoportal/lib/dbreflection.py
@@ -130,14 +130,19 @@ def get_table(
     # create table and reflect it
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", "Did not recognize type 'geometry' of column", SAWarning)
-        args = [tablename, metadata]
+        args = []
         if primary_key is not None:
             # Ensure we have a primary key to be able to edit views
             args.append(Column(primary_key, Integer, primary_key=True))
         with _get_table_lock:
-            table = Table(*args, schema=schema, autoload_with=engine)  # type: ignore[arg-type]
-        print(f"Table {tablename} loaded")
-        print([c.name for c in table.columns])
+            table = Table(
+                tablename,
+                metadata,
+                *args,
+                schema=schema,
+                autoload_with=engine,
+                keep_existing=True,
+            )
     return table
 
 


### PR DESCRIPTION
Be able to use existing table

Don't do 2 updates per editing:
In papyrus, there is a flush that creates a first INSERT or UPDATE
The idea is to update the fields in the before_* callback to avoid having two REQUESTS

<!-- pull request links -->
See JIRA issue: [GSSIT-114](https://camptocamp.atlassian.net/browse/GSSIT-114).

[GSSIT-114]: https://camptocamp.atlassian.net/browse/GSSIT-114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ