### PR TITLE
QGIS 2.7 rebuild: ltr-debug didn't exists

### DIFF
--- a/.github/workflows/rebuild-qgis-2-7.yaml
+++ b/.github/workflows/rebuild-qgis-2-7.yaml
@@ -24,7 +24,6 @@ jobs:
           - 3.34-gdal3.7
           - 3.34-gdal3.8
           - ltr
-          - ltr-debug
         branch:
           - '2.7'
 


### PR DESCRIPTION
Fix rebuild