### PR TITLE
Add missing configuration in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,9 @@
 [tool.black]
 line-length = 110
 target-version = ['py38']
+
+[tool.poetry]
+name = "c2cgeoportal"
+version = "0.0.0"
+description = 'Not used'
+authors = ["Camptocamp <info@camptocamp.com>"]


### PR DESCRIPTION
Needed to make `poetry --version` work, used in the audit.