### PR TITLE
Allow partial path matching for QGIS access control base URL

### DIFF
--- a/doc/integrator/backend_qgis.rst
+++ b/doc/integrator/backend_qgis.rst
@@ -213,7 +213,9 @@ Access Restriction on QGIS OGC server
 
 From version 2.7 the config is just made with the ``GEOMAPFISH_ACCESSCONTROL_BASE_URL`` environment
 variable which contains the base URL of the OGC servers, by default it's set to
-``QGISSERVER_URL``. And the plugin will search for the OGC servers that match with this base URL.
+``QGISSERVER_URL``. And the plugin will search for the OGC servers that match with this base URL
+(same scheme and host, and with a path that matches exactly or by prefix, e.g. ``/mapserv_proxy``
+also matches ``/mapserv_proxy/qgis``).
 It also requires that the OGC servers are configured with an URL like that
 ``config://qgisserver?map=<project_file>``.
 

--- a/docker/qgisserver/geomapfish_qgisserver/accesscontrol.py
+++ b/docker/qgisserver/geomapfish_qgisserver/accesscontrol.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2025, Camptocamp SA
+# Copyright (c) 2018-2026, Camptocamp SA
 # All rights reserved.
 
 # This program is free software; you can redistribute it and/or modify it under the terms of the
@@ -44,6 +44,17 @@ if TYPE_CHECKING:
     )
 
 _LOG = logging.getLogger(__name__)
+
+
+def _path_prefix_match(base_path: str, ogc_server_path: str) -> bool:
+    base = base_path.rstrip("/")
+    server = ogc_server_path.rstrip("/")
+
+    if base == "":
+        return True
+    if server == base:
+        return True
+    return server.startswith(f"{base}/")
 
 
 def create_session_factory(
@@ -163,7 +174,7 @@ class GeoMapFishAccessControl(QgsAccessControlFilter):  # type: ignore[misc]
                         if (
                             base_url.scheme == url.scheme
                             and base_url.netloc == url.netloc
-                            and base_url.path == url.path
+                            and _path_prefix_match(base_url.path, url.path)
                         ):
                             query = url.query_lower
                             if "map" not in query:

--- a/docker/qgisserver/tests/functional/accesscontrol_test.py
+++ b/docker/qgisserver/tests/functional/accesscontrol_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2025, Camptocamp SA
+# Copyright (c) 2018-2026, Camptocamp SA
 # All rights reserved.
 
 # This program is free software; you can redistribute it and/or modify it under the terms of the
@@ -78,7 +78,7 @@ def test_data(clean_dbsession):
     ogc_server1 = OGCServer(
         name="qgisserver1",
         type_=OGCSERVER_TYPE_QGISSERVER,
-        url="http://qgis?MAP=qgisserver1",
+        url="http://qgis/test/toto?MAP=qgisserver1",
         image_type="image/png",
         auth=OGCSERVER_AUTH_STANDARD,
     )
@@ -588,6 +588,23 @@ class TestGeoMapFishAccessControlMultipleOGCServer:
     "test_data",
 )
 class TestGeoMapFishAccessControlAutoMultiOGCServer:
+    def test_init(self, server_iface, test_data) -> None:
+        plugin = GeoMapFishAccessControl(server_iface)
+        assert plugin.single is False
+
+        assert plugin.serverInterface() is server_iface
+
+        set_request_parameters(server_iface, {"MAP": "qgisserver1"})
+        assert plugin.serverInterface().requestHandler().parameterMap()["MAP"] == "qgisserver1"
+        assert plugin.get_ogcserver_accesscontrol().ogcserver.name == "qgisserver1"
+
+
+@pytest.mark.usefixtures(
+    "qgs_access_control_filter",
+    "auto_multi_ogc_server_partial_path_env",
+    "test_data",
+)
+class TestGeoMapFishAccessControlAutoMultiOGCServerPartialPath:
     def test_init(self, server_iface, test_data) -> None:
         plugin = GeoMapFishAccessControl(server_iface)
         assert plugin.single is False

--- a/docker/qgisserver/tests/functional/conftest.py
+++ b/docker/qgisserver/tests/functional/conftest.py
@@ -123,6 +123,18 @@ def auto_multi_ogc_server_env():
 
 
 @pytest.fixture(scope="class")
+def auto_multi_ogc_server_partial_path_env():
+    with patch.dict(
+        "os.environ",
+        {
+            "GEOMAPFISH_ACCESSCONTROL_BASE_URL": "http://qgis/test",
+            "QGIS_PROJECT_FILE": "",
+        },
+    ):
+        yield
+
+
+@pytest.fixture(scope="class")
 def auto_single_ogc_server_env():
     with patch.dict(
         "os.environ",


### PR DESCRIPTION
## Summary
- allow `GEOMAPFISH_ACCESSCONTROL_BASE_URL` to match OGC server URLs when the configured path is a prefix (for example `/test` matches `/test/toto`)
- keep scheme and host matching unchanged, and add focused path-prefix matching logic in the access control plugin
- add functional coverage for partial-path auto-detection and update the integrator documentation accordingly

<!-- pull request links -->
See JIRA issue: [GSGIR-92](https://camptocamp.atlassian.net/browse/GSGIR-92).

[GSGIR-92]: https://camptocamp.atlassian.net/browse/GSGIR-92?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ