### PR TITLE
map.view.constrainResolution to false by default

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/geoportal/vars.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/geoportal/vars.yaml
@@ -81,7 +81,7 @@ vars:
             maxTilesLoading: 128
           view:
             <<: *view
-            constrainResolution: True
+            constrainResolution: False
         gmfExternalOGCServers:
           - name: swisstopo WMS
             type: WMS

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_vars.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_vars.yaml
@@ -228,8 +228,8 @@ vars:
             zoom: 3
             resolutions: [250, 100, 50, 20, 10, 5, 2, 1, 0.5, 0.25, 0.1, 0.05]
             extent: [2420000, 1030000, 2900000, 1350000]
-            constrainRotation: false
-            constrainResolution: true
+            constrainRotation: False
+            constrainResolution: False
         gmfSearchOptions:
           styles:
             default:


### PR DESCRIPTION
In vars, <interface>.gmfOptions.map.view.contrainResolution should be falsy by default. Because if "true", Openlayers makes the map looking "bumpy" on zoom in/out.

This is looks like an issue, especially on the default desktop.
Eventually, we could add `constrainResolution: True` on the desktop_alt.

See also issue opened in: https://github.com/camptocamp/GeoMapFish/issues/92

Change come from https://github.com/camptocamp/c2cgeoportal/commit/0819c1828fec85d3ba1d154222215acce10c6659#diff-25ddc46a3475e6781818af028a3ee89287e30737c656dcbcd85c0be7a36e3fd6L46