### PR TITLE
Enable lock file maintenance for geoportal/package-lock.json on all branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -201,4 +201,10 @@
       matchFileNames: ['geoportal/package.json'],
     },
   ],
+  /** Lock file maintenance for geoportal/package-lock.json on all branches */
+  lockFileMaintenance: {
+    enabled: true,
+    managerFilePatterns: ['/geoportal/package-lock.json/'],
+    schedule: 'before 5am on monday',
+  },
 }


### PR DESCRIPTION
Activate Renovate's `lockFileMaintenance` for `geoportal/package-lock.json` on all branches, not just those in `baseBranchPatterns`.