### PR TITLE
Handle deactivated user on password change

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/views/login.py
+++ b/geoportal/c2cgeoportal_geoportal/views/login.py
@@ -379,6 +379,10 @@ class Login:
                 _LOG.info("The login '%s' does not exist.", login)
                 raise HTTPUnauthorized("See server logs for details")
 
+            if user.deactivated:
+                _LOG.info("The login '%s' is deactivated.", login)
+                raise HTTPUnauthorized("See server logs for details")
+
             if self.two_factor_auth and not self._validate_2fa_totp(user, otp):
                 _LOG.info("The second factor is wrong for user '%s'.", login)
                 raise HTTPUnauthorized("See server logs for details")


### PR DESCRIPTION
Today a deactivated user can request a password change. After password is changed, the user gets an email with his account infos misleading the user. It's better to raise an unauthorized before.