### PR TITLE
Add useful scripts for QGIS projects stored in database

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/scripts/qgis-project-download
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/scripts/qgis-project-download
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+from pathlib import Path
+
+import psycopg2
+from psycopg2 import sql
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Download QGIS project from database",
+        epilog="""
+Example usage:
+
+    # Build with target environment
+    ./build --env [env.local|env.int|env.prod]
+
+    # Download QGIS project file from database
+    docker compose run --rm --user `id -u`:`id -g` tools \\
+        python3 /src/scripts/qgis-project-download qgis myproject myproject.qgz
+        """,
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    parser.add_argument("schema", default="qgis", help="Source PostgreSQL schema name")
+    parser.add_argument("project", default="project.qgz", help="Source QGIS project name")
+    parser.add_argument("filename", default="qgisserver/project.qgz", help="Destination file name")
+    args = parser.parse_args()
+
+    # Connect to a DB, e.g., the test DB on your localhost, and get a cursor
+    with psycopg2.connect(f"dbname={os.environ['PGDATABASE']}") as connection:
+        with connection.cursor() as cursor:
+
+            query = sql.SQL(
+                """
+                SELECT content
+                FROM {}.qgis_projects
+                WHERE name = %(name)s;
+            """
+            ).format(sql.Identifier(args.schema))
+
+            cursor.execute(query, {"name": args.project})
+            rows = cursor.fetchall()
+            data = bytes(rows[0][0])
+
+            path = Path("/src/qgisserver/") / args.filename
+            with path.open("wb") as f:
+                f.write(data)
+
+    print(f"Project {args.project} from schema {args.schema} downloaded as {args.filename}")
+
+
+if __name__ == "__main__":
+    main()

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/scripts/qgis-project-upload
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/scripts/qgis-project-upload
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+from pathlib import Path
+
+import psycopg2
+from psycopg2 import sql
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Upload QGIS project to database",
+        epilog="""
+Example usage:
+
+    # Build with target environment
+    ./build --env [env.local|env.int|env.prod]
+
+    # Download QGIS project file from database
+    docker compose run --rm --user `id -u`:`id -g` tools \\
+        python3 /src/scripts/qgis-project-download qgis myproject myproject.qgz
+        """,
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    parser.add_argument("filename", default="qgisserver/project.qgz", help="Source file name")
+    parser.add_argument("schema", default="qgis", help="Destination PostgreSQL schema name")
+    parser.add_argument("project", default="project.qgz", help="Destination QGIS project name")
+    args = parser.parse_args()
+
+    # Connect to a DB, e.g., the test DB on your localhost, and get a cursor
+    with psycopg2.connect(f"dbname={os.environ['PGDATABASE']}") as connection:
+        with connection.cursor() as cursor:
+
+            path = Path("/src/qgisserver") / args.filename
+            with path.open("rb") as f:
+                data = f.read()
+
+            query = sql.SQL(
+                """
+                UPDATE {}.qgis_projects
+                SET content = %(content)s
+                WHERE name = %(name)s;
+            """
+            ).format(sql.Identifier(args.schema))
+
+            cursor.execute(
+                query,
+                {
+                    "content": psycopg2.Binary(data),
+                    "name": args.project,
+                },
+            )
+
+    print(f"Project {args.filename} uploaded in schema {args.schema} with name {args.project}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I propose some scripts I made in case I have **issues** with **QGIS projects stored in database**.

For example when **bad source settings in layers**, bad `service`, unattended `authcfg` or `sslmode`, etc.

It allows you to **get the QGIS project locally in .qgz format, then make changes, check your changes, and when ok, upload it back to database**.

Example use: 

```bash
#!/bin/bash -ex

# First build with target environment
# ./build --env [env.local|env.int|env.prod]
#

ROOT=`git rev-parse --show-toplevel`

# Download QGIS project file from database
docker compose run --rm --user `id -u`:`id -g` tools \
    python3 /src/scripts/download_qgis_project.py qgis myproject myproject.qgz

# Unzip it to get the main XML file (.qgs)
rm -rf qgisserver/myproject
mkdir -p qgisserver/myproject
unzip -o qgisserver/myproject.qgz -d ${ROOT}/qgisserver/myproject

# Find the main XML file (.qgs)
file=`find qgisserver/myproject -name *.qgs`

# Prepare your git diff
# git add $file

# Make some replacements
sed -i "s#sslmode=disable##g" $file
sed -i "s#authcfg=v53rjxp##g" $file
sed -i "s#service=servicename-prod'#service='servicename'#g" $file

# See the git diff
# git diff $file

# Overwrite the main XML file (.qgs)
zip -j qgisserver/myproject.qgz qgisserver/myproject/*.qgs

# Here you should test your QGIS project before overwriting the one in database.

# Overwrite the QGIS project in database 
docker compose run --rm tools \
    python3 /src/scripts/upload_qgis_project.py myproject.qgz qgis myproject
```

I put this as draft as it may be discussed before merge, but pretty sure it can be useful for many integrators.

**Note that the projects stored in the database are not versioned; I highly recommend making a backup before any operation of this type.**