### PR TITLE
Respect query_user_info option in Bearer token authorization path

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/__init__.py
+++ b/geoportal/c2cgeoportal_geoportal/__init__.py
@@ -44,6 +44,7 @@ import dateutil.parser
 import pyramid.config
 import pyramid.request
 import pyramid.response
+import simple_openid_connect.data
 import sqlalchemy
 import sqlalchemy.orm
 import zope.event.classhandler
@@ -404,7 +405,19 @@ def create_get_user_from_request(
             ):
                 token = request.headers["Authorization"][7:]
                 client = oidc.get_oidc_client(request, request.host)
-                user_info = client.fetch_userinfo(token)
+
+                if openid_connect_configuration.get("query_user_info", False):
+                    user_info = client.fetch_userinfo(token)
+                else:
+                    access_token = simple_openid_connect.data.JwtAccessToken.parse_jwt(
+                        token, client.provider_keys
+                    )
+                    access_token.validate_extern(
+                        issuer=client.provider_config.issuer,
+                        client_id=client.client_auth.client_id,
+                    )
+                    user_info = access_token
+
                 user_info_remember = {}
                 request.get_remember_from_user_info(user_info.dict(), user_info_remember)
             elif username is None:

--- a/geoportal/c2cgeoportal_geoportal/__init__.py
+++ b/geoportal/c2cgeoportal_geoportal/__init__.py
@@ -372,6 +372,14 @@ def create_get_user_from_request(
         """
         Return the User object for the request.
 
+        Resolution order:
+        1. ``Authorization: Bearer`` header (OIDC JWT access token) — used by
+           QGIS Desktop and other clients. Either query the userinfo endpoint
+           or parse the JWT locally, depending on ``query_user_info``.
+        2. ``unauthenticated_userid`` (auth cookie or header) — may contain a JSON
+           blob with OIDC remember info (including ``access_token_expires``).
+        3. Fallback to ``None`` (anonymous).
+
         Return ``None`` if:
         * user is anonymous
         * it does not exist in the database
@@ -398,6 +406,8 @@ def create_get_user_from_request(
             user_info_remember: dict[str, Any] | None = None
             openid_connect_configuration = settings.get("authentication", {}).get("openid_connect", {})
             openid_connect_enabled = openid_connect_configuration.get("enabled", False)
+
+            # Bearer token (OIDC JWT access token)
             if (
                 openid_connect_enabled
                 and "Authorization" in request.headers
@@ -406,8 +416,10 @@ def create_get_user_from_request(
                 token = request.headers["Authorization"][7:]
                 client = oidc.get_oidc_client(request, request.host)
 
+                # Fetch userinfo from the provider (HTTP call)
                 if openid_connect_configuration.get("query_user_info", False):
                     user_info = client.fetch_userinfo(token)
+                # Parse and validate the JWT locally (no HTTP call)
                 else:
                     access_token = simple_openid_connect.data.JwtAccessToken.parse_jwt(
                         token, client.provider_keys
@@ -420,9 +432,13 @@ def create_get_user_from_request(
 
                 user_info_remember = {}
                 request.get_remember_from_user_info(user_info.dict(), user_info_remember)
+            # Auth cookie / header (unauthenticated_userid)
             elif username is None:
                 username = request.unauthenticated_userid
+
+            # Resolve the user from user_info_remember or username
             if username is not None or user_info_remember is not None:
+                # Username came from cookie — try to decode as JSON (OIDC remember blob)
                 if user_info_remember is None:
                     assert username is not None
                     try:
@@ -431,6 +447,8 @@ def create_get_user_from_request(
                         user_info_remember = None
                         _LOG.info("Failed to decode username %s as JSON", username)
                 if isinstance(user_info_remember, dict) and openid_connect_enabled:
+                    # user_info_remember from an OIDC cookie (contains access_token_expires)
+                    # → check expiry, possibly refresh the token
                     if "access_token_expires" in user_info_remember:
                         del username
                         access_token_expires = dateutil.parser.isoparse(
@@ -472,6 +490,7 @@ def create_get_user_from_request(
                                 request.host,
                             )
                     request.user_ = request.get_user_from_remember(user_info_remember)
+                # Non-OIDC user (DB lookup by username)
                 else:
                     # We know we will need the role object of the
                     # user so we use joined loading

--- a/geoportal/tests/functional/test_init.py
+++ b/geoportal/tests/functional/test_init.py
@@ -27,10 +27,15 @@
 
 # pylint: disable=missing-docstring,attribute-defined-outside-init,protected-access,no-value-for-parameter
 
+import base64
+import time
 import types
-from unittest.mock import PropertyMock, patch
+from unittest.mock import Mock, PropertyMock, patch
+from uuid import uuid4
 
+import jwt
 import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
 
 from c2cgeoportal_geoportal import create_get_user_from_request
 from c2cgeoportal_geoportal.lib import oidc
@@ -65,4 +70,134 @@ class TestGetUser:
 
             assert user is not None
             assert user.username == "12345"
+            assert user.deactivated is False
+
+    @pytest.mark.usefixtures("dbsession", "transact")
+    def test_get_user_oidc_bearer_token_query_user_info_false(self, dbsession) -> None:
+        from c2cgeoportal_commons.models.static import User
+
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+        now = int(time.time())
+        token_payload = {
+            "iss": "https://sso.example.com",
+            "sub": "jwt_test_user",
+            "aud": "test_client_id",
+            "exp": now + 3600,
+            "iat": now,
+            "jti": str(uuid4()),
+            "client_id": "test_client_id",
+            "email": "jwt_test_user@example.com",
+            "name": "JWT Test User",
+        }
+        token = jwt.encode(token_payload, private_key, algorithm="RS256")
+
+        public_numbers = private_key.public_key().public_numbers()
+        n = (
+            base64.urlsafe_b64encode(
+                public_numbers.n.to_bytes(256, byteorder="big"),
+            )
+            .decode()
+            .rstrip("=")
+        )
+        from cryptojwt.jwk.jwk import key_from_jwk_dict
+
+        jwk_obj = key_from_jwk_dict(
+            {
+                "use": "sig",
+                "kty": "RSA",
+                "e": "AQAB",
+                "n": n,
+            }
+        )
+
+        settings = {
+            "authentication": {
+                "openid_connect": {
+                    "enabled": True,
+                    "url": "https://sso.example.com",
+                    "client_id": "test_client_id",
+                },
+            },
+            "authorized_referers": ["example.com"],
+        }
+
+        request = create_dummy_request(settings)
+        request.referrer = "https://example.com"
+        request.host = "example.com"
+        request.headers["Authorization"] = f"Bearer {token}"
+
+        request.get_remember_from_user_info = types.MethodType(oidc.get_remember_from_user_info, request)
+        request.get_user_from_remember = types.MethodType(oidc.get_user_from_remember, request)
+
+        test_user = User(username="jwt_test_user", password="jwt_test_user")
+        dbsession.add(test_user)
+        dbsession.flush()
+
+        with patch("c2cgeoportal_geoportal.lib.oidc.get_oidc_client") as mock_get_client:
+            mock_client = Mock()
+            mock_client.provider_keys = [jwk_obj]
+            mock_client.provider_config = Mock()
+            mock_client.provider_config.issuer = "https://sso.example.com"
+            mock_client.client_auth = Mock()
+            mock_client.client_auth.client_id = "test_client_id"
+            mock_get_client.return_value = mock_client
+
+            get_user = create_get_user_from_request(settings)
+            user = get_user(request)
+
+            assert user is not None
+            assert user.username == "jwt_test_user"
+            assert user.deactivated is False
+
+    @pytest.mark.usefixtures("dbsession", "transact")
+    def test_get_user_oidc_bearer_token_query_user_info_true(self, dbsession) -> None:
+        from c2cgeoportal_commons.models.static import User
+
+        settings = {
+            "authentication": {
+                "openid_connect": {
+                    "enabled": True,
+                    "query_user_info": True,
+                    "url": "https://sso.example.com",
+                    "client_id": "test_client_id",
+                },
+            },
+            "authorized_referers": ["example.com"],
+        }
+
+        request = create_dummy_request(settings)
+        request.referrer = "https://example.com"
+        request.host = "example.com"
+        request.headers["Authorization"] = "Bearer dummy_token"
+
+        request.get_remember_from_user_info = types.MethodType(oidc.get_remember_from_user_info, request)
+        request.get_user_from_remember = types.MethodType(oidc.get_user_from_remember, request)
+
+        test_user = User(username="fetch_test_user", password="fetch_test_user")
+        dbsession.add(test_user)
+        dbsession.flush()
+
+        with patch("c2cgeoportal_geoportal.lib.oidc.get_oidc_client") as mock_get_client:
+            mock_client = Mock()
+
+            def fetch_userinfo(_token):
+                class UserInfo:
+                    def dict(self):
+                        return {
+                            "sub": "fetch_test_user",
+                            "email": "fetch_test_user@example.com",
+                            "name": "Fetch Test User",
+                        }
+
+                return UserInfo()
+
+            mock_client.fetch_userinfo = fetch_userinfo
+            mock_get_client.return_value = mock_client
+
+            get_user = create_get_user_from_request(settings)
+            user = get_user(request)
+
+            assert user is not None
+            assert user.username == "fetch_test_user"
             assert user.deactivated is False


### PR DESCRIPTION
## Summary

Respect the `query_user_info` configuration option in the Bearer token authorization path used for WMS/WFS/OGC API requests.

## Context

The `query_user_info` option (default: `False`) controls whether user information is fetched from the OIDC provider's UserInfo endpoint or extracted locally from the token. This option was already respected in the login callback path (`oidc.py:309`), but the Bearer token path in `__init__.py` always called `client.fetch_userinfo()`, making an HTTP request to the UserInfo endpoint on every WMS/WFS request.

This change makes the Bearer token path consistent with the login callback, avoiding unnecessary HTTP requests when the access token is a JWT containing the required user claims.

## Implementation Details

In `create_get_user_from_request()` (`__init__.py:408-420`):
- `query_user_info: True`: calls `client.fetch_userinfo(token)` (same as before)
- `query_user_info: False`: decodes the access token JWT locally via `JwtAccessToken.parse_jwt()` with signature validation, issuer/audience/expiry checks — no HTTP call

The `JwtAccessToken` model from `simple-openid-connect` v2.4.0 supports RFC 9068 JWT access tokens with `extra="allow"` to capture additional claims like `name`, `email`, `preferred_username`.

## Impact/Risks

- Backward compatible: existing behavior unchanged when `query_user_info: True`
- Requires the access token to be a JWT (RFC 9068) when `query_user_info: False`; most modern providers (Keycloak, Azure AD, Auth0) support this
- If the access token is opaque, `query_user_info` should remain `True`

<!-- pull request links -->
See JIRA issue: [GSBASSUP-206](https://camptocamp.atlassian.net/browse/GSBASSUP-206).

[GSBASSUP-206]: https://camptocamp.atlassian.net/browse/GSBASSUP-206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ