### PR TITLE
Make the raster cache thread safe

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/views/raster.py
+++ b/geoportal/c2cgeoportal_geoportal/views/raster.py
@@ -31,6 +31,7 @@ import json
 import logging
 import math
 import os
+import threading
 import traceback
 import urllib.parse
 from json.decoder import JSONDecodeError
@@ -56,7 +57,8 @@ _LOG = logging.getLogger(__name__)
 class Raster:
     """All the view concerned the raster (point, not the profile profile)."""
 
-    data: dict[str, "fiona.collection.Collection"] = {}
+    data: dict[str, "fiona.collection.Collection | DatasetReader"] = {}
+    _data_lock = threading.RLock()
 
     def __init__(self, request: pyramid.request.Request):
         self.request = request
@@ -65,9 +67,10 @@ class Raster:
         @zope.event.classhandler.handler(InvalidateCacheEvent)  # type: ignore
         def handle(event: InvalidateCacheEvent) -> None:
             del event
-            for _, v in Raster.data.items():
-                v.close()
-            Raster.data = {}
+            with Raster._data_lock:
+                for _, v in Raster.data.items():
+                    v.close()
+                Raster.data = {}
 
     def _get_required_finite_float_param(self, name: str) -> float:
         if name not in self.request.params:
@@ -118,29 +121,31 @@ class Raster:
         set_common_headers(self.request, "raster", Cache.PUBLIC_NO)
         return result
 
-    def _get_data(self, layer: dict[str, Any], name: str) -> "fiona.collection.Collection":
-        if name not in self.data:
-            path = layer["file"]
-            if layer.get("type", "shp_index") == "shp_index":
-                # Avoid loading if not needed
-                from fiona.collection import Collection  # pylint: disable=import-outside-toplevel
+    def _get_data(self, layer: dict[str, Any], name: str) -> "fiona.collection.Collection | DatasetReader":
+        with self._data_lock:
+            if name not in self.data:
+                path = layer["file"]
+                if layer.get("type", "shp_index") == "shp_index":
+                    # Avoid loading if not needed
+                    from fiona.collection import Collection  # pylint: disable=import-outside-toplevel
 
-                self.data[name] = Collection(path)
-            elif layer.get("type") == "gdal":
-                # Avoid loading if not needed
-                import rasterio  # pylint: disable=import-outside-toplevel
+                    self.data[name] = Collection(path)
+                elif layer.get("type") == "gdal":
+                    # Avoid loading if not needed
+                    import rasterio  # pylint: disable=import-outside-toplevel
 
-                self.data[name] = rasterio.open(path)
+                    self.data[name] = rasterio.open(path)
 
-        return self.data[name]
+            return self.data[name]
 
     def _get_raster_value(
         self, layer: dict[str, Any], name: str, lon: float, lat: float
     ) -> decimal.Decimal | None:
-        data = self._get_data(layer, name)
         type_ = layer.get("type", "shp_index")
         if type_ == "shp_index":
-            tiles = list(data.filter(mask={"type": "Point", "coordinates": [lon, lat]}))
+            with self._data_lock:
+                data = self._get_data(layer, name)
+                tiles = list(data.filter(mask={"type": "Point", "coordinates": [lon, lat]}))
 
             if not tiles:
                 return None
@@ -153,7 +158,9 @@ class Raster:
             with rasterio.open(path) as dataset:
                 result = self._get_value(layer, name, dataset, lon, lat)
         elif type_ == "gdal":
-            result = self._get_value(layer, name, data, lon, lat)
+            with self._data_lock:
+                data = self._get_data(layer, name)
+                result = self._get_value(layer, name, data, lon, lat)
         else:
             raise ValueError("Unsupported type " + type_)
 


### PR DESCRIPTION
## Summary

Protect the raster cache with a threading lock to prevent GDAL heap corruption when multiple threads access cached datasets concurrently.

## Context

The gunicorn configuration uses the  worker class with 10 threads per worker. The  class had a shared class-level cache ( dict) storing GDAL datasets (Fiona  and rasterio ) without any synchronization. GDAL is not thread-safe, so concurrent access from multiple threads could corrupt the heap, leading to .

Related issue: GSGEOC-452

## Implementation Details

- Replaced unprotected  dict with  +  (threading.RLock)
- Protected all cache read/write operations with the lock
- Protected GDAL read operations (Fiona  and rasterio ) on cached datasets with the lock
- Added  check in the invalidation handler to properly close both Fiona and rasterio datasets (previously only Fiona was closed)
- Converted  from  to instance method for consistency

## Testing

- All 6 existing raster tests pass

<!-- pull request links -->
See JIRA issue: [GSGEOC-452](https://camptocamp.atlassian.net/browse/GSGEOC-452).

[GSGEOC-452]: https://camptocamp.atlassian.net/browse/GSGEOC-452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ