### PR TITLE
Remove tilecloudchain secrets from env.project

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/env.project
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/env.project
@@ -40,10 +40,6 @@ TILEGENERATION_SQS_QUEUE=<queue_name>
 TILEGENERATION_S3_BUCKET=<bucket_name>
 TILEGENERATION_AZURE_CONTAINER=<container_name>
 
-# Should be filed with a strong secret, with e.g. `pwgen --secure 16`
-# TILECLOUD_CHAIN_SESSION_SECRET=
-# TILECLOUD_CHAIN_SESSION_SALT=
-
 # For production
 # FRONT_INNER_PORT=80
 # FRONT_CONFIG=haproxy


### PR DESCRIPTION
Those variables are already fully handled through project.yaml / pcreate / env.default

Related with #12401

Those variables where referenced in changelog in 2.9 but only added in env.project in master.