### PR TITLE
Pin pylint in the pre-commit prospector hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -159,6 +159,7 @@ repos:
         additional_dependencies:
           - prospector-profile-utils==1.27.0 # pypi
           - ruff==0.15.19 # pypi
+          - pylint[spelling]==4.0.6 # pypi
         exclude: |-
           (?x)(
             geoportal/c2cgeoportal_geoportal/scaffolds/[a-z_]+/\{\{cookiecutter.project\}\}/.*


### PR DESCRIPTION
Pylint is used by prospector, it should be pinned in the pre-commit hook.