### PR TITLE
Add workflow-level permissions to GitHub Actions

### DIFF
--- a/.github/workflows/ngeo-2-7.yaml
+++ b/.github/workflows/ngeo-2-7.yaml
@@ -9,6 +9,9 @@ on:
 env:
   HAS_SECRETS: ${{ secrets.HAS_SECRETS }}
 
+permissions:
+  contents: write
+
 jobs:
   main:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ngeo-2-8.yaml
+++ b/.github/workflows/ngeo-2-8.yaml
@@ -6,6 +6,10 @@ on:
       - ngeo_2.8_updated
   workflow_dispatch:
 
+permissions:
+  contents: write
+  security-events: write
+
 jobs:
   main:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ngeo-2-8.yaml
+++ b/.github/workflows/ngeo-2-8.yaml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: write
-  security-events: write
 
 jobs:
   main:

--- a/.github/workflows/ngeo-2-9.yaml
+++ b/.github/workflows/ngeo-2-9.yaml
@@ -6,6 +6,10 @@ on:
       - ngeo_2.9_updated
   workflow_dispatch:
 
+permissions:
+  contents: write
+  security-events: write
+
 jobs:
   main:
     name: Update ngeo 2.9

--- a/.github/workflows/ngeo-2-9.yaml
+++ b/.github/workflows/ngeo-2-9.yaml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: write
-  security-events: write
 
 jobs:
   main:

--- a/.github/workflows/pull-request-automation.yaml
+++ b/.github/workflows/pull-request-automation.yaml
@@ -5,6 +5,10 @@ on:
     types:
       - opened
       - reopened
+
+permissions:
+  contents: read
+
 jobs:
   auto-merge:
     name: Auto reviews pull requests from bots

--- a/.github/workflows/rebuild-2-7.yaml
+++ b/.github/workflows/rebuild-2-7.yaml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '30 3 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   main:
     runs-on: ubuntu-22.04

--- a/.github/workflows/rebuild-2-8.yaml
+++ b/.github/workflows/rebuild-2-8.yaml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   main:

--- a/.github/workflows/rebuild-2-8.yaml
+++ b/.github/workflows/rebuild-2-8.yaml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: '30 3 * * *'
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   main:
     runs-on: ubuntu-22.04

--- a/.github/workflows/rebuild-master.yaml
+++ b/.github/workflows/rebuild-master.yaml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '30 3 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   main:
     runs-on: ubuntu-24.04

--- a/.github/workflows/rebuild-qgis-2-7.yaml
+++ b/.github/workflows/rebuild-qgis-2-7.yaml
@@ -7,6 +7,9 @@ on:
 env:
   HAS_SECRETS: ${{ secrets.HAS_SECRETS }}
 
+permissions:
+  contents: read
+
 jobs:
   main:
     runs-on: ubuntu-22.04

--- a/.github/workflows/rebuild-qgis-2.8.yaml
+++ b/.github/workflows/rebuild-qgis-2.8.yaml
@@ -9,7 +9,6 @@ env:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   main:

--- a/.github/workflows/rebuild-qgis-2.8.yaml
+++ b/.github/workflows/rebuild-qgis-2.8.yaml
@@ -7,6 +7,10 @@ on:
 env:
   DOCKER_BUILDKIT: 1
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   main:
     runs-on: ubuntu-22.04

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/.github/workflows/main.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/.github/workflows/main.yaml
@@ -8,6 +8,9 @@ on:
 # env:
 #   HAS_SECRETS: ${{'{{'}} secrets.HAS_SECRETS }}
 
+permissions:
+  contents: read
+
 jobs:
   main:
     runs-on: ubuntu-24.04

--- a/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/.github/workflows/rebuild.yaml
+++ b/geoportal/c2cgeoportal_geoportal/scaffolds/create/{{cookiecutter.project}}/.github/workflows/rebuild.yaml
@@ -5,6 +5,11 @@ on:
   schedule:
     - cron: '30 2 * * *'
 
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+
 jobs:
   rebuild:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary

Add top-level `permissions` blocks to GitHub Actions workflows to follow the principle of least privilege.

## Context

GitHub recommends defining workflow-level permissions to restrict the default token scope. This PR adds explicit permissions to all workflows that previously relied on default (often overly broad) token permissions.

## Implementation Details

- `ngeo-2-7.yaml`: `contents: write`
- `ngeo-2-8.yaml`, `ngeo-2-9.yaml`: `contents: write`, `security-events: write`
- `rebuild-2-7.yaml`, `rebuild-master.yaml`, `rebuild-qgis-2-7.yaml`: `contents: read`
- `rebuild-2-8.yaml`, `rebuild-qgis-2.8.yaml`: `contents: read`, `security-events: write`
- `pull-request-automation.yaml`: `contents: read`