### PR TITLE
Fix on clone schema method.

### DIFF
--- a/scripts/clone_schema.sql
+++ b/scripts/clone_schema.sql
@@ -79,9 +79,9 @@ BEGIN
 
     IF seq.cycle_option = 'YES'
     THEN
-      sq_cycled := 'CYCLE';
+      sq_cycled := ' CYCLE';
     ELSE
-      sq_cycled := 'NO CYCLE';
+      sq_cycled := ' NO CYCLE';
     END IF;
 
     EXECUTE 'ALTER SEQUENCE ' || quote_ident(dest_schema) || '.' || quote_ident(seq.sequence_name)


### PR DESCRIPTION
I had this error when trying to clone schemas:
```
ERROR:  trailing junk after numeric literal at or near "1NO"
LINE 1: ...NVALUE 1 MAXVALUE 2147483647 START WITH 1 RESTART 1NO CYCLE;
                                                             ^
QUERY:  ALTER SEQUENCE main_int_2_9.wmts_dimension_id_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 RESTART 1NO CYCLE;
CONTEXT:  PL/pgSQL function clone_schema(text,text,boolean) line 82 at EXECUTE
more_grouper=> SELECT clone_schema('main_int_2_7', 'main_int_2_9', TRUE);
ERROR:  trailing junk after numeric literal at or near "1NO"
LINE 1: ...NVALUE 1 MAXVALUE 2147483647 START WITH 1 RESTART 1NO CYCLE;
                                                             ^
QUERY:  ALTER SEQUENCE main_int_2_9.wmts_dimension_id_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 RESTART 1NO CYCLE;
CONTEXT:  PL/pgSQL function clone_schema(text,text,boolean) line 82 at EXECUTE
```
This fix helped.
