### PR TITLE
Update ngeo documentation reference URL

### DIFF
--- a/commons/c2cgeoportal_commons/models/main.py
+++ b/commons/c2cgeoportal_commons/models/main.py
@@ -1866,7 +1866,7 @@ class Metadata(Base):  # type: ignore[valid-type,misc]
                             """,
                             mapping={
                                 "url": (
-                                    "https://camptocamp.github.io/ngeo/"
+                                    "https://camptocamp.github.io/ngeo/refs/heads/"
                                     f"{os.environ.get('MAJOR_VERSION', 'master')}"
                                     "/apidoc/interfaces/src_themes.GmfMetaData.html"
                                 ),


### PR DESCRIPTION
Update the apidoc reference URL to include `/refs/heads/` for correct path resolution.