### PR TITLE
Remove no more existing --no-use-pep517 pip argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -176,7 +176,7 @@ ENV VERSION=$VERSION
 RUN --mount=type=cache,target=/var/cache,sharing=locked \
     --mount=type=cache,target=/root/.cache \
     grep -r masterdev . || true \
-    && python3 -m pip install --no-use-pep517 --disable-pip-version-check --no-deps \
+    && python3 -m pip install --disable-pip-version-check --no-deps \
         --editable=commons \
         --editable=geoportal \
         --editable=admin


### PR DESCRIPTION
Introduced with 6559670c0da0dc17f4eff4af955726283fc5b030