### PR TITLE
Remove cache-control switch from private to public

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/lib/common_headers.py
+++ b/geoportal/c2cgeoportal_geoportal/lib/common_headers.py
@@ -33,8 +33,6 @@ from typing import Any, cast
 import pyramid.request
 import pyramid.response
 
-from c2cgeoportal_geoportal.lib import is_intranet
-
 _LOG = logging.getLogger(__name__)
 
 
@@ -124,6 +122,8 @@ def _set_common_headers(
 ) -> pyramid.response.Response:
     """Set the common headers."""
 
+    del request  # Unused
+
     response.headers.update(service_headers_settings.get("headers", {}))
 
     if cache in (Cache.PRIVATE, Cache.PRIVATE_NO):
@@ -141,10 +141,7 @@ def _set_common_headers(
     elif cache in (Cache.PUBLIC, Cache.PUBLIC_NO):
         response.cache_control.public = True
     elif cache in (Cache.PRIVATE, Cache.PRIVATE_NO):
-        if hasattr(request, "user") and request.user is not None or is_intranet(request):
-            response.cache_control.private = True
-        else:
-            response.cache_control.public = True
+        response.cache_control.private = True
     else:
         raise Exception("Invalid cache type")  # pylint: disable=broad-exception-raised
 

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/CONST_CHANGELOG.txt
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/CONST_CHANGELOG.txt
@@ -53,6 +53,12 @@ Information
        exclude_pages: []
    ```
 
+4. Previously the `Cache-Control` header was set to `public` when we are not authenticated to an endpoint
+   that use the authentication. But this didn't works in every cases, for example when we use the intranet
+   role and when we have a reverse proxy with cache. Now it's always set to private for all the endpoints
+   that use the authentication.
+
+
 =============
 Version 2.8.0
 =============

--- a/geoportal/tests/functional/test_mapserverproxy.py
+++ b/geoportal/tests/functional/test_mapserverproxy.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013-2023, Camptocamp SA
+# Copyright (c) 2013-2024, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without
@@ -281,7 +281,7 @@ class TestMapserverproxyView(TestCase):
             )
         )
         response = MapservProxy(request).proxy()
-        self.assertTrue(response.cache_control.public)
+        self.assertFalse(response.cache_control.public)
         assert response.cache_control.max_age == 3600
 
     def test_getlegendgraphic_custom_nocache(self):
@@ -362,10 +362,10 @@ class TestMapserverproxyView(TestCase):
             re.sub(pattern, "", l) for l in response.body.decode("utf-8").splitlines()
         ).encode("utf-8")
         assert response_body.decode("utf-8") == expected_response
-        self.assertTrue(response.cache_control.public)
+        self.assertFalse(response.cache_control.public)
         assert response.cache_control.max_age == 10
         self.assertEqual(
-            str(response.cache_control), "max-age=10, must-revalidate, no-cache, no-store, public"
+            str(response.cache_control), "max-age=10, must-revalidate, no-cache, no-store, private"
         )
 
     def test_get_map_unprotected_layer_anonymous(self):
@@ -389,7 +389,7 @@ class TestMapserverproxyView(TestCase):
 
         self.assertTrue(response.status_int, 200)
         self.assertEqual(
-            str(response.cache_control), "max-age=10, must-revalidate, no-cache, no-store, public"
+            str(response.cache_control), "max-age=10, must-revalidate, no-cache, no-store, private"
         )
         # 4 points
         md5sum = hashlib.md5(response.body).hexdigest()
@@ -470,7 +470,7 @@ class TestMapserverproxyView(TestCase):
 
         self.assertTrue(response.status_int, 200)
         self.assertEqual(
-            str(response.cache_control), "max-age=10, must-revalidate, no-cache, no-store, public"
+            str(response.cache_control), "max-age=10, must-revalidate, no-cache, no-store, private"
         )
         # empty
         md5sum = hashlib.md5(response.body).hexdigest()
@@ -900,7 +900,7 @@ class TestMapserverproxyView(TestCase):
 
         self.assertTrue(response.body != "")
         self.assertEqual(
-            str(response.cache_control), "max-age=10, must-revalidate, no-cache, no-store, public"
+            str(response.cache_control), "max-age=10, must-revalidate, no-cache, no-store, private"
         )
 
     def test_substitution(self):

--- a/geoportal/tests/functional/test_oauth2.py
+++ b/geoportal/tests/functional/test_oauth2.py
@@ -153,7 +153,7 @@ class TestLoginView(TestCase):
         assert response.headers["Content-Type"] == "application/json"
         assert response.headers["Pragma"] == "no-cache"
         assert response.headers["Vary"] == "Origin, Access-Control-Request-Headers, Cookie"
-        assert response.headers["Cache-Control"] == "max-age=10, no-store, public"
+        assert response.headers["Cache-Control"] == "max-age=10, no-store, private"
         data = json.loads(response.body)
         assert set(data.keys()) == {"access_token", "expires_in", "token_type", "refresh_token"}
         assert data["expires_in"] == 3600
@@ -272,7 +272,7 @@ class TestLoginView(TestCase):
         assert response.headers["Content-Type"] == "application/json"
         assert response.headers["Pragma"] == "no-cache"
         assert response.headers["Vary"] == "Origin, Access-Control-Request-Headers, Cookie"
-        assert response.headers["Cache-Control"] == "max-age=10, no-store, public"
+        assert response.headers["Cache-Control"] == "max-age=10, no-store, private"
         data = json.loads(response.body)
         assert set(data.keys()) == {"access_token", "expires_in", "token_type", "refresh_token"}
         assert data["expires_in"] == 3600
@@ -356,7 +356,7 @@ class TestLoginView(TestCase):
         assert response.headers["Content-Type"] == "application/json"
         assert response.headers["Pragma"] == "no-cache"
         assert response.headers["Vary"] == "Origin, Access-Control-Request-Headers, Cookie"
-        assert response.headers["Cache-Control"] == "max-age=10, no-store, public"
+        assert response.headers["Cache-Control"] == "max-age=10, no-store, private"
         data = json.loads(response.body)
         assert set(data.keys()) == {"access_token", "expires_in", "token_type", "refresh_token"}
         assert data["expires_in"] == 3600
@@ -479,7 +479,7 @@ class TestLoginView(TestCase):
         assert response.headers["Content-Type"] == "application/json"
         assert response.headers["Pragma"] == "no-cache"
         assert response.headers["Vary"] == "Origin, Access-Control-Request-Headers, Cookie"
-        assert response.headers["Cache-Control"] == "max-age=10, no-store, public"
+        assert response.headers["Cache-Control"] == "max-age=10, no-store, private"
         data = json.loads(response.body)
         assert set(data.keys()) == {"access_token", "expires_in", "token_type", "refresh_token"}
         assert data["expires_in"] == 3600
@@ -612,7 +612,7 @@ class TestLoginView(TestCase):
         assert response.headers["Content-Type"] == "application/json"
         assert response.headers["Pragma"] == "no-cache"
         assert response.headers["Vary"] == "Origin, Access-Control-Request-Headers, Cookie"
-        assert response.headers["Cache-Control"] == "max-age=10, no-store, public"
+        assert response.headers["Cache-Control"] == "max-age=10, no-store, private"
         data = json.loads(response.body)
         assert set(data.keys()) == {"access_token", "expires_in", "token_type", "refresh_token"}
         assert data["expires_in"] == 3600
@@ -709,7 +709,7 @@ class TestLoginView(TestCase):
         assert response.headers["Content-Type"] == "application/json"
         assert response.headers["Pragma"] == "no-cache"
         assert response.headers["Vary"] == "Origin, Access-Control-Request-Headers, Cookie"
-        assert response.headers["Cache-Control"] == "max-age=10, no-store, public"
+        assert response.headers["Cache-Control"] == "max-age=10, no-store, private"
         data = json.loads(response.body)
         assert set(data.keys()) == {"access_token", "expires_in", "token_type", "refresh_token"}
         assert data["expires_in"] == 3600

--- a/geoportal/tests/test_caching.py
+++ b/geoportal/tests/test_caching.py
@@ -61,7 +61,7 @@ class TestSetCorsHeaders(TestCase):
         # 1. If the Origin header is not present terminate this set of steps.
         #    The request is outside the scope of this specification.
         assert self._do("POST", {}) == {
-            "Cache-Control": "max-age=10, public",
+            "Cache-Control": "max-age=10, private",
             "Content-Length": "0",
             "Content-Type": "text/html; charset=UTF-8",
             "Vary": "Origin, Access-Control-Request-Headers, Cookie",
@@ -71,7 +71,7 @@ class TestSetCorsHeaders(TestCase):
         #    any of the values in list of origins, do not set any additional
         #    headers and terminate this set of steps.
         assert self._do("POST", {"Origin": "http://foe.com"}) == {
-            "Cache-Control": "max-age=10, public",
+            "Cache-Control": "max-age=10, private",
             "Content-Length": "0",
             "Content-Type": "text/html; charset=UTF-8",
             "Vary": "Origin, Access-Control-Request-Headers, Cookie",
@@ -82,7 +82,7 @@ class TestSetCorsHeaders(TestCase):
         #    header as value, and add a single Access-Control-Allow-Credentials
         #    header with the case-sensitive string "true" as value.
         assert self._do("POST", {"Origin": self.ORIGIN2}, credentials=True) == {
-            "Cache-Control": "max-age=10, public",
+            "Cache-Control": "max-age=10, private",
             "Content-Length": "0",
             "Content-Type": "text/html; charset=UTF-8",
             "Vary": "Origin, Access-Control-Request-Headers, Cookie",
@@ -202,7 +202,7 @@ class TestSetCorsHeaders(TestCase):
     def test_not_configured(self):
         # If the service is not configured, then no CORS head.
         assert self._do("GET", {"Origin": self.ORIGIN1}, settings=None) == {
-            "Cache-Control": "max-age=10, public",
+            "Cache-Control": "max-age=10, private",
             "Content-Length": "0",
             "Content-Type": "text/html; charset=UTF-8",
             "Vary": "Origin, Access-Control-Request-Headers, Cookie",
@@ -217,7 +217,7 @@ class TestSetCorsHeaders(TestCase):
         # An origin included in the access_control_allow_origin list is OK with
         # credentials
         assert self._do("POST", {"Origin": self.ORIGIN1}, credentials=True, settings=settings) == {
-            "Cache-Control": "max-age=10, public",
+            "Cache-Control": "max-age=10, private",
             "Content-Length": "0",
             "Content-Type": "text/html; charset=UTF-8",
             "Vary": "Origin, Access-Control-Request-Headers, Cookie",
@@ -230,7 +230,7 @@ class TestSetCorsHeaders(TestCase):
         # 3. Otherwise, add a single Access-Control-Allow-Origin header, with
         #    either the value of the Origin header or the string "*" as value.
         assert self._do("POST", {"Origin": "http://www.guest.com"}, settings=settings) == {
-            "Cache-Control": "max-age=10, public",
+            "Cache-Control": "max-age=10, private",
             "Content-Length": "0",
             "Content-Type": "text/html; charset=UTF-8",
             "Vary": "Origin, Access-Control-Request-Headers, Cookie",


### PR DESCRIPTION
This is not working with intranet detection

To make it working (with intranet detection and reverse proxy cache) without the possibility of cache pollution, we should:
- Disable it for the loginuser end-point.
- Be sure that we have the user or roles in the query string, And verify them in the Pyramid view.