### PR TITLE
In theme2fts, only index visible themes, groups and layers

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scripts/theme2fts.py
+++ b/geoportal/c2cgeoportal_geoportal/scripts/theme2fts.py
@@ -231,13 +231,13 @@ class Import:
         print("Collecting data")
         start_time = time.time()
 
-        self.public_theme: dict[int, list[int]] = {}
-        self.public_group: dict[int, list[int]] = {}
-        self.public_layer: dict[int, list[int]] = {}
+        self.public_theme: dict[int, set[int]] = {}
+        self.public_group: dict[int, set[int]] = {}
+        self.public_layer: dict[int, set[int]] = {}
         for interface in self.interfaces:
-            self.public_theme[interface.id] = []
-            self.public_group[interface.id] = []
-            self.public_layer[interface.id] = []
+            self.public_theme[interface.id] = set()
+            self.public_group[interface.id] = set()
+            self.public_layer[interface.id] = set()
 
         self.full_text_search: list[dict[str, Any]] = []
 
@@ -329,7 +329,7 @@ class Import:
 
                 if fill and self.options.themes:
                     if role is None:
-                        self.public_theme[interface.id].append(theme.id)
+                        self.public_theme[interface.id].add(theme.id)
 
                     if role is None or theme.id not in self.public_theme[interface.id]:
                         self._add_fts(theme, interface, "add_theme", role)
@@ -368,7 +368,7 @@ class Import:
 
         if fill and export:
             if role is None:
-                self.public_group[interface.id].append(group.id)
+                self.public_group[interface.id].add(group.id)
 
             if role is None or group.id not in self.public_group[interface.id]:
                 self._add_fts(group, interface, "add_group", role)
@@ -399,7 +399,7 @@ class Import:
 
         if fill and self.options.layers:
             if role is None:
-                self.public_layer[interface.id].append(layer.id)
+                self.public_layer[interface.id].add(layer.id)
 
             if role is None or layer.id not in self.public_layer[interface.id]:
                 self._add_fts(layer, interface, "add_layer", role)

--- a/geoportal/c2cgeoportal_geoportal/scripts/theme2fts.py
+++ b/geoportal/c2cgeoportal_geoportal/scripts/theme2fts.py
@@ -202,6 +202,7 @@ class Import:
         all_themes = (
             self.session.query(Theme)
             .options(
+                sqlalchemy.orm.subqueryload(Theme.restricted_roles),
                 sqlalchemy.orm.subqueryload(Theme.children_relation),
                 sqlalchemy.orm.subqueryload(LayerWMS.metadatas),
             )

--- a/geoportal/c2cgeoportal_geoportal/scripts/theme2fts.py
+++ b/geoportal/c2cgeoportal_geoportal/scripts/theme2fts.py
@@ -232,9 +232,11 @@ class Import:
 
         self.public_theme: dict[int, list[int]] = {}
         self.public_group: dict[int, list[int]] = {}
+        self.public_layer: dict[int, list[int]] = {}
         for interface in self.interfaces:
             self.public_theme[interface.id] = []
             self.public_group[interface.id] = []
+            self.public_layer[interface.id] = []
 
         self.full_text_search: list[dict[str, Any]] = []
 
@@ -315,6 +317,9 @@ class Import:
         theme: "c2cgeoportal_commons.models.main.Theme",
         role: Optional["c2cgeoportal_commons.models.main.Role"] = None,
     ) -> None:
+        if role is not None and role not in theme.restricted_roles:
+            return
+
         fill = False
         for interface in self.interfaces:
             if interface in theme.interfaces:
@@ -392,7 +397,11 @@ class Import:
         fill = interface in layer.interfaces and self._layer_visible(layer, role)
 
         if fill and self.options.layers:
-            self._add_fts(layer, interface, "add_layer", role)
+            if role is None:
+                self.public_layer[interface.id].append(layer.id)
+
+            if role is None or layer.id not in self.public_layer[interface.id]:
+                self._add_fts(layer, interface, "add_layer", role)
 
         return fill
 

--- a/geoportal/tests/functional/test_theme2fts.py
+++ b/geoportal/tests/functional/test_theme2fts.py
@@ -126,12 +126,17 @@ def test_data(dbsession, transact):
     private_layer.interfaces = list(interfaces.values())
     add_parent(dbsession, private_layer, second_level_group)
 
-    layers = {layer.name: layer for layer in [public_layer, private_layer]}
+    private_layer_in_public_theme = main.LayerWMS(name="private_layer_in_public_theme", public=False)
+    private_layer_in_public_theme.ogc_server = ogc_server
+    private_layer_in_public_theme.interfaces = list(interfaces.values())
+    add_parent(dbsession, private_layer_in_public_theme, first_level_group)
+
+    layers = {layer.name: layer for layer in [public_layer, private_layer, private_layer_in_public_theme]}
     dbsession.add_all(layers.values())
 
     ra = main.RestrictionArea(name="ra")
     ra.roles = [role]
-    ra.layers = [private_layer]
+    ra.layers = [private_layer, private_layer_in_public_theme]
     dbsession.add(ra)
 
     dbsession.flush()  # Flush here to detect integrity errors now.
@@ -225,8 +230,8 @@ class TestImport:
         # languages * interfaces * (public_theme + first_level_group + public_layer)
         total = 4 * 2 * (1 + 1 + 1)
 
-        # private: languages * interfaces * (private_theme + second_level_group + private_layer) * (role)
-        total += 4 * 2 * (1 + 1 + 1) * 1
+        # private: languages * interfaces * (private_theme + second_level_group + private_layer, private_layer_in_public_theme) * (role)
+        total += 4 * 2 * (1 + 1 + 1 + 1) * 1
 
         assert dbsession.query(main.FullTextSearch).count() == total, "\n".join(
             [
@@ -323,6 +328,20 @@ class TestImport:
                             "it": "'it':3 'layer':2 'priv':1",
                         },
                         "actions": [{"action": "add_layer", "data": "private_layer"}],
+                    },
+                    {
+                        "label": f"private_layer_in_public_theme_{lang}",
+                        "role": test_data["roles"]["role"],
+                        "interface": interface,
+                        "lang": lang,
+                        "public": False,
+                        "ts": {
+                            "fr": "'fr':6 'in':3 'lai':2 'privat':1 'public':4 'them':5",
+                            "en": "'en':6 'layer':2 'privat':1 'public':4 'theme':5",
+                            "de": "'de':6 'lay':2 'privat':1 'public':4 'them':5",
+                            "it": "'it':6 'layer':2 'priv':1 'public':4 'them':5",
+                        },
+                        "actions": [{"action": "add_layer", "data": "private_layer_in_public_theme"}],
                     },
                 ]
                 for e in expected:

--- a/geoportal/tests/functional/test_theme2fts.py
+++ b/geoportal/tests/functional/test_theme2fts.py
@@ -91,7 +91,9 @@ def test_data(dbsession, transact):
     dbsession.add_all(interfaces.values())
 
     role = main.Role(name="role")
-    dbsession.add(role)
+    empty_role = main.Role(name="empty role")
+    roles = {r.name: r for r in [role, empty_role]}
+    dbsession.add_all(roles.values())
 
     public_theme = main.Theme(name="public_theme")
     public_theme.interfaces = list(interfaces.values())
@@ -137,7 +139,7 @@ def test_data(dbsession, transact):
     yield {
         "ogc_server": ogc_server,
         "interfaces": interfaces,
-        "role": role,
+        "roles": roles,
         "themes": themes,
         "groups": groups,
         "layers": layers,
@@ -220,10 +222,12 @@ class TestImport:
 
         Import(dbsession, settings, options())
 
-        # languages * interfaces * (themes + groups + layers)
+        # languages * interfaces * (public_theme + first_level_group + public_layer)
         total = 4 * 2 * (1 + 1 + 1)
-        # private: languages * interfaces * (themes + layers) * roles
-        total += 4 * 2 * (1 + 1) * 5
+
+        # private: languages * interfaces * (private_theme + second_level_group + private_layer) * (role)
+        total += 4 * 2 * (1 + 1 + 1) * 1
+
         assert dbsession.query(main.FullTextSearch).count() == total, "\n".join(
             [
                 ", ".join((fts.label, str(fts.lang), str(fts.interface), str(fts.public), str(fts.role)))
@@ -252,7 +256,7 @@ class TestImport:
                     },
                     {
                         "label": f"private_theme_{lang}",
-                        "role": test_data["role"],
+                        "role": test_data["roles"]["role"],
                         "interface": interface,
                         "lang": lang,
                         "public": False,
@@ -280,7 +284,7 @@ class TestImport:
                     },
                     {
                         "label": f"second_level_group_{lang}",
-                        "role": test_data["role"],
+                        "role": test_data["roles"]["role"],
                         "interface": interface,
                         "lang": lang,
                         "public": False,
@@ -308,7 +312,7 @@ class TestImport:
                     },
                     {
                         "label": f"private_layer_{lang}",
-                        "role": test_data["role"],
+                        "role": test_data["roles"]["role"],
                         "interface": interface,
                         "lang": lang,
                         "public": False,


### PR DESCRIPTION
Theme should be indexed only if `theme.public` is True or if current role is in `theme.restricted_roles`.

No need to browse the children of an inaccessible theme.

No need to have a layer indexed as public and private at the same time.

<!-- pull request links -->
See JIRA issue: [GSTIC-55](https://camptocamp.atlassian.net/browse/GSTIC-55).

[GSTIC-55]: https://camptocamp.atlassian.net/browse/GSTIC-55?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ