### PR TITLE
Fix gmfOptions.map shared across interfaces via YAML alias

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/geoportal/vars.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/geoportal/vars.yaml
@@ -395,6 +395,7 @@ update_paths:
   - headers.login.headers
   - interfaces_config.default.constants.ngeoWfsPermalinkOptions
   - interfaces_config.default.constants.gmfOptions.view
+  - interfaces_config.default.constants.gmfOptions.map
   - interfaces_config.default.constants.gmfSearchOptions
   - interfaces_config.default.constants.gmfPermalinkOptions
   - interfaces_config.default.constants.gmfVectorTilesOptions
@@ -402,11 +403,14 @@ update_paths:
   - interfaces_config.default.static
   - interfaces_config.default.routes.fulltextsearchUrl
   - interfaces_config.desktop.constants.gmfOptions.view
+  - interfaces_config.desktop.constants.gmfOptions.map
   - interfaces_config.desktop.constants.gmfPrintOptions
   - interfaces_config.desktop.routes
   - interfaces_config.mobile.constants.gmfOptions.view
+  - interfaces_config.mobile.constants.gmfOptions.map
   - interfaces_config.mobile.constants.gmfMobileMeasurePointOptions
   - interfaces_config.iframe_api.constants.gmfOptions.view
+  - interfaces_config.iframe_api.constants.gmfOptions.map
   - interfaces_config.api.constants
   - interfaces_config.api.routes.searchUrl
   - interfaces_theme

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_vars.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_vars.yaml
@@ -365,7 +365,9 @@ vars:
       redirect_interface: mobile
       do_redirect: True
       constants:
-        gmfOptions: *gmfOptions
+        gmfOptions:
+          <<: *gmfOptions
+          map: {}
         ngeoProfileOptions: {}
         ngeoStreetviewOptions:
           viewer: 'mapillary'
@@ -430,7 +432,9 @@ vars:
       extends: default
       redirect_interface: desktop
       constants:
-        gmfOptions: *gmfOptions
+        gmfOptions:
+          <<: *gmfOptions
+          map: {}
         gmfMobileMeasureAreaOptions:
           precision: 2
           sketchStyle: &mobileMeasureStyle
@@ -477,7 +481,9 @@ vars:
     iframe_api:
       extends: default
       constants:
-        gmfOptions: *gmfOptions
+        gmfOptions:
+          <<: *gmfOptions
+          map: {}
         gmfSearchGroups: []
         gmfFitOptions:
           # Padding (in pixels) to be correctly fitted inside the view. Values in the array are top, right, bottom and left padding.


### PR DESCRIPTION
## Problem

In `CONST_vars.yaml`, the `desktop`, `mobile`, and `iframe_api` interfaces all used a plain YAML alias (`*gmfOptions`) to reference the default interface's `gmfOptions`. This means all four interfaces share the **same Python dict object** for `gmfOptions` — and crucially, the same `map: {}` nested dict.

When `c2c-template`'s `update_vars()` processes interfaces in YAML order, it mutates these shared dicts in-place. If a later interface (e.g. `iframe_api` with `map: {}` and no `update_paths` entry for `map`) is processed after an earlier one that set a value (e.g. `mobile` with `moveTolerance: 8`), the later interface **replaces** the shared map dict, wiping the earlier value.

Concrete failure: setting `gmfOptions.map.moveTolerance` in the `mobile` interface had no effect because `iframe_api`'s `map: {}` (processed last) replaced the shared map with an empty dict.

## Fix

- **`CONST_vars.yaml`**: Replace `gmfOptions: *gmfOptions` with a merge key (`<<: *gmfOptions`) plus an explicit `map: {}` for each of `desktop`, `mobile`, and `iframe_api`. Each interface now has its own independent `map` dict that cannot be accidentally overwritten by another interface's processing.

- **`vars.yaml` (create scaffold)**: Add `interfaces_config.*.constants.gmfOptions.map` to `update_paths` for all interfaces so that project-level `map` settings are **merged** into (rather than replacing) the per-interface `map` dict.

## Notes

- The same bug exists in the `2.9` branch and will need to be backported.
- Related customer issue: GSTIC-57