### PR TITLE
Export the public attribute defined for themes

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/views/theme.py
+++ b/geoportal/c2cgeoportal_geoportal/views/theme.py
@@ -863,6 +863,11 @@ class Theme:
                 theme_theme = {
                     "id": theme.id,
                     "name": theme.name,
+                    "public": (
+                        theme.public
+                        or self.request.get_organization_role("anonymous")
+                        in theme.restricted_roles
+                    ),
                     "icon": icon,
                     "children": children,
                     "functionalities": self._get_functionalities(theme),

--- a/geoportal/c2cgeoportal_geoportal/views/theme.py
+++ b/geoportal/c2cgeoportal_geoportal/views/theme.py
@@ -865,8 +865,7 @@ class Theme:
                     "name": theme.name,
                     "public": (
                         theme.public
-                        or self.request.get_organization_role("anonymous")
-                        in theme.restricted_roles
+                        or self.request.get_organization_role("anonymous") in theme.restricted_roles
                     ),
                     "icon": icon,
                     "children": children,

--- a/geoportal/c2cgeoportal_geoportal/views/theme.py
+++ b/geoportal/c2cgeoportal_geoportal/views/theme.py
@@ -865,7 +865,7 @@ class Theme:
                     "name": theme.name,
                     "public": (
                         theme.public
-                        or self.request.get_organization_role("anonymous") in theme.restricted_roles
+                        or self.request.get_organization_role("anonymous") in [role.name for role in theme.restricted_roles]
                     ),
                     "icon": icon,
                     "children": children,

--- a/geoportal/c2cgeoportal_geoportal/views/theme.py
+++ b/geoportal/c2cgeoportal_geoportal/views/theme.py
@@ -865,7 +865,8 @@ class Theme:
                     "name": theme.name,
                     "public": (
                         theme.public
-                        or self.request.get_organization_role("anonymous") in [role.name for role in theme.restricted_roles]
+                        or self.request.get_organization_role("anonymous")
+                        in [role.name for role in theme.restricted_roles]
                     ),
                     "icon": icon,
                     "children": children,

--- a/geoportal/tests/functional/test_themes_private.py
+++ b/geoportal/tests/functional/test_themes_private.py
@@ -259,6 +259,7 @@ class TestThemesPrivateView(TestCase):
             [self._only_name(t, attribute="public") for t in themes["themes"]],
             [
                 {
+                    "public": True,  # from theme
                     "children": [
                         {
                             "children": [


### PR DESCRIPTION
Forgot the public attribute of themes.
The client app can then combine public attributes of the theme and the layers to determine if data can be considered restricted or not.