### PR TITLE
Prepare i18n catalogs for Python package publishing

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -255,6 +255,13 @@ jobs:
           && env.HAS_SECRETS == 'HAS_SECRETS'
 
       - run: git reset --hard
+      - name: Prepare i18n catalogs for PyPI packages
+        run: |
+          make --makefile=dependencies.mk dependencies
+          make --makefile=build.mk python-mo
+        if: >
+          env.HAS_SECRETS == 'HAS_SECRETS'
+          && steps.version.outputs.versions != ''
       - name: Publish
         run: >
           c2cciutils-publish

--- a/.github/workflows/ngeo-2-6.yaml
+++ b/.github/workflows/ngeo-2-6.yaml
@@ -147,6 +147,8 @@ jobs:
 
       - name: Publish version branch
         run: |
+          make --makefile=dependencies.mk dependencies
+          make --makefile=build.mk python-mo
           c2cciutils-publish --type=version_branch --version=${{ steps.version.outputs.major }}
           c2cciutils-publish --group=full --type=version_branch --version=${{ steps.version.outputs.full }}
 

--- a/.github/workflows/ngeo-2-7.yaml
+++ b/.github/workflows/ngeo-2-7.yaml
@@ -158,6 +158,8 @@ jobs:
 
       - name: Publish version branch
         run: |
+          make --makefile=dependencies.mk dependencies
+          make --makefile=build.mk python-mo
           c2cciutils-publish --type=version_branch --version=${{ steps.version.outputs.major }}
           c2cciutils-publish --type=version_branch --version=${{ steps.version.outputs.major_minor }}
           c2cciutils-publish --group=full --type=version_branch --version=${{ steps.version.outputs.full }}

--- a/.github/workflows/ngeo-2-8.yaml
+++ b/.github/workflows/ngeo-2-8.yaml
@@ -174,6 +174,10 @@ jobs:
             git push origin HEAD:${{ env.MAIN_BRANCH }} \
           )
 
+      - name: Prepare i18n catalogs for PyPI packages
+        run: |
+          make --makefile=dependencies.mk dependencies
+          make --makefile=build.mk python-mo
       - name: Publish
         run: >
           c2cciutils-publish

--- a/admin/MANIFEST.in
+++ b/admin/MANIFEST.in
@@ -1,2 +1,3 @@
 include requirements.txt requirements-dev.txt README.md package.json
 recursive-include c2cgeoportal_admin *.css *.jinja2 *.mo *.pt
+recursive-include c2cgeoportal_admin/locale *.po

--- a/admin/setup.py
+++ b/admin/setup.py
@@ -65,7 +65,13 @@ setup(
     url="https://github.com/camptocamp/c2cgeoportal/",
     keywords="web gis geoportail c2cgeoportal geocommune pyramid",
     packages=find_packages(exclude=["tests.*"]),
-    package_data={"c2cgeoportal_admin": ["py.typed"]},
+    package_data={
+        "c2cgeoportal_admin": [
+            "py.typed",
+            "locale/*/LC_MESSAGES/*.mo",
+            "locale/*/LC_MESSAGES/*.po",
+        ]
+    },
     include_package_data=True,
     zip_safe=False,
     install_requires=install_requires,

--- a/build.mk
+++ b/build.mk
@@ -1,4 +1,5 @@
-MO_FILES = $(addsuffix .mo,$(basename $(PYTHON_PO_FILES)))
+COMMONS_PO_FILES = $(wildcard commons/c2cgeoportal_commons/locale/*/LC_MESSAGES/c2cgeoportal_commons.po)
+MO_FILES = $(addsuffix .mo,$(basename $(PYTHON_PO_FILES) $(COMMONS_PO_FILES)))
 SRC_FILES = $(shell ls -1 geoportal/c2cgeoportal_geoportal/*.py 2> /dev/null) \
 	$(shell find geoportal/c2cgeoportal_geoportal/lib -name "*.py" -print 2> /dev/null) \
 	$(shell find geoportal/c2cgeoportal_geoportal/views -name "*.py" -print 2> /dev/null) \
@@ -40,6 +41,9 @@ build: \
 	geoportal/c2cgeoportal_geoportal/scaffolds/advance_update/{{cookiecutter.project}}/CONST_create_template/ \
 	$(APPS_FILES_ALT) \
 	$(MO_FILES)
+
+.PHONY: python-mo
+python-mo: $(MO_FILES)
 
 # Import ngeo templates
 

--- a/commons/MANIFEST.in
+++ b/commons/MANIFEST.in
@@ -1,2 +1,4 @@
 include README.rst requirements.txt
 recursive-include c2cgeoportal_commons/alembic *.py
+recursive-include c2cgeoportal_commons/locale *.po
+recursive-include c2cgeoportal_commons/locale *.mo

--- a/commons/setup.py
+++ b/commons/setup.py
@@ -64,7 +64,13 @@ setup(
     url="https://github.com/camptocamp/c2cgeoportal/",
     keywords="web gis geoportail c2cgeoportal geocommune pyramid",
     packages=find_packages(exclude=["tests.*"]),
-    package_data={"c2cgeoportal_commons": ["py.typed"]},
+    package_data={
+        "c2cgeoportal_commons": [
+            "py.typed",
+            "locale/*/LC_MESSAGES/*.mo",
+            "locale/*/LC_MESSAGES/*.po",
+        ]
+    },
     include_package_data=True,
     zip_safe=False,
     install_requires=install_requires,

--- a/geoportal/setup.py
+++ b/geoportal/setup.py
@@ -73,7 +73,13 @@ setup(
     url="https://github.com/camptocamp/c2cgeoportal/",
     keywords="web gis geoportail c2cgeoportal geocommune pyramid",
     packages=find_packages(exclude=["tests.*"]),
-    package_data={"c2cgeoportal_geoportal": ["py.typed"]},
+    package_data={
+        "c2cgeoportal_geoportal": [
+            "py.typed",
+            "locale/*/LC_MESSAGES/*.mo",
+            "locale/*/LC_MESSAGES/*.po",
+        ]
+    },
     include_package_data=True,
     zip_safe=False,
     install_requires=INSTALL_REQUIRES,


### PR DESCRIPTION
## Summary
- include gettext locale catalogs (`.po` and `.mo`) in Python package metadata for `admin`, `geoportal`, and `commons`
- add a dedicated `python-mo` target in `build.mk` and extend MO generation to include commons catalogs
- update release workflows to fetch translations and compile Python MO catalogs before `c2cciutils-publish`

## Why
This ensures published PyPI artifacts contain up-to-date translation catalogs generated by CI, without versioning locale files in git.

<!-- pull request links -->
See JIRA issue: [GSBLGEOS-50](https://camptocamp.atlassian.net/browse/GSBLGEOS-50).

[GSBLGEOS-50]: https://camptocamp.atlassian.net/browse/GSBLGEOS-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ