### PR TITLE
Fix list rendering in documentation

### DIFF
--- a/doc/developer/cache.rst
+++ b/doc/developer/cache.rst
@@ -6,6 +6,7 @@ Cache management
 Here we describe the strategy we use to manage the cache.
 
 We have three kinds of services:
+
  * Without any cache (**no_cache**).
  * Cache related to the application version (**public_cache**).
  * Cache related to the application version and the current role (**private_cache**).

--- a/doc/developer/server_side.rst
+++ b/doc/developer/server_side.rst
@@ -125,6 +125,7 @@ Then, customize the migration to suit your needs, test it:
     docker compose exec geoportal upgrade head
 
 More information at:
+
  * https://alembic.readthedocs.org/en/latest/index.html
  * https://alembic.readthedocs.org/en/latest/tutorial.html#create-a-migration-script
  * https://alembic.readthedocs.org/en/latest/ops.html

--- a/doc/integrator/admin_interface.rst
+++ b/doc/integrator/admin_interface.rst
@@ -24,6 +24,7 @@ Default tabs/modules
 ~~~~~~~~~~~~~~~~~~~~
 
 The active default tabs (route urls) are:
+
 - layertree
 - themes
 - layer_groups

--- a/doc/integrator/create_application.rst
+++ b/doc/integrator/create_application.rst
@@ -307,6 +307,7 @@ With the application we have some predefined workflows.
 .............................
 
 The workflow that will run on all your commits, it will:
+
 - Run some code style checks on your code.
 - Build you application.
 - Run the acceptance tests (if configured).

--- a/doc/integrator/extend_application.rst
+++ b/doc/integrator/extend_application.rst
@@ -310,6 +310,7 @@ The panel will be included with the following HTML:
 ```
 
 The modifications in the ``vars`` file are:
+
 - Add the JavaScript file as ``gmfCustomJavascriptUrl``.
 - Be sure that we have the CSS file as ``gmfCustomStylesheetUrl``.
 - Add in comment all the needed configuration to be able to debug.

--- a/doc/integrator/install_application.rst
+++ b/doc/integrator/install_application.rst
@@ -8,6 +8,7 @@ On this page, we explain the procedure to build an application from only the cur
 If you want to use an existing database, you should ignore all the commands concerning the database.
 
 This guide assumes that:
+
  - all dependencies described in the :ref:`requirements <integrator_requirements>` are installed,
  - Git is used as revision control.
 

--- a/doc/integrator/interface.rst
+++ b/doc/integrator/interface.rst
@@ -52,6 +52,7 @@ If you need cache bustering you should put your files in the ``geoportal/geomapf
 directory (``/etc/geomapfish/static`` in the container).
 
 The interface HTML file is considered as mako template and he can use the following variables:
+
 - ``request``: the Pyramid request object.
 - ``dynamicUrl``: the URL to get the interface configuration.
 - ``interface``: the interface name.

--- a/doc/integrator/ogc_api.rst
+++ b/doc/integrator/ogc_api.rst
@@ -37,6 +37,7 @@ QGIS Server and MapServer are already configured to support the OGC API and dete
 Landing pages for both MapServer and QGIS Server are not supported yet.
 
 OGC API features are accessible through ``mapserv_proxy``, with the following URLs:
+
 * ``/mapserv_proxy/<ogc-server>/ogcapi/*``: The MapServer path.
 * ``/mapserv_proxy/<ogc-server>/wfs3/*``: The QGIS Server path.
 

--- a/doc/integrator/vector_tiles.rst
+++ b/doc/integrator/vector_tiles.rst
@@ -33,6 +33,7 @@ name
 
 style
    URL to a Mapbox Style file (version 8 or higher), examples:
+
    - https://example.com/mystyle.json
    - static:///mb_styles/osm_landuse.json
 


### PR DESCRIPTION
This fixes the OGC API URL list formatting in the integrator documentation.

- add the required blank line before the bullet list in `doc/integrator/ogc_api.rst`
- restore correct list rendering in generated HTML