### PR TITLE
Replace --die-on-tool-error by --direct-tool-stdout in prospector

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -132,7 +132,7 @@ repos:
         args:
           - --profile=utils:pre-commit
           - --profile=.prospector-pre-commit.yaml
-          - --die-on-tool-error
+          - --direct-tool-stdout
           - --output-format=pylint
           - --without-tool=mypy
         additional_dependencies:
@@ -152,7 +152,7 @@ repos:
           )
       - id: prospector
         args:
-          - --die-on-tool-error
+          - --direct-tool-stdout
           - --output-format=pylint
           - --profile=.prospector-test.yaml
           - --profile=utils:pre-commit

--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,9 @@ prospector: build-checks ## Run the prospector checker
 	@docker run --rm camptocamp/geomapfish-checks:$(DOCKER_TAG) pylint --version --rcfile=/dev/null
 	@docker run --rm camptocamp/geomapfish-checks:$(DOCKER_TAG) pyflakes --version
 	docker run --rm --volume=$(shell pwd):/opt/c2cgeoportal camptocamp/geomapfish-checks:$(DOCKER_TAG) \
-		prospector --without=mypy --output-format=pylint --die-on-tool-error --direct-tool-stdout
+		prospector --without=mypy --output-format=pylint --direct-tool-stdout
 	docker run --rm --volume=$(shell pwd):/opt/c2cgeoportal camptocamp/geomapfish-checks:$(DOCKER_TAG) \
-		prospector --tool=mypy --output-format=pylint --die-on-tool-error --direct-tool-stdout -I 'bin/.*' -I 'ci/.*' -I 'scripts/.*'
+		prospector --tool=mypy --output-format=pylint --direct-tool-stdout -I 'bin/.*' -I 'ci/.*' -I 'scripts/.*'
 
 .PHONY: poetry-dev
 poetry-dev:
@@ -48,11 +48,11 @@ poetry-dev:
 
 .PHONY: prospector-poetry-nomypy
 prospector-poetry-nomypy: poetry-dev
-	poetry run prospector --without=mypy --output-format=pylint --die-on-tool-error --direct-tool-stdout
+	poetry run prospector --without=mypy --output-format=pylint --direct-tool-stdout
 
 .PHONY: prospector-poetry-mypy
 prospector-poetry-mypy: poetry-dev
-	poetry run prospector --tool=mypy --output-format=pylint --die-on-tool-error --direct-tool-stdout -I 'bin/.*' -I 'ci/.*' -I 'scripts/.*'
+	poetry run prospector --tool=mypy --output-format=pylint --direct-tool-stdout -I 'bin/.*' -I 'ci/.*' -I 'scripts/.*'
 
 .PHONY: prospector-poetry
 prospector-poetry: prospector-poetry-nomypy prospector-poetry-mypy
@@ -116,9 +116,9 @@ build-qgisserver-tests:
 .PHONY: prospector-qgisserver
 prospector-qgisserver: build-qgisserver-tests
 	docker run --rm --volume=$(shell pwd)/docker/qgisserver:/src camptocamp/geomapfish-qgisserver-tests \
-		prospector --without=mypy --without=pylint --output-format=pylint --die-on-tool-error --direct-tool-stdout
+		prospector --without=mypy --without=pylint --output-format=pylint --direct-tool-stdout
 	docker run --rm --volume=$(shell pwd)/docker/qgisserver:/src camptocamp/geomapfish-qgisserver-tests \
-		prospector --tool=mypy --output-format=pylint --die-on-tool-error --direct-tool-stdout -I 'acceptance-tests/.*'
+		prospector --tool=mypy --output-format=pylint --direct-tool-stdout -I 'acceptance-tests/.*'
 
 .PHONY: build-test-db
 build-test-db:

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/Makefile
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/Makefile
@@ -32,7 +32,7 @@ prospector: ## Runs the Prospector checks
 	mkdir geoportal/.ruff_cache || true
 	chmod 777 geoportal/.ruff_cache || true
 	docker compose run --workdir=/app/geoportal --rm --volume=$(CURDIR)/geoportal:/app/geoportal tools \
-		prospector --output-format=pylint --die-on-tool-error
+		prospector --output-format=pylint --direct-tool-stdout
 
 .PHONY: eslint
 eslint: ## Runs the eslint checks


### PR DESCRIPTION
Prospector --die-on-tool-error is replaced by --direct-tool-stdout.