### PR TITLE
Add custom interface type

### DIFF
--- a/doc/integrator/configuration.rst
+++ b/doc/integrator/configuration.rst
@@ -10,6 +10,7 @@ This chapter describes advanced configuration settings.
 
    build
    runtime
+   interface
    ngeo
    backend
    caching

--- a/doc/integrator/interface.rst
+++ b/doc/integrator/interface.rst
@@ -1,0 +1,79 @@
+.. _integrator_interface:
+
+Introduction
+------------
+
+This chapter describes how to integrate a new ``custom`` interface in a c2cgeoportal application.
+
+``custom`` means that interface can be based on another frontend than ngeo even if at the end of this
+document we will speak about how to integrate ngeo as a custom interface with a simple build chain.
+
+Review
+------
+
+In the c2cgeoportal application we have by default 3 interfaces: desktop, mobile and iframe.
+
+c2cgeoportal provide different things around interface but they are not hard linked:
+
+- The interface in the admin interface is a way to define the layers visible in the interface.
+- The ``interfaces_config`` in the ``vars.yaml`` is a way to define configurations for every interface.
+- The ``interface`` in the ``vars.yaml`` is a way to configure interfaces route in c2cgeoportal: ``/``,
+  ``/theme/<theme>``, ``/<interface>`` and ``/<interface>/theme/<theme_name>``.
+
+Configuration
+-------------
+
+Here we will describe how to add a new ``custom`` interface in a c2cgeoportal application,
+for that we should add a new entry in the ``interface_config`` with the ``type`` set to ``custom``.
+
+.. code:: yaml
+
+    vars:
+      interfaces_config:
+        custom:
+          type: custom
+          name: my_interface
+
+We can also add an optional ``html_filename`` attribute in the config to specify the file that should be used for the interface,
+with relative (from ``/etc/static-frontend``) or absolute file name.
+
+Interface integration
+---------------------
+
+To publish interfaces we should provide interfaces files (HTML, CSS, JavaScript, images, ...) in
+the ``/etc/static-frontend/`` directory.
+
+The interface files should be in a directory named with the interface name suffixed by ``.html``.
+
+Note that this folder is also available on the ``/static-frontend/`` endpoint with cache headers without
+any cash bustering, then files (other than interfaces HTML files) should contains an hash.
+
+If you need cache bustering you should put your files in the ``geoportal/geomapfish_geoportal/static/``
+directory (``/etc/geomapfish/static`` in the container).
+
+The interface HTML file is considered as mako template and he can use the following variables:
+- ``request``: the Pyramid request object.
+- ``dynamicUrl``: the URL to get the interface configuration.
+- ``interface``: the interface name.
+- ``staticFrontend``: the URL to the static frontend directory.
+- ``staticCashBuster``: the URL to the static cash buster directory.
+
+For that you should create a Docker image that provide a ``/etc/static-frontend/`` volume (``VOLUME /etc/static-frontend``).
+
+And include it in the ``docker-compose.yaml`` file with something like:
+
+.. code:: yaml
+
+    services:
+      my_interface:
+        image: my_interface
+        user: www-data
+
+      geoportal:
+        volumes_from:
+          - my_interface:ro
+
+Ngeo integration
+----------------
+
+TODO

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/Dockerfile
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/Dockerfile
@@ -14,7 +14,7 @@ ENV CONFIG_VARS sqlalchemy.url sqlalchemy.pool_recycle sqlalchemy.pool_size sqla
     dbsessions urllogin host_forward_host headers_whitelist headers_blacklist \
     smtp c2c.base_path welcome_email \
     lingva_extractor interfaces_config interfaces devserver_url api authentication intranet metrics pdfreport \
-    vector_tiles i18next main_ogc_server
+    vector_tiles i18next main_ogc_server static_files
 
 COPY . /tmp/config/
 

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_config-schema.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_config-schema.yaml
@@ -121,6 +121,8 @@ mapping:
               layout:
                 type: str
                 default: ngeo
+              html_filename:
+                type: str
       interfaces_config:
         required: True
         type: map

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_vars.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_vars.yaml
@@ -73,6 +73,14 @@ vars:
       escapeValue: false
     backend: {}
 
+  static_files:
+    favicon.ico: /etc/geomapfish/static/images/favicon.ico
+    robot.txt: /etc/geomapfish/static/robot.txt
+    api.js: /etc/static-ngeo/api.js
+    api.js.map: /etc/static-ngeo/api.js.map
+    api.css: /etc/static-ngeo/api.css
+    apihelp.html: /etc/geomapfish/static/apihelp/index.html
+
   interfaces_config:
     default:
       constants:

--- a/poetry.lock
+++ b/poetry.lock
@@ -4805,4 +4805,4 @@ test = ["zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "77c9877ead5991bb52f7e19399ebb3dc5affb6b0d44a6422fea7055d470f7dbb"
+content-hash = "6ddcdeedbf612dfd030c969d827b37a1b4afeec865a4076f2423a34c7a783feb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ basicauth = "1.0.0"
 prospector = { extras = ["with_mypy", "with_bandit", "with_pyroma"], version = "1.12.0" }
 prospector-profile-duplicated = "1.5.0"
 prospector-profile-utils  = "1.9.0"
+beautifulsoup4 = "4.12.3"
 
 [tool.poetry.group.dev.dependencies]
 Babel = "2.16.0" # i18n


### PR DESCRIPTION
To be able to integrate interface that not be build with the GeoMapGish build chain.

Also be able to configure some static files: `favicon.ico`, `robot.txt`, `api.js`, `api.js.map`, `api.css`, `apihelp.html`.
<!-- pull request links -->
See JIRA issue: [GSNGEO-9](https://camptocamp.atlassian.net/browse/GSNGEO-9).

TODO in another Pull request:
 - [ ] Add ngeo documentation

[GSNGEO-9]: https://camptocamp.atlassian.net/browse/GSNGEO-9?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ