### PR TITLE
Add debounceDelay option to gmfWMSSourceOptions

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_vars.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_vars.yaml
@@ -312,6 +312,9 @@ vars:
           # The default value is 1.5 but it add a slight blur on the layer,
           # 2 is also possible but it uses many network and can break on some mobile devices.
           ratio: 1
+          # Delay in milliseconds before sending a WMS GetMap request when the view changes.
+          # This prevents duplicate requests during animated zoom or pan.
+          debounceDelay: 100
 
       dynamic_constants:
         interface: interface


### PR DESCRIPTION
Add the `debounceDelay` option to `gmfWMSSourceOptions` with a default value of 100ms.

This option prevents duplicate WMS GetMap requests during animated zoom or pan by using the new `DebouncedImageWMS` source from ngeo (see https://github.com/camptocamp/ngeo/pull/10149).


<!-- pull request links -->
See JIRA issue: [GSGEOC-463](https://camptocamp.atlassian.net/browse/GSGEOC-463).

[GSGEOC-463]: https://camptocamp.atlassian.net/browse/GSGEOC-463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ