### PR TITLE
Fix workflow ngeo-2-7

### DIFF
--- a/.github/workflows/ngeo-2-7.yaml
+++ b/.github/workflows/ngeo-2-7.yaml
@@ -4,6 +4,7 @@ on:
   repository_dispatch:
     types:
       - ngeo_2.7_updated
+  workflow_dispatch:
 
 env:
   HAS_SECRETS: ${{ secrets.HAS_SECRETS }}
@@ -104,6 +105,15 @@ jobs:
           if-no-files-found: ignore
           retention-days: 5
 
+      # Use minimal version from the documentation
+      - uses: actions/setup-python@v4
+        with:
+          # When we upgrade this we should also upgrade the requirements
+          # in the documentation: doc/integrator/requirements.rst
+          python-version: '3.7'
+      # When we upgrade this we should also upgrade the requirements
+      # in the documentation: doc/integrator/requirements.rst
+      # netifaces is for 2.4
       - run: pip install --user PyYAML==3.13 docker-compose==1.21.0 netifaces 'requests<2.32.0'
 
       # Test App

--- a/.github/workflows/ngeo-2-8.yaml
+++ b/.github/workflows/ngeo-2-8.yaml
@@ -4,6 +4,7 @@ on:
   repository_dispatch:
     types:
       - ngeo_2.8_updated
+  workflow_dispatch:
 
 jobs:
   main:


### PR DESCRIPTION
Avoid error:

Failed to build PyYAML
ERROR: Could not build wheels for PyYAML, which is required to install pyproject.toml-based projects