### PR TITLE
Force to use https in dev mode

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/docker-compose.override.sample.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/docker-compose.override.sample.yaml
@@ -25,6 +25,7 @@ services:
       # - PRINT_URL=http://print:8080/print/
       - PYTHONWARNINGS=default::DeprecationWarning
       - SQLALCHEMY_WARN_20=true
+      - C2CWSGIUTILS_FORCE_PROTO=true
     ports:
       - 5678:5678 # For remote debugging using Visual Studio Code
 


### PR DESCRIPTION
The new version waitress didn't do that correctly

Requires: https://github.com/camptocamp/c2cwsgiutils/pull/2523