### PR TITLE
Fix OIDC refresh for providers without refresh_expires_in

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/__init__.py
+++ b/geoportal/c2cgeoportal_geoportal/__init__.py
@@ -462,29 +462,32 @@ def create_get_user_from_request(
                             )
                             access_token_expires = access_token_expires.replace(tzinfo=datetime.UTC)
                         if access_token_expires < datetime.datetime.now(tz=datetime.UTC):
-                            if user_info_remember["refresh_token_expires"] is None:
-                                return None
                             refresh_token = request.cookies.get("refresh_token")
                             if refresh_token is None:
                                 return None
-                            refresh_token_expires = dateutil.parser.isoparse(
-                                user_info_remember["refresh_token_expires"],
-                            )
-                            # If refresh_token_expires is not offset-aware make it offset-aware
-                            if refresh_token_expires.tzinfo is None:
-                                _LOG.warning(
-                                    "refresh_token_expires is not offset-aware, "
-                                    "make it offset-aware by replacing tzinfo with UTC",
+                            if user_info_remember["refresh_token_expires"] is not None:
+                                refresh_token_expires = dateutil.parser.isoparse(
+                                    user_info_remember["refresh_token_expires"],
                                 )
-                                refresh_token_expires = refresh_token_expires.replace(
-                                    tzinfo=datetime.UTC,
-                                )
-                            if refresh_token_expires < datetime.datetime.now(tz=datetime.UTC):
-                                return None
+                                if refresh_token_expires.tzinfo is None:
+                                    _LOG.warning(
+                                        "refresh_token_expires is not offset-aware, "
+                                        "make it offset-aware by replacing tzinfo with UTC",
+                                    )
+                                    refresh_token_expires = refresh_token_expires.replace(
+                                        tzinfo=datetime.UTC,
+                                    )
+                                if refresh_token_expires < datetime.datetime.now(tz=datetime.UTC):
+                                    return None
                             token_response = oidc.get_oidc_client(
                                 request,
                                 request.host,
                             ).exchange_refresh_token(refresh_token)
+                            if isinstance(
+                                token_response,
+                                simple_openid_connect.data.TokenErrorResponse,
+                            ):
+                                return None
                             user_info_remember = oidc.OidcRemember(request).remember(
                                 token_response,
                                 request.host,

--- a/geoportal/c2cgeoportal_geoportal/lib/oidc.py
+++ b/geoportal/c2cgeoportal_geoportal/lib/oidc.py
@@ -276,7 +276,7 @@ class OidcRemember:
             samesite="Lax",
             domain=self.request.domain,
         )
-        if token_response.refresh_expires_in is not None:
+        if token_response.refresh_token is not None:
             self.request.response.set_cookie(
                 "refresh_token",
                 token_response.refresh_token,

--- a/geoportal/tests/functional/test_init.py
+++ b/geoportal/tests/functional/test_init.py
@@ -28,6 +28,8 @@
 # pylint: disable=missing-docstring,attribute-defined-outside-init,protected-access,no-value-for-parameter
 
 import base64
+import datetime
+import json
 import time
 import types
 from unittest.mock import Mock, PropertyMock, patch
@@ -35,6 +37,7 @@ from uuid import uuid4
 
 import jwt
 import pytest
+import simple_openid_connect.data
 from cryptography.hazmat.primitives.asymmetric import rsa
 
 from c2cgeoportal_geoportal import create_get_user_from_request
@@ -201,3 +204,132 @@ class TestGetUser:
             assert user is not None
             assert user.username == "fetch_test_user"
             assert user.deactivated is False
+
+    @pytest.mark.usefixtures("dbsession", "transact")
+    def test_get_user_oidc_refresh_when_no_refresh_expires(self, dbsession) -> None:
+        from c2cgeoportal_commons.models.static import User
+
+        settings = {
+            "authentication": {
+                "openid_connect": {
+                    "enabled": True,
+                    "url": "https://sso.example.com",
+                    "client_id": "test_client_id",
+                },
+            },
+            "authorized_referers": ["example.com"],
+        }
+
+        request = create_dummy_request(settings, cookies={"refresh_token": "refresh_123"})
+        request.referrer = "https://example.com"
+        request.host = "example.com"
+
+        request.get_remember_from_user_info = types.MethodType(oidc.get_remember_from_user_info, request)
+        request.get_user_from_remember = types.MethodType(oidc.get_user_from_remember, request)
+
+        test_user = User(username="refresh_test_user", password="refresh_test_user")
+        dbsession.add(test_user)
+        dbsession.flush()
+
+        now = datetime.datetime.now(tz=datetime.UTC)
+        remember_object = json.dumps(
+            {
+                "access_token_expires": (now - datetime.timedelta(hours=1)).isoformat(),
+                "refresh_token_expires": None,
+                "username": "refresh_test_user",
+                "display_name": None,
+                "email": None,
+                "settings_role": None,
+                "roles": [],
+            }
+        )
+        refreshed_object = {
+            "access_token_expires": (now + datetime.timedelta(hours=1)).isoformat(),
+            "refresh_token_expires": None,
+            "username": "refresh_test_user",
+            "display_name": "Refresh Test User",
+            "email": "refresh_test_user@example.com",
+            "settings_role": None,
+            "roles": [],
+        }
+
+        with (
+            patch.object(type(request), "unauthenticated_userid", new_callable=PropertyMock) as mock_userid,
+            patch("c2cgeoportal_geoportal.lib.oidc.get_oidc_client") as mock_get_client,
+            patch("c2cgeoportal_geoportal.lib.oidc.OidcRemember.remember") as mock_remember,
+        ):
+            mock_userid.return_value = remember_object
+            mock_remember.return_value = refreshed_object
+
+            mock_client = Mock()
+            mock_client.exchange_refresh_token = Mock(
+                return_value=simple_openid_connect.data.TokenSuccessResponse(
+                    access_token="new_access",
+                    expires_in=3600,
+                    refresh_token="new_refresh",
+                    token_type="Bearer",
+                    id_token="",
+                ),
+            )
+            mock_get_client.return_value = mock_client
+
+            get_user = create_get_user_from_request(settings)
+            user = get_user(request)
+
+            mock_client.exchange_refresh_token.assert_called_once_with("refresh_123")
+            assert user is not None
+            assert user.username == "refresh_test_user"
+
+    @pytest.mark.usefixtures("dbsession", "transact")
+    def test_get_user_oidc_refresh_token_expired(self, dbsession) -> None:
+        settings = {
+            "authentication": {
+                "openid_connect": {
+                    "enabled": True,
+                    "url": "https://sso.example.com",
+                    "client_id": "test_client_id",
+                },
+            },
+            "authorized_referers": ["example.com"],
+        }
+
+        request = create_dummy_request(settings, cookies={"refresh_token": "refresh_123"})
+        request.referrer = "https://example.com"
+        request.host = "example.com"
+
+        request.get_remember_from_user_info = types.MethodType(oidc.get_remember_from_user_info, request)
+        request.get_user_from_remember = types.MethodType(oidc.get_user_from_remember, request)
+
+        now = datetime.datetime.now(tz=datetime.UTC)
+        remember_object = json.dumps(
+            {
+                "access_token_expires": (now - datetime.timedelta(hours=1)).isoformat(),
+                "refresh_token_expires": None,
+                "username": "expired_test_user",
+                "display_name": None,
+                "email": None,
+                "settings_role": None,
+                "roles": [],
+            }
+        )
+
+        with (
+            patch.object(type(request), "unauthenticated_userid", new_callable=PropertyMock) as mock_userid,
+            patch("c2cgeoportal_geoportal.lib.oidc.get_oidc_client") as mock_get_client,
+        ):
+            mock_userid.return_value = remember_object
+
+            mock_client = Mock()
+            mock_client.exchange_refresh_token = Mock(
+                return_value=simple_openid_connect.data.TokenErrorResponse(
+                    error="invalid_grant",
+                    error_description="The refresh token is expired",
+                ),
+            )
+            mock_get_client.return_value = mock_client
+
+            get_user = create_get_user_from_request(settings)
+            user = get_user(request)
+
+            mock_client.exchange_refresh_token.assert_called_once_with("refresh_123")
+            assert user is None

--- a/geoportal/tests/functional/test_oidc.py
+++ b/geoportal/tests/functional/test_oidc.py
@@ -167,3 +167,60 @@ class TestLogin(TestCase):
         assert set_cookies["code_challenge"].startswith("; Max-Age=0; Path=/; expires="), set_cookies[
             "code_challenge"
         ]
+
+    @responses.activate
+    def test_callback_refresh_token_set(self) -> None:
+        from c2cgeoportal_geoportal.views.login import Login
+
+        request = create_dummy_request(
+            {
+                "authentication": {
+                    "openid_connect": {
+                        "enabled": True,
+                        "provide_roles": True,
+                        "url": "https://sso.example.com",
+                        "client_id": "client_id_123",
+                    },
+                },
+            },
+            params={"code": "code_123"},
+            cookies={
+                "came_from": "/came_from",
+                "code_verifier": "code_verifier",
+                "code_challenge": "code_challenge",
+            },
+        )
+        includeme(request)
+        responses.get("https://sso.example.com/.well-known/openid-configuration", json=_OIDC_CONFIGURATION)
+        responses.get("https://sso.example.com/jwks", json=_OIDC_KEYS)
+        responses.post(
+            "https://sso.example.com/token",
+            json={
+                "access_token": "access",
+                "expires_in": 3600,
+                "refresh_token": "refresh_123",
+                "token_type": "Bearer",
+                "id_token": jwt.encode(
+                    {
+                        "sub": "1234",
+                        "name": "Test User",
+                        "email": "user@example.com",
+                        "iss": "https://sso.example.com",
+                        "aud": "client_id_123",
+                        "exp": 2000000000,
+                        "iat": 1000000000,
+                    },
+                    _PRIVATE_KEY,
+                    algorithm="RS256",
+                ),
+            },
+        )
+        response = Login(request).oidc_callback()
+        assert response.status_int == 302
+        assert response.headers["Location"] == "/came_from"
+
+        set_cookies = dict([v.split("=", 1) for v in response.headers.getall("Set-Cookie")])
+        assert "refresh_token" in set_cookies, "refresh_token cookie should be set"
+        assert set_cookies["refresh_token"].startswith("refresh_123;"), (
+            "refresh_token cookie should contain the refresh token value"
+        )


### PR DESCRIPTION
## Summary

Fix the OIDC refresh flow for providers that do not send the Keycloak-specific `refresh_expires_in` field in the token response (e.g. Duende IdentityServer).

## Context

- `refresh_expires_in` is not a standard OIDC field — it is a Keycloak extension. Other providers like Duende IdentityServer do not include it.
- The code was gating the refresh entirely on this field: the `refresh_token` cookie was never set when `refresh_expires_in` was missing, and the refresh logic returned `None` immediately when `refresh_token_expires` was `None`, without attempting to use the refresh token.
- This made sessions expire after the access token lifetime for non-Keycloak providers, since the refresh cycle could never start.
- Related issue: GSSIT-131

## Implementation Details

Three changes:

1. **`oidc.py` — `OidcRemember.remember()`**: Changed the condition to set the `refresh_token` cookie from `if token_response.refresh_expires_in is not None` to `if token_response.refresh_token is not None`. When `refresh_expires_in` is not available, the cookie is set as a session cookie (no `max_age`), which is the safest default since we don't know the provider-side expiry.

2. **`__init__.py` — `get_user_from_request()`**: Inverted the refresh expiry logic. Previously: if `refresh_token_expires` is `None` → `return None` (abort). Now: if `refresh_token_expires` is `None` → skip the expiry check and attempt the refresh. The expiry check only applies when the date is known. Additionally, if `exchange_refresh_token` returns a `TokenErrorResponse` (refresh token expired/invalid), we return `None` (anonymous) instead of letting `HTTPUnauthorized` propagate, which would give the user a 401 instead of a clean redirect to login.

3. **Error handling**: The `isinstance(token_response, TokenErrorResponse)` check before calling `remember()` ensures that a failed refresh produces a clean `None` return (anonymous session) rather than an exception.

## Testing & Validation

- Three new tests added:
  - `test_callback_refresh_token_set`: verifies the `refresh_token` cookie is set when the token response includes a refresh token but no `refresh_expires_in`.
  - `test_get_user_oidc_refresh_when_no_refresh_expires`: verifies that `exchange_refresh_token` is called when `refresh_token_expires` is `None` and the refresh succeeds.
  - `test_get_user_oidc_refresh_token_expired`: verifies that the user is `None` (anonymous) when the refresh token exchange fails.
- Compilation, ruff lint/format, and mypy pass.
- Functional tests (pre-existing + new) require a PostGIS-enabled database and could not be run locally, but all 8 tests are collected correctly.

## Impact/Risks

- No backward compatibility impact: the fix only adds behavior for the case where `refresh_expires_in` is missing (which was already broken). The Keycloak path (where `refresh_expires_in` is present) is unchanged.
- The session cookie approach for `refresh_token` when the expiry is unknown means the browser keeps the refresh token until the user closes the browser. This is reasonable and matches the previous behavior of keeping the session alive as long as the user is active.
- If the refresh token expires server-side while the session cookie is still alive, the next refresh attempt will fail cleanly (anonymous).

<!-- pull request links -->
See JIRA issue: [GSSIT-131](https://camptocamp.atlassian.net/browse/GSSIT-131).

[GSSIT-131]: https://camptocamp.atlassian.net/browse/GSSIT-131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ