### PR TITLE
Add feedback service

### DIFF
--- a/commons/c2cgeoportal_commons/alembic/static/3d75d1d9500b_add_feedback_table.py
+++ b/commons/c2cgeoportal_commons/alembic/static/3d75d1d9500b_add_feedback_table.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026, Camptocamp SA
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# The views and conclusions contained in the software and documentation are those
+# of the authors and should not be interpreted as representing official policies,
+# either expressed or implied, of the FreeBSD Project.
+
+# pylint: disable=invalid-name
+
+"""
+Add feedback table.
+
+Revision ID: 3d75d1d9500b
+Revises: f5e8b5dd3241
+Create Date: 2026-07-16 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from c2c.template.config import config
+
+# revision identifiers, used by Alembic.
+revision = "3d75d1d9500b"
+down_revision = "f5e8b5dd3241"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Upgrade."""
+    staticschema = config["schema_static"]
+
+    op.create_table(
+        "feedback",
+        sa.Column("id_feedback", sa.Integer(), nullable=False),
+        sa.Column("user_agent", sa.String(), nullable=True),
+        sa.Column("application", sa.String(), nullable=True),
+        sa.Column("permalink", sa.String(), nullable=True),
+        sa.Column("text", sa.String(), nullable=True),
+        sa.Column("email", sa.String(), nullable=True),
+        sa.PrimaryKeyConstraint("id_feedback"),
+        schema=staticschema,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade."""
+    staticschema = config["schema_static"]
+
+    op.drop_table("feedback", schema=staticschema)

--- a/commons/c2cgeoportal_commons/models/static.py
+++ b/commons/c2cgeoportal_commons/models/static.py
@@ -555,3 +555,16 @@ class Log(AbstractLog):
         "polymorphic_identity": "static",
         "concrete": True,
     }
+
+
+class Feedback(Base):  # type: ignore[valid-type,misc]
+    """The feedback table representation."""
+
+    __tablename__ = "feedback"
+    __table_args__ = {"schema": _schema}  # noqa: RUF012
+    id_feedback: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_agent: Mapped[str | None] = mapped_column(String)
+    application: Mapped[str | None] = mapped_column(String)
+    permalink: Mapped[str | None] = mapped_column(String)
+    text: Mapped[str | None] = mapped_column(String)
+    email: Mapped[str | None] = mapped_column(String)

--- a/doc/developer/webservices.rst
+++ b/doc/developer/webservices.rst
@@ -768,6 +768,36 @@ Result
     }
 
 
+Feedback
+========
+
+Create
+------
+
+URL: ``.../feedback``
+
+Method ``POST``
+
+Parameters
+~~~~~~~~~~
+
+* ``user_agent``: User agent string.
+* ``application``: Application identifier.
+* ``permalink``: The current map permalink URL.
+* ``email``: User email address.
+* ``email_optional``: Email address to send a notification to (optional).
+* ``feedback``: The feedback text.
+
+Result
+~~~~~~
+
+.. code::
+
+    {
+        "success": true
+    }
+
+
 Geometry processing
 ===================
 

--- a/doc/integrator/features.rst
+++ b/doc/integrator/features.rst
@@ -20,4 +20,5 @@ Features that require additional steps (most of the time):
    routing
    multi_tenant
    vector_tiles
+   feedback
    extend_application

--- a/doc/integrator/feedback.rst
+++ b/doc/integrator/feedback.rst
@@ -1,0 +1,56 @@
+.. _integrator_feedback:
+
+Configure feedback
+==================
+
+The configuration in ``vars.yaml`` looks like this:
+
+.. code:: yaml
+
+   # SMTP configuration could be already there if needed by other feature
+   smtp:
+       host: smtp.example.com:465
+       ssl: true
+       user: <username>
+       password: <password>
+       starttls: false
+
+   feedback:
+        # Used to send a feedback notification email
+        email_from: info@camptocamp.com
+        email_subject: Feedback - Map viewer
+        email_body: |
+            This is an automated email. A new feedback has been inserted in the database.
+
+            Instance: {instance}
+
+            Feedback ID: {id_feedback}
+
+            User agent: {user_agent}
+
+            Application: {application}
+
+            Permalink: {permalink}
+
+            User email: {user_email}
+
+            User text: {text}
+
+The feedback form data is stored in the ``feedback`` database table with the
+following fields: ``user_agent``, ``application``, ``permalink``, ``text``,
+and ``email``.
+
+The service exposes a ``POST /feedback`` endpoint. The frontend can access it
+through the ``feedbackUrl`` route entrypoint, configured in
+``interfaces_config.default.routes.feedbackUrl`` in the ``vars.yaml`` file.
+
+When a user provides an email address in the ``email_optional`` field, a
+notification email is sent to that address using the configured SMTP server.
+
+If the SMTP host ends with a colon (`:`) followed by a number, and
+there is no port specified, that suffix will be stripped off and the
+number interpreted as the port number to use.
+
+Replace the ``smtp.example.com`` value by a working SMTP server name.
+If your SMTP server does not require user login, then remove the configuration
+for user and password.

--- a/geoportal/c2cgeoportal_geoportal/__init__.py
+++ b/geoportal/c2cgeoportal_geoportal/__init__.py
@@ -744,6 +744,10 @@ def includeme(config: pyramid.config.Configurator) -> None:
     config.add_route("oidc_login", "/oidc/login", request_method="GET")
     config.add_route("oidc_callback", "/oidc/callback", request_method="GET")
 
+    # Feedback
+    add_cors_route(config, "/feedback", "feedback")
+    config.add_route("feedback", "/feedback", request_method="POST")
+
     config.add_renderer(".map", AssetRendererFactory)
     config.add_renderer(".css", AssetRendererFactory)
     config.add_renderer(".ico", AssetRendererFactory)

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/Dockerfile
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/Dockerfile
@@ -12,7 +12,7 @@ ENV CONFIG_VARS sqlalchemy.url sqlalchemy.pool_recycle sqlalchemy.pool_size sqla
     checker check_collector default_max_age package srid \
     reset_password fulltextsearch global_headers headers authorized_referers hooks stats db_chooser \
     dbsessions urllogin host_forward_host headers_whitelist headers_blacklist \
-    smtp c2c.base_path welcome_email \
+    smtp c2c.base_path welcome_email feedback \
     lingva_extractor interfaces_config interfaces devserver_url api authentication intranet metrics pdfreport \
     vector_tiles i18next main_ogc_server static_files http_options
 

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/geoportal/vars.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/geoportal/vars.yaml
@@ -267,6 +267,35 @@ vars:
       Sincerely yours
       The GeoMapFish team
 
+  feedback:
+    # Used to send a feedback notification email
+    email_from: info@camptocamp.com
+    email_subject: Feedback - Map viewer
+    # Email template, can contain:
+    # - {instance}
+    # - {id_feedback}
+    # - {user_agent}
+    # - {application}
+    # - {permalink}
+    # - {user_email}
+    # - {text}
+    email_body: |
+      This is an automated email. A new feedback has been inserted in the database.
+
+      Instance: {instance}
+
+      Feedback ID: {id_feedback}
+
+      User agent: {user_agent}
+
+      Application: {application}
+
+      Permalink: {permalink}
+
+      User email: {user_email}
+
+      User text: {text}
+
   allowed_hosts:
     # TODO: Add the allowed hosts for the application (themes and dynamic.json)
     - localhost:8484
@@ -340,6 +369,7 @@ vars:
     raster: *header
     vector_tiles: *header
     error: *header
+    feedback: *header
     themes: &auth_header {}
     config: *auth_header
     print: *auth_header
@@ -383,6 +413,7 @@ update_paths:
   - headers.raster.headers
   - headers.vector_tiles.headers
   - headers.error.headers
+  - headers.feedback.headers
   - headers.themes.headers
   - headers.config.headers
   - headers.print.headers
@@ -401,6 +432,7 @@ update_paths:
   - interfaces_config.default.dynamic_constants
   - interfaces_config.default.static
   - interfaces_config.default.routes.fulltextsearchUrl
+  - interfaces_config.default.routes.feedbackUrl
   - interfaces_config.desktop.constants.gmfOptions.view
   - interfaces_config.desktop.constants.gmfPrintOptions
   - interfaces_config.desktop.routes
@@ -422,6 +454,7 @@ no_interpreted:
   - reset_password.email_body
   - shortener.email_body
   - welcome_email.email_body
+  - feedback.email_body
   - authentication.openid_connect.user_info_fields.display_name
 
 # Only for Standalone version (should be commented for Kubernetes version)

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_config-schema.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_config-schema.yaml
@@ -367,6 +367,7 @@ mapping:
           shortener: *header
           user_settings: *header
           error: *header
+          feedback: *header
 
       urllogin:
         type: map
@@ -622,6 +623,10 @@ mapping:
             required: True
             type: str
       welcome_email:
+        type: map
+        required: True
+        mapping: *send_email
+      feedback:
         type: map
         required: True
         mapping: *send_email

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_vars.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/update/{{cookiecutter.project}}/geoportal/CONST_vars.yaml
@@ -363,6 +363,8 @@ vars:
             interface: interface
         gmfVectorTilesUrl:
           name: vector_tiles_root
+        feedbackUrl:
+          name: feedback
     desktop:
       extends: default
       redirect_interface: mobile
@@ -984,6 +986,9 @@ vars:
   # Used to send an email on password reset
   reset_password: {}
 
+  # Used to send an email on feedback
+  feedback: {}
+
   # The shortener base configuration
   shortener:
     length: 4
@@ -1188,6 +1193,7 @@ vars:
     raster: *header
     vector_tiles: *header
     error: *header
+    feedback: *header
     themes: &auth_header
       cache_control_max_age: 600 # 10 minutes
       cache_control_max_age_nocache: 10 # 10 seconds, to avoid too many call

--- a/geoportal/c2cgeoportal_geoportal/views/feedback.py
+++ b/geoportal/c2cgeoportal_geoportal/views/feedback.py
@@ -1,0 +1,56 @@
+import logging
+from typing import Any
+
+import pyramid.request
+from pyramid.httpexceptions import HTTPBadRequest
+from pyramid.view import view_config
+
+from c2cgeoportal_commons.lib.email_ import send_email_config
+from c2cgeoportal_commons.models import DBSession
+from c2cgeoportal_commons.models.static import Feedback
+from c2cgeoportal_geoportal.lib.common_headers import Cache, set_common_headers
+
+_LOG = logging.getLogger(__name__)
+
+
+@view_config(route_name="feedback", renderer="json")  # type: ignore[untyped-decorator]
+def feedback_post(request: pyramid.request.Request) -> dict[str, Any]:
+    """Handle feedback form submission."""
+    if (
+        "permalink" not in request.params
+        or "user_agent" not in request.params
+        or "application" not in request.params
+        or "email" not in request.params
+        or "email_optional" not in request.params
+        or "feedback" not in request.params
+    ):
+        raise HTTPBadRequest(detail="parameter missing")
+
+    new_feedback = Feedback()
+    new_feedback.user_agent = request.params["user_agent"]
+    new_feedback.application = request.params["application"]
+    new_feedback.permalink = request.params["permalink"]
+    new_feedback.email = request.params["email"]
+    new_feedback.text = request.params["feedback"]
+    assert DBSession is not None
+    DBSession.add(new_feedback)
+    DBSession.flush()
+
+    instance = request.params["permalink"].split("?")[0]
+    email = request.params.get("email_optional", "")
+    if email != "":
+        send_email_config(
+            request.registry.settings,
+            "feedback",
+            email,
+            instance=instance,
+            id_feedback=str(new_feedback.id_feedback),
+            user_agent=new_feedback.user_agent or "",
+            application=new_feedback.application or "",
+            permalink=new_feedback.permalink or "",
+            user_email=new_feedback.email or "",
+            text=new_feedback.text or "",
+        )
+
+    set_common_headers(request, "feedback", Cache.PRIVATE_NO)
+    return {"success": True}

--- a/geoportal/tests/functional/test_feedback.py
+++ b/geoportal/tests/functional/test_feedback.py
@@ -33,16 +33,23 @@ from unittest.mock import patch
 
 from pyramid import testing
 
-from tests.functional import cleanup_db, create_dummy_request, setup_db
+from tests.functional import create_dummy_request
+from tests.functional import setup_common as setup_module  # noqa
+from tests.functional import teardown_common as teardown_module  # noqa
 
 
 class TestFeedbackView(TestCase):
-    def setup_method(self, _) -> None:
-        setup_db()
-
     def teardown_method(self, _) -> None:
         testing.tearDown()
-        cleanup_db()
+
+        import transaction
+
+        from c2cgeoportal_commons.models import DBSession
+        from c2cgeoportal_commons.models.static import Feedback
+
+        assert DBSession is not None
+        DBSession.query(Feedback).delete()
+        transaction.commit()
 
     @staticmethod
     def _create_request(params=None):

--- a/geoportal/tests/functional/test_feedback.py
+++ b/geoportal/tests/functional/test_feedback.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2026, Camptocamp SA
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# The views and conclusions contained in the software and documentation are those
+# of the authors and should not be interpreted as representing official policies,
+# either expressed or implied, of the FreeBSD Project.
+
+# pylint: disable=missing-docstring,attribute-defined-outside-init,protected-access
+
+
+from unittest import TestCase
+from unittest.mock import patch
+
+from pyramid import testing
+
+from tests.functional import cleanup_db, create_dummy_request, setup_db
+
+
+class TestFeedbackView(TestCase):
+    def setup_method(self, _) -> None:
+        setup_db()
+
+    def teardown_method(self, _) -> None:
+        testing.tearDown()
+        cleanup_db()
+
+    @staticmethod
+    def _create_request(params=None):
+        if params is None:
+            params = {}
+        request = create_dummy_request(
+            additional_settings={
+                "feedback": {
+                    "email_from": "test@example.com",
+                    "email_subject": "Test feedback",
+                    "email_body": "Instance: {instance}\nID: {id_feedback}",
+                },
+            }
+        )
+        request.params = params
+        return request
+
+    def test_missing_params(self) -> None:
+        from pyramid.httpexceptions import HTTPBadRequest
+
+        from c2cgeoportal_geoportal.views.feedback import feedback_post
+
+        request = self._create_request({})
+        with self.assertRaises(HTTPBadRequest):
+            feedback_post(request)
+
+    def test_missing_user_agent(self) -> None:
+        from pyramid.httpexceptions import HTTPBadRequest
+
+        from c2cgeoportal_geoportal.views.feedback import feedback_post
+
+        request = self._create_request(
+            {
+                "permalink": "https://example.com/view",
+                "email": "user@example.com",
+                "email_optional": "admin@example.com",
+                "feedback": "Great app!",
+            }
+        )
+        with self.assertRaises(HTTPBadRequest):
+            feedback_post(request)
+
+    def test_success(self) -> None:
+        from c2cgeoportal_geoportal.views.feedback import feedback_post
+
+        request = self._create_request(
+            {
+                "permalink": "https://example.com/view?theme=Demo",
+                "user_agent": "Mozilla/5.0",
+                "application": "viewer",
+                "email": "user@example.com",
+                "email_optional": "",
+                "feedback": "Great app!",
+            }
+        )
+        result = feedback_post(request)
+        assert result == {"success": True}
+
+    def test_success_with_email(self) -> None:
+        from c2cgeoportal_geoportal.views.feedback import feedback_post
+
+        request = self._create_request(
+            {
+                "permalink": "https://example.com/view?theme=Demo",
+                "user_agent": "Mozilla/5.0",
+                "application": "viewer",
+                "email": "user@example.com",
+                "email_optional": "admin@example.com",
+                "feedback": "Great app!",
+            }
+        )
+        with patch("c2cgeoportal_geoportal.views.feedback.send_email_config") as mock_send:
+            result = feedback_post(request)
+            assert result == {"success": True}
+            mock_send.assert_called_once()
+            _, kwargs = mock_send.call_args
+            assert kwargs["instance"] == "https://example.com/view"
+            assert kwargs["user_agent"] == "Mozilla/5.0"
+            assert kwargs["application"] == "viewer"
+            assert kwargs["permalink"] == "https://example.com/view?theme=Demo"
+            assert kwargs["user_email"] == "user@example.com"
+            assert kwargs["text"] == "Great app!"


### PR DESCRIPTION
Port the feedback feature from demo_geomapfish to c2cgeoportal.

Changes:
- Add Feedback model in static schema (commons/.../models/static.py)
- Add Alembic migration for feedback table
- Add POST /feedback view with DB persistence and email notification
- Add route and CORS support
- Add headers configuration for feedback service
- Add email configuration with template
- Add `feedbackUrl` route in interfaces_config for frontend

First part of: https://camptocamp.atlassian.net/browse/GSGIR-99