### PR TITLE
Remove the shortner base_url

### DIFF
--- a/doc/integrator/shortener.rst
+++ b/doc/integrator/shortener.rst
@@ -16,7 +16,7 @@ The configuration in ``vars.yaml`` looks like this:
        starttls: false
 
    shortener:
-        # The base of created URL
+        # The base of created URL (optional)
         base_url:  https://{host}/{apache_entry_point}s/
         # Used to send a confirmation email
         email_from: info@camptocamp.com

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_vars.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_vars.yaml
@@ -935,8 +935,6 @@ vars:
 
   # The shortener base configuration
   shortener:
-    # The base of created URL
-    base_url: '{VISIBLE_WEB_PROTOCOL}://{VISIBLE_WEB_HOST}{VISIBLE_ENTRY_POINT}s/'
     allowed_hosts:
       - '{VISIBLE_WEB_HOST}'
     length: 4


### PR DESCRIPTION
The default create_route do the job
and it create an issue for multi-tenant instance.
<!-- pull request links -->
See JIRA issue: [GSGMG-4](https://camptocamp.atlassian.net/browse/GSGMG-4).

[GSGMG-4]: https://camptocamp.atlassian.net/browse/GSGMG-4?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ