### PR TITLE
Filter unauthorized layers from /themes and secure /locale.pot with GitHub OIDC

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/lib/layers.py
+++ b/geoportal/c2cgeoportal_geoportal/lib/layers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2025, Camptocamp SA
+# Copyright (c) 2018-2026, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/geoportal/c2cgeoportal_geoportal/lib/layers.py
+++ b/geoportal/c2cgeoportal_geoportal/lib/layers.py
@@ -26,6 +26,7 @@
 # either expressed or implied, of the FreeBSD Project.
 
 
+import copy
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
@@ -143,3 +144,43 @@ def get_private_layers(ogc_server_ids: Iterable[int]) -> dict[int, "main.LayerWM
     results = q.all()
     DBSession.expunge_all()
     return {r.id: r for r in results}
+
+
+def get_unauthorized_layers(
+    request: Request,
+    ogc_server_id: int,
+    wms_children_map: dict[str, list[str]],
+) -> set[str]:
+    """
+    Get the set of OGC layer names that the current user is not authorized to access.
+
+    A layer is unauthorized if it is private (public=False) in c2cgeoportal AND the user does not have
+    access to it through their roles. When a parent group is unauthorized, all its descendant layers are
+    also considered unauthorized.
+
+    Layers that are not defined in c2cgeoportal at all are considered public (not unauthorized).
+    """
+    gmf_private_layers = copy.copy(get_private_layers([ogc_server_id]))
+    for id_ in list(get_protected_layers(request, [ogc_server_id]).keys()):
+        if id_ in gmf_private_layers:
+            del gmf_private_layers[id_]
+
+    unauthorized: set[str] = set()
+    for gmf_layer in list(gmf_private_layers.values()):
+        for ogc_layer in gmf_layer.layer.split(","):
+            unauthorized.add(ogc_layer)
+            _add_descendants(ogc_layer, wms_children_map, unauthorized)
+
+    return unauthorized
+
+
+def _add_descendants(
+    layer_name: str,
+    wms_children_map: dict[str, list[str]],
+    result: set[str],
+) -> None:
+    """Recursively add all descendants of a layer to the result set."""
+    for child in wms_children_map.get(layer_name, []):
+        if child not in result:
+            result.add(child)
+            _add_descendants(child, wms_children_map, result)

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/.github/workflows/update_l10n.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/.github/workflows/update_l10n.yaml
@@ -5,6 +5,11 @@ on:
   schedule:
     - cron: '0 3 * * *'
 
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
 jobs:
   l10n:
     runs-on: ubuntu-24.04
@@ -27,7 +32,16 @@ jobs:
           token: ${{'{{'}} secrets.GOPASS_CI_GITHUB_TOKEN {{'}}'}}
 
       - run: ./build --env
-      - run: PROJECT_PUBLIC_URL=${{'{{'}} matrix.base_url {{'}}'}} make -e update-po-from-url
+
+      - name: Get GitHub OIDC token
+        id: oidc
+        run: |
+          TOKEN=$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=geomapfish-l10n" | jq -r .value)
+          echo "::add-mask::$TOKEN"
+          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+
+      - run: PROJECT_PUBLIC_URL=${{'{{'}} matrix.base_url {{'}}'}} OIDC_TOKEN=${{'{{'}} steps.oidc.outputs.token {{'}}'}} make -e update-po-from-url
 
       - name: Init Git
         run: |

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/Makefile
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/Makefile
@@ -16,6 +16,7 @@ help: ## Display this help message
 .PHONY: update-po-from-url
 update-po-from-url: ## Update the po files from the URL provide by PROJECT_PUBLIC_URL
 	curl ${CURL_ARGS} --fail --retry 5 --retry-delay 1 \
+		$(if $(OIDC_TOKEN),--header "Authorization: Bearer $(OIDC_TOKEN)") \
 		$(PROJECT_PUBLIC_URL)locale.pot > geoportal/${PACKAGE}_geoportal/locale/${PACKAGE}_geoportal-client${SUFFIX}.pot
 	sed -i '/^"POT-Creation-Date: /d' geoportal/${PACKAGE}_geoportal/locale/${PACKAGE}_geoportal-client${SUFFIX}.pot
 	docker compose run --rm -T --env=SUFFIX=${SUFFIX} tools update-po-only `id --user` `id --group` $(LANGUAGES)

--- a/geoportal/c2cgeoportal_geoportal/views/i18n.py
+++ b/geoportal/c2cgeoportal_geoportal/views/i18n.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2025, Camptocamp SA
+# Copyright (c) 2019-2026, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/geoportal/c2cgeoportal_geoportal/views/i18n.py
+++ b/geoportal/c2cgeoportal_geoportal/views/i18n.py
@@ -28,9 +28,13 @@
 
 import glob
 import logging
+from typing import Any
 
+import jwt
 import pyramid.request
 import pyramid.response
+from c2cwsgiutils.auth import auth_view
+from jwt import PyJWKClient
 from lingva.extract import (  # strip_linenumbers,
     ExtractorOptions,
     POEntry,
@@ -42,7 +46,7 @@ from lingva.extract import (  # strip_linenumbers,
 )
 from lingva.extractors import get_extractor, register_extractors
 from lingva.extractors.babel import register_babel_plugins
-from pyramid.httpexceptions import HTTPFound, HTTPInternalServerError
+from pyramid.httpexceptions import HTTPForbidden, HTTPFound, HTTPInternalServerError
 from pyramid.view import view_config
 
 from c2cgeoportal_geoportal.lib.cacheversion import get_cache_version
@@ -50,6 +54,72 @@ from c2cgeoportal_geoportal.lib.common_headers import Cache, set_common_headers
 
 _LOG = logging.getLogger(__name__)
 _INITIALIZED = False
+
+_GITHUB_OIDC_ISSUER = "https://token.actions.githubusercontent.com"
+_GITHUB_OIDC_JWKS_URL = "https://token.actions.githubusercontent.com/.well-known/jwks.json"
+_OIDC_AUDIENCE = "geomapfish-l10n"
+_jwks_client: PyJWKClient | None = None
+
+
+def _get_jwks_client() -> PyJWKClient:
+    """Get or create the JWKS client for GitHub OIDC."""
+    global _jwks_client  # pylint: disable=global-statement
+    if _jwks_client is None:
+        _jwks_client = PyJWKClient(_GITHUB_OIDC_JWKS_URL, cache_keys=True)
+    return _jwks_client
+
+
+def _verify_github_oidc_token(token: str, allowed_repository: str | None) -> dict[str, Any]:
+    """
+    Validate a GitHub Actions OIDC token.
+
+    Returns the decoded payload if valid, raises HTTPForbidden otherwise.
+    """
+    try:
+        jwks_client = _get_jwks_client()
+        signing_key = jwks_client.get_signing_key_from_jwt(token)
+        payload = jwt.decode(
+            token,
+            signing_key.key,
+            algorithms=["RS256"],
+            audience=_OIDC_AUDIENCE,
+            issuer=_GITHUB_OIDC_ISSUER,
+            options={"verify_exp": True},
+        )
+    except jwt.ExpiredSignatureError:
+        raise HTTPForbidden("Token expired") from None
+    except jwt.InvalidAudienceError:
+        raise HTTPForbidden("Invalid token audience") from None
+    except jwt.InvalidIssuerError:
+        raise HTTPForbidden("Invalid token issuer") from None
+    except jwt.InvalidTokenError as exc:
+        raise HTTPForbidden(f"Invalid token: {exc}") from None
+
+    if allowed_repository is not None and payload.get("repository") != allowed_repository:
+        raise HTTPForbidden(
+            f"Unauthorized repository: {payload.get('repository')}, expected: {allowed_repository}"
+        )
+
+    return payload
+
+
+def _authenticate_localepot(request: pyramid.request.Request) -> None:
+    """
+    Authenticate the request for the /locale.pot endpoint.
+
+    Accepts either:
+    - A GitHub Actions OIDC token in the Authorization header (Bearer token)
+    - An admin authentication (via c2cwsgiutils.auth_view) as fallback
+    """
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.startswith("Bearer "):
+        token = auth_header[7:]
+        settings = request.registry.settings or {}
+        allowed_repository = settings.get("github_oidc_allowed_repository")
+        _verify_github_oidc_token(token, allowed_repository)
+        return
+
+    auth_view(request)
 
 
 @view_config(route_name="localejson")  # type: ignore[untyped-decorator]
@@ -68,6 +138,8 @@ def locale(request: pyramid.request.Request) -> pyramid.response.Response:
 @view_config(route_name="localepot")  # type: ignore[untyped-decorator]
 def localepot(request: pyramid.request.Request) -> pyramid.response.Response:
     """Get the pot from an HTTP request."""
+    _authenticate_localepot(request)
+
     # Build the list of files to be processed
     sources = []
     sources += glob.glob(f"/app/{request.registry.package_name}/static-ngeo/js/apps/*.html.ejs")

--- a/geoportal/c2cgeoportal_geoportal/views/theme.py
+++ b/geoportal/c2cgeoportal_geoportal/views/theme.py
@@ -65,9 +65,8 @@ from c2cgeoportal_geoportal.lib.caching import get_region
 from c2cgeoportal_geoportal.lib.common_headers import Cache, set_common_headers
 from c2cgeoportal_geoportal.lib.functionality import get_mapserver_substitution_params
 from c2cgeoportal_geoportal.lib.layers import (
-    get_private_layers,
-    get_protected_layers,
     get_protected_layers_query,
+    get_unauthorized_layers,
 )
 from c2cgeoportal_geoportal.lib.wmstparsing import TimeInformation, parse_extent
 from c2cgeoportal_geoportal.views.layers import get_layer_metadata
@@ -543,13 +542,16 @@ class Theme:
         layer_theme: dict[str, Any],
         layer_name: str,
         wms: dict[str, dict[str, Any]],
+        unauthorized_layers: set[str],
     ) -> None:
+        if layer_name in unauthorized_layers:
+            return
         wms_layer_obj = wms["layers"][layer_name]
         if not wms_layer_obj["children"]:
             layer_theme["childLayers"].append(wms["layers"][layer_name]["info"])
         else:
             for child_layer in wms_layer_obj["children"]:
-                self._fill_child_layer(layer_theme, child_layer, wms)
+                self._fill_child_layer(layer_theme, child_layer, wms, unauthorized_layers)
 
     async def _fill_wms(
         self,
@@ -567,11 +569,15 @@ class Theme:
         if layer.style:
             layer_theme["style"] = layer.style
 
-        # now look at what is in the WMS capabilities doc
+        wms_children_map: dict[str, list[str]] = {
+            name: layer_data["children"] for name, layer_data in wms["layers"].items()
+        }
+        unauthorized_layers = get_unauthorized_layers(self.request, layer.ogc_server.id, wms_children_map)
+
         layer_theme["childLayers"] = []
         for layer_name in layer.layer.split(","):
             if layer_name in wms["layers"]:
-                self._fill_child_layer(layer_theme, layer_name, wms)
+                self._fill_child_layer(layer_theme, layer_name, wms, unauthorized_layers)
             else:
                 errors.add(
                     f"The layer '{layer_name}' ({layer.name}) is not defined in WMS capabilities "
@@ -1283,25 +1289,25 @@ class Theme:
                         url_internal_wfs,
                         ogc_server,
                     )
-                    # Create a local copy (don't modify the cache)
                     if attributes is not None:
                         attributes = dict(attributes)
                     all_errors |= errors
 
-                    all_private_layers = get_private_layers([ogc_server.id]).values()
-                    protected_layers_name = [
-                        layer.name for layer in get_protected_layers(self.request, [ogc_server.id]).values()
-                    ]
-                    private_layers_name: list[str] = []
-                    for layers in [
-                        v.layer for v in all_private_layers if v.name not in protected_layers_name
-                    ]:
-                        private_layers_name.extend(layers.split(","))
+                    wms, wms_errors = await self._wms_getcap(ogc_server)
+                    all_errors |= wms_errors
+                    wms_children_map: dict[str, list[str]] = {}
+                    if wms is not None:
+                        wms_children_map = {
+                            name: layer_data["children"] for name, layer_data in wms["layers"].items()
+                        }
+
+                    unauthorized_layers = get_unauthorized_layers(
+                        self.request, ogc_server.id, wms_children_map
+                    )
 
                     if attributes is not None:
-                        for name in private_layers_name:
-                            if name in attributes:
-                                del attributes[name]
+                        for name in unauthorized_layers:
+                            attributes.pop(name, None)
 
                 result["ogcServers"][ogc_server.name] = {
                     "url": url.url() if url else None,

--- a/geoportal/tests/test_i18n_oidc.py
+++ b/geoportal/tests/test_i18n_oidc.py
@@ -49,7 +49,7 @@ def _create_test_token(
     expired=False,
 ):
     """Create a test JWT token."""
-    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    now = datetime.datetime.now(tz=datetime.UTC)
     payload = {
         "iss": issuer,
         "aud": audience,
@@ -103,8 +103,9 @@ class TestVerifyGithubOidcToken(TestCase):
     @patch("c2cgeoportal_geoportal.views.i18n._get_jwks_client")
     def test_wrong_repository(self, mock_get_client):
         """A token with wrong repository should be rejected."""
-        from c2cgeoportal_geoportal.views.i18n import _verify_github_oidc_token
         from pyramid.httpexceptions import HTTPForbidden
+
+        from c2cgeoportal_geoportal.views.i18n import _verify_github_oidc_token
 
         token = _create_test_token(self.private_key, repository="org/repo")
         mock_get_client.return_value = self._mock_jwks_client(self.public_key)
@@ -116,8 +117,9 @@ class TestVerifyGithubOidcToken(TestCase):
     @patch("c2cgeoportal_geoportal.views.i18n._get_jwks_client")
     def test_expired_token(self, mock_get_client):
         """An expired token should be rejected."""
-        from c2cgeoportal_geoportal.views.i18n import _verify_github_oidc_token
         from pyramid.httpexceptions import HTTPForbidden
+
+        from c2cgeoportal_geoportal.views.i18n import _verify_github_oidc_token
 
         token = _create_test_token(self.private_key, expired=True)
         mock_get_client.return_value = self._mock_jwks_client(self.public_key)
@@ -129,8 +131,9 @@ class TestVerifyGithubOidcToken(TestCase):
     @patch("c2cgeoportal_geoportal.views.i18n._get_jwks_client")
     def test_wrong_audience(self, mock_get_client):
         """A token with wrong audience should be rejected."""
-        from c2cgeoportal_geoportal.views.i18n import _verify_github_oidc_token
         from pyramid.httpexceptions import HTTPForbidden
+
+        from c2cgeoportal_geoportal.views.i18n import _verify_github_oidc_token
 
         token = _create_test_token(self.private_key, audience="wrong-audience")
         mock_get_client.return_value = self._mock_jwks_client(self.public_key)
@@ -142,12 +145,11 @@ class TestVerifyGithubOidcToken(TestCase):
     @patch("c2cgeoportal_geoportal.views.i18n._get_jwks_client")
     def test_wrong_issuer(self, mock_get_client):
         """A token with wrong issuer should be rejected."""
-        from c2cgeoportal_geoportal.views.i18n import _verify_github_oidc_token
         from pyramid.httpexceptions import HTTPForbidden
 
-        token = _create_test_token(
-            self.private_key, issuer="https://evil.example.com"
-        )
+        from c2cgeoportal_geoportal.views.i18n import _verify_github_oidc_token
+
+        token = _create_test_token(self.private_key, issuer="https://evil.example.com")
         mock_get_client.return_value = self._mock_jwks_client(self.public_key)
 
         with self.assertRaises(HTTPForbidden) as ctx:

--- a/geoportal/tests/test_i18n_oidc.py
+++ b/geoportal/tests/test_i18n_oidc.py
@@ -1,0 +1,209 @@
+# Copyright (c) 2026, Camptocamp SA
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# The views and conclusions contained in the software and documentation are those
+# of the authors and should not be interpreted as representing official policies,
+# either expressed or implied, of the FreeBSD Project.
+
+
+import datetime
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import jwt
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+def _generate_rsa_key_pair():
+    """Generate an RSA key pair for testing."""
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_key = private_key.public_key()
+    return private_key, public_key
+
+
+def _create_test_token(
+    private_key,
+    audience="geomapfish-l10n",
+    issuer="https://token.actions.githubusercontent.com",
+    repository="org/repo",
+    expired=False,
+):
+    """Create a test JWT token."""
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    payload = {
+        "iss": issuer,
+        "aud": audience,
+        "exp": now - datetime.timedelta(hours=1) if expired else now + datetime.timedelta(hours=1),
+        "iat": now,
+        "sub": f"repo:{repository}:ref:refs/heads/main",
+        "repository": repository,
+        "repository_owner": repository.split("/")[0],
+        "workflow": "update_l10n",
+        "job_workflow_ref": f"{repository}/.github/workflows/update_l10n.yaml@refs/heads/main",
+    }
+    return jwt.encode(payload, private_key, algorithm="RS256")
+
+
+class TestVerifyGithubOidcToken(TestCase):
+    """Tests for _verify_github_oidc_token."""
+
+    def setUp(self):
+        self.private_key, self.public_key = _generate_rsa_key_pair()
+
+    def _mock_jwks_client(self, signing_key):
+        """Create a mock JWKS client that returns the given signing key."""
+        mock_client = MagicMock()
+        mock_signing_key = MagicMock()
+        mock_signing_key.key = self.public_key
+        mock_client.get_signing_key_from_jwt.return_value = mock_signing_key
+        return mock_client
+
+    @patch("c2cgeoportal_geoportal.views.i18n._get_jwks_client")
+    def test_valid_token(self, mock_get_client):
+        """A valid token should be accepted."""
+        from c2cgeoportal_geoportal.views.i18n import _verify_github_oidc_token
+
+        token = _create_test_token(self.private_key)
+        mock_get_client.return_value = self._mock_jwks_client(self.public_key)
+
+        payload = _verify_github_oidc_token(token, None)
+        self.assertEqual(payload["repository"], "org/repo")
+
+    @patch("c2cgeoportal_geoportal.views.i18n._get_jwks_client")
+    def test_valid_token_with_repository_check(self, mock_get_client):
+        """A valid token with correct repository should be accepted."""
+        from c2cgeoportal_geoportal.views.i18n import _verify_github_oidc_token
+
+        token = _create_test_token(self.private_key, repository="org/repo")
+        mock_get_client.return_value = self._mock_jwks_client(self.public_key)
+
+        payload = _verify_github_oidc_token(token, "org/repo")
+        self.assertEqual(payload["repository"], "org/repo")
+
+    @patch("c2cgeoportal_geoportal.views.i18n._get_jwks_client")
+    def test_wrong_repository(self, mock_get_client):
+        """A token with wrong repository should be rejected."""
+        from c2cgeoportal_geoportal.views.i18n import _verify_github_oidc_token
+        from pyramid.httpexceptions import HTTPForbidden
+
+        token = _create_test_token(self.private_key, repository="org/repo")
+        mock_get_client.return_value = self._mock_jwks_client(self.public_key)
+
+        with self.assertRaises(HTTPForbidden) as ctx:
+            _verify_github_oidc_token(token, "other/repo")
+        self.assertIn("Unauthorized repository", str(ctx.exception.detail))
+
+    @patch("c2cgeoportal_geoportal.views.i18n._get_jwks_client")
+    def test_expired_token(self, mock_get_client):
+        """An expired token should be rejected."""
+        from c2cgeoportal_geoportal.views.i18n import _verify_github_oidc_token
+        from pyramid.httpexceptions import HTTPForbidden
+
+        token = _create_test_token(self.private_key, expired=True)
+        mock_get_client.return_value = self._mock_jwks_client(self.public_key)
+
+        with self.assertRaises(HTTPForbidden) as ctx:
+            _verify_github_oidc_token(token, None)
+        self.assertEqual("Token expired", str(ctx.exception.detail))
+
+    @patch("c2cgeoportal_geoportal.views.i18n._get_jwks_client")
+    def test_wrong_audience(self, mock_get_client):
+        """A token with wrong audience should be rejected."""
+        from c2cgeoportal_geoportal.views.i18n import _verify_github_oidc_token
+        from pyramid.httpexceptions import HTTPForbidden
+
+        token = _create_test_token(self.private_key, audience="wrong-audience")
+        mock_get_client.return_value = self._mock_jwks_client(self.public_key)
+
+        with self.assertRaises(HTTPForbidden) as ctx:
+            _verify_github_oidc_token(token, None)
+        self.assertEqual("Invalid token audience", str(ctx.exception.detail))
+
+    @patch("c2cgeoportal_geoportal.views.i18n._get_jwks_client")
+    def test_wrong_issuer(self, mock_get_client):
+        """A token with wrong issuer should be rejected."""
+        from c2cgeoportal_geoportal.views.i18n import _verify_github_oidc_token
+        from pyramid.httpexceptions import HTTPForbidden
+
+        token = _create_test_token(
+            self.private_key, issuer="https://evil.example.com"
+        )
+        mock_get_client.return_value = self._mock_jwks_client(self.public_key)
+
+        with self.assertRaises(HTTPForbidden) as ctx:
+            _verify_github_oidc_token(token, None)
+        self.assertEqual("Invalid token issuer", str(ctx.exception.detail))
+
+
+class TestAuthenticateLocalepot(TestCase):
+    """Tests for _authenticate_localepot."""
+
+    def test_bearer_token_with_valid_oidc(self):
+        """A valid Bearer token should be accepted."""
+        from c2cgeoportal_geoportal.views.i18n import _authenticate_localepot
+
+        request = MagicMock()
+        request.headers = {"Authorization": "Bearer fake-token"}
+        request.registry.settings = {}
+
+        with patch("c2cgeoportal_geoportal.views.i18n._verify_github_oidc_token") as mock_verify:
+            mock_verify.return_value = {"repository": "org/repo"}
+            _authenticate_localepot(request)
+            mock_verify.assert_called_once_with("fake-token", None)
+
+    def test_bearer_token_with_repository_setting(self):
+        """The allowed_repository setting should be passed to verification."""
+        from c2cgeoportal_geoportal.views.i18n import _authenticate_localepot
+
+        request = MagicMock()
+        request.headers = {"Authorization": "Bearer fake-token"}
+        request.registry.settings = {"github_oidc_allowed_repository": "my/repo"}
+
+        with patch("c2cgeoportal_geoportal.views.i18n._verify_github_oidc_token") as mock_verify:
+            mock_verify.return_value = {"repository": "my/repo"}
+            _authenticate_localepot(request)
+            mock_verify.assert_called_once_with("fake-token", "my/repo")
+
+    def test_no_bearer_token_falls_back_to_auth_view(self):
+        """Without a Bearer token, auth_view should be called."""
+        from c2cgeoportal_geoportal.views.i18n import _authenticate_localepot
+
+        request = MagicMock()
+        request.headers = {}
+        request.registry.settings = {}
+
+        with patch("c2cgeoportal_geoportal.views.i18n.auth_view") as mock_auth_view:
+            _authenticate_localepot(request)
+            mock_auth_view.assert_called_once_with(request)
+
+    def test_non_bearer_auth_header_falls_back_to_auth_view(self):
+        """A non-Bearer Authorization header should fall back to auth_view."""
+        from c2cgeoportal_geoportal.views.i18n import _authenticate_localepot
+
+        request = MagicMock()
+        request.headers = {"Authorization": "Basic dXNlcjpwYXNz"}
+        request.registry.settings = {}
+
+        with patch("c2cgeoportal_geoportal.views.i18n.auth_view") as mock_auth_view:
+            _authenticate_localepot(request)
+            mock_auth_view.assert_called_once_with(request)

--- a/geoportal/tests/test_unauthorized_layers.py
+++ b/geoportal/tests/test_unauthorized_layers.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2026, Camptocamp SA
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT OR LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# The views and conclusions contained in the software and documentation are those
+# of the authors and should not be interpreted as representing official policies,
+# either expressed or implied, of the FreeBSD Project.
+
+
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+
+class TestUnauthorizedLayers(TestCase):
+    """Tests for get_unauthorized_layers."""
+
+    @patch("c2cgeoportal_geoportal.lib.layers.get_protected_layers")
+    @patch("c2cgeoportal_geoportal.lib.layers.get_private_layers")
+    def test_no_private_layers(self, mock_private, mock_protected):
+        """When there are no private layers, nothing is unauthorized."""
+        from c2cgeoportal_geoportal.lib.layers import get_unauthorized_layers
+
+        mock_private.return_value = {}
+        mock_protected.return_value = {}
+        request = MagicMock()
+
+        result = get_unauthorized_layers(request, 1, {})
+        self.assertEqual(result, set())
+
+    @patch("c2cgeoportal_geoportal.lib.layers.get_protected_layers")
+    @patch("c2cgeoportal_geoportal.lib.layers.get_private_layers")
+    def test_private_layer_not_protected(self, mock_private, mock_protected):
+        """A private layer the user cannot access is unauthorized."""
+        from c2cgeoportal_geoportal.lib.layers import get_unauthorized_layers
+
+        layer = MagicMock()
+        layer.layer = "private_layer"
+        mock_private.return_value = {1: layer}
+        mock_protected.return_value = {}
+        request = MagicMock()
+
+        result = get_unauthorized_layers(request, 1, {})
+        self.assertEqual(result, {"private_layer"})
+
+    @patch("c2cgeoportal_geoportal.lib.layers.get_protected_layers")
+    @patch("c2cgeoportal_geoportal.lib.layers.get_private_layers")
+    def test_private_layer_protected(self, mock_private, mock_protected):
+        """A private layer the user can access is not unauthorized."""
+        from c2cgeoportal_geoportal.lib.layers import get_unauthorized_layers
+
+        layer = MagicMock()
+        layer.layer = "private_layer"
+        mock_private.return_value = {1: layer}
+        mock_protected.return_value = {1: layer}
+        request = MagicMock()
+
+        result = get_unauthorized_layers(request, 1, {})
+        self.assertEqual(result, set())
+
+    @patch("c2cgeoportal_geoportal.lib.layers.get_protected_layers")
+    @patch("c2cgeoportal_geoportal.lib.layers.get_private_layers")
+    def test_private_group_children_unauthorized(self, mock_private, mock_protected):
+        """When a group is unauthorized, all its children are also unauthorized."""
+        from c2cgeoportal_geoportal.lib.layers import get_unauthorized_layers
+
+        layer = MagicMock()
+        layer.layer = "private_group"
+        mock_private.return_value = {1: layer}
+        mock_protected.return_value = {}
+        request = MagicMock()
+
+        wms_children_map = {
+            "private_group": ["child1", "child2"],
+            "child1": ["grandchild1"],
+        }
+
+        result = get_unauthorized_layers(request, 1, wms_children_map)
+        self.assertEqual(result, {"private_group", "child1", "child2", "grandchild1"})
+
+    @patch("c2cgeoportal_geoportal.lib.layers.get_protected_layers")
+    @patch("c2cgeoportal_geoportal.lib.layers.get_private_layers")
+    def test_multiple_ogc_layers(self, mock_private, mock_protected):
+        """A LayerWMS can reference multiple OGC layers."""
+        from c2cgeoportal_geoportal.lib.layers import get_unauthorized_layers
+
+        layer = MagicMock()
+        layer.layer = "layer1,layer2"
+        mock_private.return_value = {1: layer}
+        mock_protected.return_value = {}
+        request = MagicMock()
+
+        result = get_unauthorized_layers(request, 1, {})
+        self.assertEqual(result, {"layer1", "layer2"})
+
+    @patch("c2cgeoportal_geoportal.lib.layers.get_protected_layers")
+    @patch("c2cgeoportal_geoportal.lib.layers.get_private_layers")
+    def test_layers_not_in_c2cgeoportal_are_public(self, mock_private, mock_protected):
+        """Layers not defined in c2cgeoportal are considered public (not unauthorized)."""
+        from c2cgeoportal_geoportal.lib.layers import get_unauthorized_layers
+
+        layer = MagicMock()
+        layer.layer = "defined_layer"
+        mock_private.return_value = {1: layer}
+        mock_protected.return_value = {}
+        request = MagicMock()
+
+        wms_children_map = {
+            "defined_layer": ["child_defined"],
+            "not_defined_group": ["child_not_defined"],
+        }
+
+        result = get_unauthorized_layers(request, 1, wms_children_map)
+        self.assertIn("defined_layer", result)
+        self.assertIn("child_defined", result)
+        self.assertNotIn("not_defined_group", result)
+        self.assertNotIn("child_not_defined", result)


### PR DESCRIPTION
## Summary

Fix data leak in `/themes` endpoint where backend-only resources were exposed to unauthorized users, and secure the `/locale.pot` endpoint with GitHub Actions OIDC token validation.

## Context

The `/themes` view was exposing information from WMS/WFS backends that a user should not have access to based on their roles:
- `ogcServers.*.attributes`: WFS feature types from the backend that are not defined in c2cgeoportal were included in the response.
- `childLayers` (WMS): children of WMS group layers were added recursively without filtering, exposing backend-only sub-layers.

Additionally, the `/locale.pot` HTTP endpoint was publicly accessible, allowing anyone to extract layer names and attributes without authentication.

## Implementation Details

### 1. `get_unauthorized_layers()` helper (`layers.py`)
New function that computes the set of OGC layer names the current user cannot access. It follows the same logic as `filter_capabilities.py`: private layers not accessible to the user, plus all descendants of unauthorized groups.

### 2. Filter `childLayers` WMS (`theme.py`)
`_fill_child_layer()` now recursively skips layers that are in the unauthorized set. A private group in c2cgeoportal makes all its WMS children unauthorized.

### 3. Filter `ogcServers.*.attributes` WFS (`theme.py`)
Replaced the previous partial blacklist with `get_unauthorized_layers()`. Layers defined in the backend but not in c2cgeoportal are now considered public (matching `filter_capabilities` behavior).

### 4. Secure `/locale.pot` with GitHub OIDC (`i18n.py`)
- Validate Bearer tokens against GitHub's JWKS endpoint
- Required audience: `geomapfish-l10n`
- Required issuer: `https://token.actions.githubusercontent.com`
- Optional repository claim check via `github_oidc_allowed_repository` setting
- Fallback to `auth_view` (admin) when no Bearer token is provided (local/dev usage)

### 5. Scaffold updates
- `Makefile`: `update-po-from-url` target passes `OIDC_TOKEN` as `Authorization: Bearer` header when defined.
- `update_l10n.yaml` workflow: requests an OIDC token with audience `geomapfish-l10n` and passes it to make. Added required permissions (`id-token: write`, `contents: write`, `pull-requests: write`).

## Testing & Validation

- 6 new unit tests for `get_unauthorized_layers()` (mocked DB)
- 10 new unit tests for OIDC validation (RSA key pair generation, JWT creation/validation)
- All 98 existing non-functional tests pass

## Impact/Risks

- **Breaking change**: `/locale.pot` now requires authentication (Bearer OIDC token or admin auth). Consumers that relied on anonymous access must be updated to provide credentials.
- **Theme response change**: `childLayers` and `ogcServers.*.attributes` will contain fewer entries for users without access to private groups. This is the intended security fix.
- **No impact on lingva_extractor CLI**: it connects directly to the backend, bypassing c2cgeoportal, and continues to work as before.

session: ses_000c5b8edffeAlZ99kRT3khkIj

<!-- pull request links -->
See JIRA issue: [GSBLGEOS-45](https://camptocamp.atlassian.net/browse/GSBLGEOS-45).

[GSBLGEOS-45]: https://camptocamp.atlassian.net/browse/GSBLGEOS-45?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ