### PR TITLE
Fix server l10n compilation

### DIFF
--- a/bin/build-l10n
+++ b/bin/build-l10n
@@ -38,7 +38,7 @@ def main():
                     check=True,
                 )
 
-            if os.path.exists(f"{base_path}/{lang}/LC_MESSAGES/{args.package}_geoportal-server{suffix}.mo"):
+            if os.path.exists(f"{base_path}/{lang}/LC_MESSAGES/{args.package}_geoportal-server{suffix}.po"):
                 if args.dry_run:
                     print(
                         f"{base_path}/{lang}/LC_MESSAGES/{args.package}_geoportal-server{suffix}.po => "


### PR DESCRIPTION
Actually script `build-l10n` check existance of `{package}_geoportal-server.mo` which is the compiled version, it does not exist before compilation.

Fix it by checking existance of `{package}_geoportal-server.po` which is the source file.