### PR TITLE
QGIS desktop fix

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/Makefile
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/Makefile
@@ -39,6 +39,7 @@ eslint: ## Runs the eslint checks
 
 .PHONY: qgis
 qgis: ## Run QGIS desktop
+	xhost +local:docker
 	docker compose -f docker-compose.yaml -f docker-compose-qgis.yaml run --rm qgis
 
 secrets.tar.bz2.gpg: env.secrets ## Encrypt the secrets for committing changes

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/docker-compose-qgis.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/docker-compose-qgis.yaml
@@ -1,21 +1,29 @@
 # This file is used to run QGIS client from the Docker image
 
+volumes:
+  qgis-home:
+
 services:
   qgis:
     extends:
       file: docker-compose-lib.yaml
       service: qgisserver
     image: camptocamp/qgis-server:${QGIS_VERSION}-desktop
-    user: root
+    user: ubuntu
     volumes_from:
       - config
     volumes:
-      - ${HOME}:${HOME}
+      - qgis-home:/home/ubuntu
       - /tmp/.X11-unix:/tmp/.X11-unix
+      - ./qgisserver:/qgisserver
+    devices:
+      - /dev/dri:/dev/dri
     environment:
+      - HOME=/home/ubuntu
       - PGSERVICEFILE=/etc/qgisserver/pg_service.conf
       - DISPLAY=unix${DISPLAY}
       - QGIS_DEBUG=0
       - QGIS_LOG_FILE=/dev/null
       - PGOPTIONS=-c statement_timeout=30000
       - AZURE_STORAGE_CONNECTION_STRING
+    command: qgis


### PR DESCRIPTION
**GDAL docker image now comes with an exiting user named ubuntu.**

This brokes https://github.com/camptocamp/docker-qgis-server/blob/3.40-gdal3.10/runtime-desktop/usr/local/bin/start-client as we have **multiple folders in `/home`**.

Replace current https://github.com/camptocamp/docker-qgis-server desktop strategy which was IMHO far from perfect.

I prefer having a dedicated settings folder which do not alter my host settings, I'm pleased having a dedicated environment for each project:
- Dedicated user settings (PostgreSQL connections) in a dedicated volume for current composition
- Dedicated plugins installed
-  etc

=> faster QGIS startup
=> easyer to find right PostgreSQL connection
=> dedicated recent projects
=> directly use the composition pgservice file with current environment
=> **never break you local QGIS settings**

This might replace https://github.com/camptocamp/docker-qgis-server/blob/3.40-gdal3.10/runtime-desktop/usr/local/bin/start-client by `COMMAND qgis`

Also handle some issues with up to date x11 server.