### PR TITLE
Add backend settings endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,40 @@ Use the long parameter names for clarity and maintainability.
 
 The new functionalities should be reasonably tested in the `*/tests/` folder or in `ci/test-app`.
 
+## Headers configuration
+
+When adding a new backend service/route that uses `set_common_headers(..., "<service>", ...)`:
+
+- Add the corresponding key in `geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/geoportal/vars.yaml` under `headers`.
+- Add the same key in `geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_vars.yaml` under `headers`.
+- Update `geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_config-schema.yaml` to allow this `headers.<service>` entry.
+- Add `headers.<service>.headers` in `geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/geoportal/vars.yaml` `update_paths` so values are inherited from `CONST_vars.yaml`.
+
+This keeps generated projects consistent and allows CORS/cache header configuration for the service.
+
+## Settings schema configuration
+
+When adding backend runtime settings:
+
+- Prefer nested settings maps (example: `settings.max_payload_size` should be configured as `settings: { max_payload_size: ... }`).
+- Define defaults in `geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_vars.yaml` close to related settings.
+- Update `geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_config-schema.yaml` accordingly.
+- Validate settings type/shape in code and return an internal server error for invalid server configuration.
+
+## Vars scaffolds overview
+
+How the scaffolded configuration files work together:
+
+- `geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_vars.yaml` is the source of default values (referred by the `extends` field of the `vars.yaml` file).
+- `geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/geoportal/vars.yaml` extends those defaults and should usually contain only project overrides.
+- `geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_config-schema.yaml` validates the final merged config.
+
+When adding new config entries, keep all three in sync:
+
+- Add defaults in `CONST_vars.yaml`.
+- Add schema support in `CONST_config-schema.yaml`.
+- If the value should be inherited by generated projects through the create scaffold, add the relevant path in `create/.../vars.yaml` `update_paths`.
+
 ## Branch naming
 
 Branch names must follow this format:

--- a/commons/c2cgeoportal_commons/alembic/static/f5e8b5dd3241_add_settings_column_on_user.py
+++ b/commons/c2cgeoportal_commons/alembic/static/f5e8b5dd3241_add_settings_column_on_user.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026, Camptocamp SA
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# The views and conclusions contained in the software and documentation are those
+# of the authors and should not be interpreted as representing official policies,
+# either expressed or implied, of the FreeBSD Project.
+
+# pylint: disable=invalid-name
+
+"""
+Add settings column on user.
+
+Revision ID: f5e8b5dd3241
+Revises: 267b4c1bde2e
+Create Date: 2026-06-10 10:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from c2c.template.config import config
+from sqlalchemy.dialects.postgresql import JSONB
+
+# revision identifiers, used by Alembic.
+revision = "f5e8b5dd3241"
+down_revision = "267b4c1bde2e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Upgrade."""
+    staticschema = config["schema_static"]
+
+    op.add_column(
+        "user",
+        sa.Column("settings", JSONB(), nullable=False, server_default=sa.text("'{}'::jsonb")),
+        schema=staticschema,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade."""
+    staticschema = config["schema_static"]
+    op.drop_column("user", "settings", schema=staticschema)

--- a/commons/c2cgeoportal_commons/models/static.py
+++ b/commons/c2cgeoportal_commons/models/static.py
@@ -36,8 +36,8 @@ from typing import Any
 
 import sqlalchemy.schema
 from c2c.template.config import config
-from sqlalchemy import Column, ForeignKey, Table
-from sqlalchemy.dialects.postgresql import HSTORE
+from sqlalchemy import Column, ForeignKey, Table, text
+from sqlalchemy.dialects.postgresql import HSTORE, JSONB
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import Mapped, backref, mapped_column, relationship
 from sqlalchemy.types import Boolean, DateTime, Integer, String, Unicode
@@ -179,6 +179,13 @@ class User(Base):  # type: ignore[valid-type,misc]
         info={"colanderalchemy": {"exclude": True}},
     )
     tech_data = mapped_column(MutableDict.as_mutable(HSTORE), info={"colanderalchemy": {"exclude": True}})
+    settings: Mapped[dict[str, Any]] = mapped_column(
+        MutableDict.as_mutable(JSONB),
+        default=dict,
+        nullable=False,
+        server_default=text("'{}'::jsonb"),
+        info={"colanderalchemy": {"exclude": True}},
+    )
     email: Mapped[str] = mapped_column(
         Unicode,
         nullable=False,
@@ -319,6 +326,7 @@ class User(Base):  # type: ignore[valid-type,misc]
         self.display_name = display_name or username
         self.password = password
         self.tech_data = {}
+        self.settings = {}
         self.email = email
         self.is_password_changed = is_password_changed
         if settings_role:

--- a/geoportal/c2cgeoportal_geoportal/__init__.py
+++ b/geoportal/c2cgeoportal_geoportal/__init__.py
@@ -801,6 +801,15 @@ def includeme(config: pyramid.config.Configurator) -> None:
     add_cors_route(config, "/profile.json", "profile")
     config.add_route("profile.json", "/profile.json", request_method="POST")
 
+    add_cors_route(config, "/user/settings", "settings")
+    config.add_route("settings_get", "/user/settings", request_method="GET")
+    config.add_route(
+        "settings_update",
+        "/user/settings",
+        request_method="POST",
+        header=_JSON_CONTENT_TYPE,
+    )
+
     # Access to vector tiles
     add_cors_route(config, "/vector_tiles", "vector_tiles")
     config.add_route("vector_tiles", "/vector_tiles/{layer_name}/{z}/{x}/{y}.pbf", request_method="GET")

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/geoportal/vars.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/geoportal/vars.yaml
@@ -348,6 +348,7 @@ vars:
     tinyows: *auth_header
     layers: *auth_header
     shortener: *auth_header
+    settings: *auth_header
     login: {}
 
 update_paths:
@@ -390,6 +391,7 @@ update_paths:
   - headers.tinyows.headers
   - headers.layers.headers
   - headers.shortener.headers
+  - headers.settings.headers
   - headers.login.headers
   - interfaces_config.default.constants.ngeoWfsPermalinkOptions
   - interfaces_config.default.constants.gmfOptions.view

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_config-schema.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_config-schema.yaml
@@ -87,6 +87,11 @@ mapping:
       schema:
         type: str
         required: True
+      settings:
+        type: map
+        mapping:
+          max_payload_size:
+            type: int
 
       dbsessions:
         type: map
@@ -360,6 +365,7 @@ mapping:
           raster: *header
           vector_tiles: *header
           shortener: *header
+          settings: *header
           error: *header
 
       urllogin:

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_vars.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_vars.yaml
@@ -11,6 +11,10 @@ vars:
   # Sqlalchemy static schema
   schema_static: '{PGSCHEMA_STATIC}'
 
+  settings:
+    # Maximum size in bytes accepted on POST /user/settings payload
+    max_payload_size: 65536
+
   dbsessions: {}
 
   enable_admin_interface: True
@@ -1201,6 +1205,7 @@ vars:
       <<: *auth_header
       cache_control_max_age_nocache: 0 # to refresh issue in editing
     shortener: *auth_header
+    settings: *auth_header
     login:
       <<: *auth_header
       access_control_allow_origin:

--- a/geoportal/c2cgeoportal_geoportal/views/settings.py
+++ b/geoportal/c2cgeoportal_geoportal/views/settings.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2026, Camptocamp SA
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# The views and conclusions contained in the software and documentation are those
+# of the authors and should not be interpreted as representing official policies,
+# either expressed or implied, of the FreeBSD Project.
+
+
+import json
+import logging
+from typing import Any, cast
+
+import pyramid.request
+from pyramid.httpexceptions import (
+    HTTPBadRequest,
+    HTTPInternalServerError,
+    HTTPRequestEntityTooLarge,
+    HTTPUnauthorized,
+)
+from pyramid.view import view_config
+
+from c2cgeoportal_commons import models
+from c2cgeoportal_commons.models import static
+from c2cgeoportal_geoportal.lib.common_headers import Cache, set_common_headers
+
+_LOG = logging.getLogger(__name__)
+
+
+class Settings:
+    """User settings endpoint."""
+
+    _SERVICE_NAME = "settings"
+    _DEFAULT_MAX_PAYLOAD_SIZE = 65536
+    _MAX_PAYLOAD_SIZE_CONFIG_NAME = "max_payload_size"
+
+    def __init__(self, request: pyramid.request.Request) -> None:
+        self.request = request
+        self.config = self.request.registry.settings.get("settings", {})
+        if not isinstance(self.config, dict):
+            _LOG.error("The 'settings' configuration should be a map, got %s", type(self.config).__name__)
+            raise HTTPInternalServerError("Invalid 'settings' configuration.")
+
+    def _get_user(self) -> static.User:
+        user = cast("static.User | None", self.request.user)
+        if user is None:
+            raise HTTPUnauthorized("See server logs for details")
+        return user
+
+    @staticmethod
+    def _parse_max_payload_size(raw_value: Any) -> int:
+        if raw_value is None:
+            return Settings._DEFAULT_MAX_PAYLOAD_SIZE
+        try:
+            value = int(raw_value)
+        except (TypeError, ValueError) as exc:
+            _LOG.exception("Invalid settings.max_payload_size value: %r", raw_value)
+            raise HTTPInternalServerError("Invalid 'settings.max_payload_size' configuration.") from exc
+        if value < 1:
+            _LOG.error("settings.max_payload_size should be greater than 0, got %s", value)
+            raise HTTPInternalServerError("Invalid 'settings.max_payload_size' configuration.")
+        return value
+
+    def _read_body_with_limit(self) -> bytes:
+        max_payload_size = self._parse_max_payload_size(self.config.get(self._MAX_PAYLOAD_SIZE_CONFIG_NAME))
+        if self.request.content_length is not None and self.request.content_length > max_payload_size:
+            raise HTTPRequestEntityTooLarge("The payload is too large.")
+
+        body = cast("bytes", self.request.body_file.read(max_payload_size + 1))
+        if len(body) > max_payload_size:
+            raise HTTPRequestEntityTooLarge("The payload is too large.")
+        return body
+
+    @view_config(route_name="settings_get", renderer="json")  # type: ignore[untyped-decorator]
+    def get(self) -> dict[str, Any]:
+        user = self._get_user()
+        set_common_headers(self.request, self._SERVICE_NAME, Cache.PRIVATE_NO)
+        return user.settings or {}
+
+    @view_config(route_name="settings_update", renderer="json")  # type: ignore[untyped-decorator]
+    def update(self) -> dict[str, Any]:
+        assert models.DBSession is not None
+
+        user = self._get_user()
+        body = self._read_body_with_limit()
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError as exc:
+            raise HTTPBadRequest("Body should be valid JSON.") from exc
+        if not isinstance(payload, dict):
+            raise HTTPBadRequest("Body should be a JSON object.")
+
+        user.settings = payload
+        models.DBSession.flush()
+
+        set_common_headers(self.request, self._SERVICE_NAME, Cache.PRIVATE_NO)
+        return user.settings

--- a/geoportal/tests/functional/test_settings.py
+++ b/geoportal/tests/functional/test_settings.py
@@ -1,0 +1,155 @@
+# Copyright (c) 2026, Camptocamp SA
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# The views and conclusions contained in the software and documentation are those
+# of the authors and should not be interpreted as representing official policies,
+# either expressed or implied, of the FreeBSD Project.
+
+# pylint: disable=missing-docstring,attribute-defined-outside-init,protected-access
+
+
+import json
+from io import BytesIO
+
+import pytest
+
+from tests.functional import create_dummy_request
+
+
+@pytest.fixture
+def settings_setup(dbsession, transact):
+    from c2cgeoportal_commons.models.main import Role
+    from c2cgeoportal_commons.models.static import User
+
+    del transact
+
+    role = Role(name="__test_role")
+    user = User(username="__test_user", password="__test_user", settings_role=role, roles=[role])
+    user.email = "__test_user@example.com"
+    dbsession.add_all([user])
+    dbsession.flush()
+    return user
+
+
+class TestSettingsView:
+    @staticmethod
+    def _create_request_obj(username=None, body=None, additional_settings=None):
+        from c2cgeoportal_commons.models import DBSession
+        from c2cgeoportal_commons.models.static import User
+
+        request = create_dummy_request(authentication=True, additional_settings=additional_settings)
+
+        if username is not None:
+            request.user = DBSession.query(User).filter_by(username=username).one()
+        if body is not None:
+            request.body = body
+            request.body_file = BytesIO(body)
+            request.content_length = len(body)
+        return request
+
+    def test_get_initial_settings_returns_empty_object(self, settings_setup) -> None:
+        del settings_setup
+        from c2cgeoportal_geoportal.views.settings import Settings
+
+        request = self._create_request_obj(username="__test_user")
+        response = Settings(request).get()
+        assert response == {}
+
+    def test_get_requires_authentication(self, settings_setup) -> None:
+        del settings_setup
+        from pyramid.httpexceptions import HTTPUnauthorized
+
+        from c2cgeoportal_geoportal.views.settings import Settings
+
+        request = self._create_request_obj()
+        with pytest.raises(HTTPUnauthorized):
+            Settings(request).get()
+
+    def test_post_round_trip_and_overwrite(self, settings_setup) -> None:
+        del settings_setup
+        from c2cgeoportal_geoportal.views.settings import Settings
+
+        request = self._create_request_obj(username="__test_user", body=b'{"a": 1, "b": {"c": true}}')
+        response = Settings(request).update()
+        assert response == {"a": 1, "b": {"c": True}}
+
+        request = self._create_request_obj(username="__test_user")
+        assert Settings(request).get() == {"a": 1, "b": {"c": True}}
+
+        request = self._create_request_obj(username="__test_user", body=b'{"theme": "night"}')
+        response = Settings(request).update()
+        assert response == {"theme": "night"}
+
+        request = self._create_request_obj(username="__test_user")
+        assert Settings(request).get() == {"theme": "night"}
+
+    def test_post_requires_json_object(self, settings_setup) -> None:
+        del settings_setup
+        from pyramid.httpexceptions import HTTPBadRequest
+
+        from c2cgeoportal_geoportal.views.settings import Settings
+
+        request = self._create_request_obj(username="__test_user", body=b'["not", "an", "object"]')
+        with pytest.raises(HTTPBadRequest):
+            Settings(request).update()
+
+    def test_post_invalid_json(self, settings_setup) -> None:
+        del settings_setup
+        from pyramid.httpexceptions import HTTPBadRequest
+
+        from c2cgeoportal_geoportal.views.settings import Settings
+
+        request = self._create_request_obj(username="__test_user", body=b"not-json")
+        with pytest.raises(HTTPBadRequest):
+            Settings(request).update()
+
+    def test_post_too_large(self, settings_setup) -> None:
+        del settings_setup
+        from pyramid.httpexceptions import HTTPRequestEntityTooLarge
+
+        from c2cgeoportal_geoportal.views.settings import Settings
+
+        body = json.dumps({"data": "x" * 200}).encode()
+        request = self._create_request_obj(
+            username="__test_user",
+            body=body,
+            additional_settings={"settings": {"max_payload_size": 100}},
+        )
+
+        with pytest.raises(HTTPRequestEntityTooLarge):
+            Settings(request).update()
+
+    def test_post_invalid_settings_configuration(self, settings_setup) -> None:
+        del settings_setup
+        from pyramid.httpexceptions import HTTPInternalServerError
+
+        from c2cgeoportal_geoportal.views.settings import Settings
+
+        request = self._create_request_obj(
+            username="__test_user",
+            body=b"{}",
+            additional_settings={"settings": {"max_payload_size": "wrong"}},
+        )
+
+        with pytest.raises(HTTPInternalServerError):
+            Settings(request).update()


### PR DESCRIPTION
## What
- add fixed backend route `/settings` for authenticated users
- add GET `/settings` (returns `{}` for initial config)
- add POST `/settings` to overwrite saved settings JSON
- add configurable payload size limit via `settings.max_payload_size`
- add `user.settings` `JSONB` column in `static` schema
- add alembic migration for the new column
- add functional tests for auth, initial empty settings, overwrite, invalid JSON, and payload too large

Backend part of: https://gitlab.com/geogirafe/gg-viewer/-/work_items/825
<!-- session: ses_14eaef3a8ffeirQQ8snEdhmJXD -->
<!-- pull request links -->
See JIRA issue: [GSGIR-93](https://camptocamp.atlassian.net/browse/GSGIR-93).

[GSGIR-93]: https://camptocamp.atlassian.net/browse/GSGIR-93?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ