### PR TITLE
OIDC: Be able to ignore role, to have template in match

### DIFF
--- a/doc/integrator/authentication_oidc.rst
+++ b/doc/integrator/authentication_oidc.rst
@@ -89,6 +89,9 @@ Other options
 ``create_user``: If ``true``, a user will be create in the geomapfish database if not exists,
   default is ``false``.
 
+``provide_roles``: If ``true``, the OpenID Connect provider will provide the roles for the user,
+  default is ``false``.
+
 ``login_extra_params``: Extra parameters to add to the login request.
   See `Zitadel additional parameters <https://zitadel.com/docs/apis/openidoauth/endpoints#additional-parameters>`_.
   Default is ``{}``.
@@ -99,14 +102,23 @@ Other options
   ``username``, ``display_name`` and ``email``.
 
 ``user_info_fields:`` The mapping between the user info fields and the user fields in the GeoMapFish database,
-  the key is the GeoMpaFish user field and the value is the field of the user info provided by the
-  OpenID Connect provider, default is:
+  the key is the GeoMapFish user field and the value is the field of the user info provided by the
+  OpenID Connect provider, can be a Python template, for example:
+
+  .. code:: yaml
+
+     username: sub
+     display_name: "{{ first_name }} {{ last_name }}"
+     email: email
+
+  The default mapping is:
 
   .. code:: yaml
 
      username: sub
      display_name: name
      email: email
+
 
 Example with Zitadel
 ~~~~~~~~~~~~~~~~~~~~

--- a/geoportal/c2cgeoportal_geoportal/__init__.py
+++ b/geoportal/c2cgeoportal_geoportal/__init__.py
@@ -42,10 +42,8 @@ import c2cwsgiutils.db
 import c2cwsgiutils.index
 import dateutil.parser
 import pyramid.config
-import pyramid.renderers
 import pyramid.request
 import pyramid.response
-import pyramid.security
 import sqlalchemy
 import sqlalchemy.orm
 import zope.event.classhandler

--- a/geoportal/c2cgeoportal_geoportal/lib/oidc.py
+++ b/geoportal/c2cgeoportal_geoportal/lib/oidc.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, Camptocamp SA
+# Copyright (c) 2024-2025, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,7 @@
 import datetime
 import json
 import logging
+import string
 from typing import TYPE_CHECKING, Any, NamedTuple, Optional, TypedDict, Union
 
 import pyramid.request
@@ -77,7 +78,7 @@ def get_oidc_client(request: pyramid.request.Request, host: str) -> simple_openi
         url=openid_connect["url"],
         authentication_redirect_uri=request.route_url("oidc_callback"),
         client_id=openid_connect["client_id"],
-        client_secret=openid_connect.get("client-secret"),
+        client_secret=openid_connect.get("client_secret"),
         scope=" ".join(openid_connect.get("scopes", ["openid", "profile", "email"])),
     )
 
@@ -124,16 +125,31 @@ def get_remember_from_user_info(
         ("settings_role", None),
         ("roles", None),
     ):
-        user_info_field = settings_fields.get(field_, default_field)
-        if user_info_field is not None:
-            if user_info_field not in user_info:
-                _LOG.error(
-                    "Field '%s' not found in user info, available: %s.",
-                    user_info_field,
-                    ", ".join(user_info.keys()),
-                )
-                raise HTTPInternalServerError(f"Field '{user_info_field}' not found in user info.")
-            remember_object[field_] = user_info[user_info_field]  # type: ignore[literal-required]
+        _LOG.debug("User info keys: %s", ", ".join(user_info.keys()))
+        user_info_field_template = settings_fields.get(field_, default_field)
+        if user_info_field_template is not None:
+            if "{" in user_info_field_template:
+                formatter = string.Formatter()
+                attributes = formatter.parse(user_info_field_template)
+                user_info_fields = [e[1] for e in attributes if e[1] is not None]
+            else:
+                user_info_fields = [user_info_field_template]
+
+            for user_info_field in user_info_fields:
+                if user_info_field not in user_info:
+                    _LOG.error(
+                        "Field '%s' not found in user info, available: %s.",
+                        user_info_field,
+                        ", ".join(user_info.keys()),
+                    )
+                    raise HTTPInternalServerError(f"Field '{user_info_field}' not found in user info.")
+
+            user_info_value = (
+                user_info_field_template.format(**user_info)
+                if "{" in user_info_field_template
+                else user_info[user_info_field_template]
+            )
+            remember_object[field_] = user_info_value  # type: ignore[literal-required]
 
 
 def get_user_from_remember(
@@ -194,6 +210,11 @@ def get_user_from_remember(
                 user = static.User(username=username, email=email, display_name=display_name)
                 models.DBSession.add(user)
     else:
+        roles = []
+        role_names = remember_object.get("roles", [])
+        if role_names:
+            query = models.DBSession.query(main.Role).filter(main.Role.name.in_(role_names))
+            roles = query.all()
         user = DynamicUser(
             id=-1,
             username=username,
@@ -204,10 +225,7 @@ def get_user_from_remember(
                 if remember_object.get("settings_role") is not None
                 else None
             ),
-            roles=[
-                models.DBSession.query(main.Role).filter_by(name=role).one()
-                for role in remember_object.get("roles", [])
-            ],
+            roles=roles,
         )
     return user
 

--- a/geoportal/c2cgeoportal_geoportal/views/theme.py
+++ b/geoportal/c2cgeoportal_geoportal/views/theme.py
@@ -1279,8 +1279,7 @@ class Theme:
         if not self.request.user:
             raise pyramid.httpexceptions.HTTPForbidden()
 
-        admin_roles = [r for r in self.request.user.roles if r.name == ("role_admin")]
-        if not admin_roles:
+        if not self.request.has_permission("admin"):
             raise pyramid.httpexceptions.HTTPForbidden()
 
         self._ogc_server_clear_cache(

--- a/geoportal/tests/__init__.py
+++ b/geoportal/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2023, Camptocamp SA
+# Copyright (c) 2011-2025, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/geoportal/tests/functional/test_themes_ogc_server_cache_clean.py
+++ b/geoportal/tests/functional/test_themes_ogc_server_cache_clean.py
@@ -31,17 +31,21 @@ import asyncio
 from unittest import TestCase
 
 import pyramid.httpexceptions
+import pyramid.security
+import pyramid.testing
 import pytest
 import responses
+import tests.functional
 import transaction
 from pyramid import testing
+from pyramid.interfaces import ISecurityPolicy
 from tests.functional import create_default_ogcserver, create_dummy_request
 from tests.functional import setup_common as setup_module  # noqa
 from tests.functional import teardown_common as teardown_module  # noqa
 
 from c2cgeoportal_geoportal.lib import caching
 
-CAP = """<?xml version="1.0" encoding="utf-8"?>
+_CAP = """<?xml version="1.0" encoding="utf-8"?>
 <WMT_MS_Capabilities version="1.1.1">
 <Service></Service>
 <Capability>
@@ -92,7 +96,7 @@ CAP = """<?xml version="1.0" encoding="utf-8"?>
 </Capability>
 </WMT_MS_Capabilities>"""
 
-DFT = """<?xml version='1.0' encoding="UTF-8" ?>
+_DFT = """<?xml version='1.0' encoding="UTF-8" ?>
 <schema
    targetNamespace="http://mapserver.gis.umn.edu/mapserver"
    xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
@@ -240,12 +244,12 @@ class TestThemesView(TestCase):
         responses.get(
             "http://mapserver:8080/?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetCapabilities&ROLE_IDS=0&USER_ID=0",
             content_type="application/vnd.ogc.wms_xml",
-            body=CAP.format(name2="__test_layer_internal_wms2"),
+            body=_CAP.format(name2="__test_layer_internal_wms2"),
         )
         responses.get(
             "http://mapserver:8080/?SERVICE=WFS&VERSION=1.0.0&REQUEST=DescribeFeatureType&ROLE_IDS=0&USER_ID=0",
             content_type="application/vnd.ogc.wms_xml",
-            body=DFT.format(name2="police1"),
+            body=_DFT.format(name2="police1"),
         )
         asyncio.run(theme._preload(set()))
         responses.reset()
@@ -279,12 +283,12 @@ class TestThemesView(TestCase):
         responses.get(
             "http://mapserver:8080/?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetCapabilities&ROLE_IDS=0&USER_ID=0",
             content_type="application/vnd.ogc.wms_xml",
-            body=CAP.format(name2="__test_layer_internal_wms3"),
+            body=_CAP.format(name2="__test_layer_internal_wms3"),
         )
         responses.get(
             "http://mapserver:8080/?SERVICE=WFS&VERSION=1.0.0&REQUEST=DescribeFeatureType&ROLE_IDS=0&USER_ID=0",
             content_type="application/vnd.ogc.wms_xml",
-            body=DFT.format(name2="police2"),
+            body=_DFT.format(name2="police2"),
         )
         theme._ogc_server_clear_cache(ogc_server)
         responses.reset()
@@ -342,12 +346,12 @@ def test_ogc_server_cache_clean_wrong_host(
     responses.get(
         "http://mapserver:8080/?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetCapabilities&ROLE_IDS=0&USER_ID=0",
         content_type="application/vnd.ogc.wms_xml",
-        body=CAP.format(name2="__test_layer_internal_wms3"),
+        body=_CAP.format(name2="__test_layer_internal_wms3"),
     )
     responses.get(
         "http://mapserver:8080/?SERVICE=WFS&VERSION=1.0.0&REQUEST=DescribeFeatureType&ROLE_IDS=0&USER_ID=0",
         content_type="application/vnd.ogc.wms_xml",
-        body=DFT.format(name2="police2"),
+        body=_DFT.format(name2="police2"),
     )
     with pytest.raises(
         pyramid.httpexceptions.HTTPFound if expected else pyramid.httpexceptions.HTTPBadRequest
@@ -356,9 +360,14 @@ def test_ogc_server_cache_clean_wrong_host(
 
 
 def test_ogc_server_cache_clean_wrong_host_non_admin_user(some_user):
+    from c2cgeoportal_geoportal.lib.authentication import create_authentication
     from c2cgeoportal_geoportal.views.theme import Theme
 
-    request = create_dummy_request(user=some_user.username)
+    # config = testing.setUp()
+    # config.set_root_factory(_Root)
+
+    request = create_dummy_request(user=some_user.username, force_authentication=True)
+
     theme = Theme(request)
 
     with pytest.raises(pyramid.httpexceptions.HTTPForbidden):


### PR DESCRIPTION
- Be able to ignore role that's not existing in the GeoMapFish database
- Be able to have a template in match to be able to combine field
- Don't hardcode the 'role_admin' to be able to configure any roles in the default context (Root)

<!-- pull request links -->
See JIRA issue: [GSEPF-995](https://camptocamp.atlassian.net/browse/GSEPF-995).

[GSEPF-995]: https://camptocamp.atlassian.net/browse/GSEPF-995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ