### PR TITLE
Pin Node.js to version 20 in ngeo-2.9 workflow

### DIFF
--- a/.github/workflows/ngeo-2-9.yaml
+++ b/.github/workflows/ngeo-2-9.yaml
@@ -49,6 +49,9 @@ jobs:
 
       - run: c2cciutils-download-applications --applications-file=ci/applications.yaml --versions-file=ci/applications-versions.yaml
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
       - run: cd geoportal && npm update
       - id: version
         run: scripts/get-version --auto-increment --github


### PR DESCRIPTION
## Summary

Pin Node.js to v20 in the ngeo-2.9 CI workflow so `npm update` can use pre-built binaries for `canvas@2.11.2`.

## Context

The `ngeo_2.9_updated` CI run (#253) fails because `canvas@2.11.2` (a transitive dependency via `ngeo` → `qruri`) has no pre-built binary for Node.js v22 (ABI `node-v127`) on `ubuntu-24.04` runners. The fallback to native compilation fails because `pixman-1` and other system libraries are missing.

## Implementation Details

Added `actions/setup-node@v4` with `node-version: '20'` before the `cd geoportal && npm update` step. `canvas@2.11.2` ships pre-built binaries for ABI `node-v115` (Node.js 20) which are used directly without compilation.

## Impact/Risks

Only the `npm update` step is affected. All subsequent steps run in Docker containers and are not impacted by the host Node.js version.