### PR TITLE
Accept and POST, PUT, DELETE methods for OGC API Features part 4 (editing)

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/__init__.py
+++ b/geoportal/c2cgeoportal_geoportal/__init__.py
@@ -674,7 +674,7 @@ def includeme(config: pyramid.config.Configurator) -> None:
         "/mapserv_proxy/{ogcserver}/wfs3/*path",
         mapserverproxy=True,
         pregenerator=C2CPregenerator(role=True),
-        request_method="GET",
+        request_method=("GET", "POST", "PUT", "DELETE"),
     )
     add_cors_route(config, "/mapserv_proxy", "mapserver")
 

--- a/geoportal/c2cgeoportal_geoportal/__init__.py
+++ b/geoportal/c2cgeoportal_geoportal/__init__.py
@@ -674,7 +674,7 @@ def includeme(config: pyramid.config.Configurator) -> None:
         "/mapserv_proxy/{ogcserver}/wfs3/*path",
         mapserverproxy=True,
         pregenerator=C2CPregenerator(role=True),
-        request_method=("GET", "POST", "PUT", "DELETE"),
+        request_method=("GET", "POST", "PUT", "DELETE", "PATCH"),
     )
     add_cors_route(config, "/mapserv_proxy", "mapserver")
 


### PR DESCRIPTION
To be able to fully use OGC API requests via the geoportal proxy, also PUT, POST and DELETE methods must be accepted and forwarded to a QGIS Server instance.