### PR TITLE
Restore poetry-dynamic-versioning plugin extra, pin poetry-core to 2.0.1 and pin build-system requires

### DIFF
--- a/admin/pyproject.toml
+++ b/admin/pyproject.toml
@@ -78,5 +78,5 @@ main = "c2cgeoportal_admin:main"
 geomapfish-admin-config = "c2cgeoportal_admin.lib.lingva_extractor:GeomapfishConfigExtractor"
 
 [build-system]
-requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning[plugin]", "poetry-plugin-tweak-dependencies-version", "poetry-plugin-drop-python-upper-constraint"]
+requires = ["poetry-core==2.4.0", "poetry-dynamic-versioning[plugin]==1.10.0", "poetry-plugin-tweak-dependencies-version==1.5.6", "poetry-plugin-drop-python-upper-constraint==1.0.1"]
 build-backend = "poetry.core.masonry.api"

--- a/admin/pyproject.toml
+++ b/admin/pyproject.toml
@@ -78,5 +78,5 @@ main = "c2cgeoportal_admin:main"
 geomapfish-admin-config = "c2cgeoportal_admin.lib.lingva_extractor:GeomapfishConfigExtractor"
 
 [build-system]
-requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning", "poetry-plugin-tweak-dependencies-version", "poetry-plugin-drop-python-upper-constraint"]
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning[plugin]", "poetry-plugin-tweak-dependencies-version", "poetry-plugin-drop-python-upper-constraint"]
 build-backend = "poetry.core.masonry.api"

--- a/admin/pyproject.toml
+++ b/admin/pyproject.toml
@@ -78,5 +78,5 @@ main = "c2cgeoportal_admin:main"
 geomapfish-admin-config = "c2cgeoportal_admin.lib.lingva_extractor:GeomapfishConfigExtractor"
 
 [build-system]
-requires = ["poetry-core==2.4.0", "poetry-dynamic-versioning[plugin]==1.10.0", "poetry-plugin-tweak-dependencies-version==1.5.6", "poetry-plugin-drop-python-upper-constraint==1.0.1"]
+requires = ["poetry-core==2.0.1", "poetry-dynamic-versioning[plugin]==1.10.0", "poetry-plugin-tweak-dependencies-version==1.5.6", "poetry-plugin-drop-python-upper-constraint==1.0.1"]
 build-backend = "poetry.core.masonry.api"

--- a/commons/pyproject.toml
+++ b/commons/pyproject.toml
@@ -64,5 +64,5 @@ upgrade = ["alembic", "psycopg2"]
 broadcast = ["c2cwsgiutils"]
 
 [build-system]
-requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning[plugin]", "poetry-plugin-tweak-dependencies-version", "poetry-plugin-drop-python-upper-constraint"]
+requires = ["poetry-core==2.4.0", "poetry-dynamic-versioning[plugin]==1.10.0", "poetry-plugin-tweak-dependencies-version==1.5.6", "poetry-plugin-drop-python-upper-constraint==1.0.1"]
 build-backend = "poetry.core.masonry.api"

--- a/commons/pyproject.toml
+++ b/commons/pyproject.toml
@@ -64,5 +64,5 @@ upgrade = ["alembic", "psycopg2"]
 broadcast = ["c2cwsgiutils"]
 
 [build-system]
-requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning", "poetry-plugin-tweak-dependencies-version", "poetry-plugin-drop-python-upper-constraint"]
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning[plugin]", "poetry-plugin-tweak-dependencies-version", "poetry-plugin-drop-python-upper-constraint"]
 build-backend = "poetry.core.masonry.api"

--- a/commons/pyproject.toml
+++ b/commons/pyproject.toml
@@ -64,5 +64,5 @@ upgrade = ["alembic", "psycopg2"]
 broadcast = ["c2cwsgiutils"]
 
 [build-system]
-requires = ["poetry-core==2.4.0", "poetry-dynamic-versioning[plugin]==1.10.0", "poetry-plugin-tweak-dependencies-version==1.5.6", "poetry-plugin-drop-python-upper-constraint==1.0.1"]
+requires = ["poetry-core==2.0.1", "poetry-dynamic-versioning[plugin]==1.10.0", "poetry-plugin-tweak-dependencies-version==1.5.6", "poetry-plugin-drop-python-upper-constraint==1.0.1"]
 build-backend = "poetry.core.masonry.api"

--- a/geoportal/pyproject.toml
+++ b/geoportal/pyproject.toml
@@ -129,5 +129,5 @@ c2cgeoportal = "c2cgeoportal_geoportal.lib.loader:Loader"
 "c2cgeoportal+egg" = "c2cgeoportal_geoportal.lib.loader:Loader"
 
 [build-system]
-requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning[plugin]", "poetry-plugin-tweak-dependencies-version", "poetry-plugin-drop-python-upper-constraint"]
+requires = ["poetry-core==2.4.0", "poetry-dynamic-versioning[plugin]==1.10.0", "poetry-plugin-tweak-dependencies-version==1.5.6", "poetry-plugin-drop-python-upper-constraint==1.0.1"]
 build-backend = "poetry.core.masonry.api"

--- a/geoportal/pyproject.toml
+++ b/geoportal/pyproject.toml
@@ -129,5 +129,5 @@ c2cgeoportal = "c2cgeoportal_geoportal.lib.loader:Loader"
 "c2cgeoportal+egg" = "c2cgeoportal_geoportal.lib.loader:Loader"
 
 [build-system]
-requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning", "poetry-plugin-tweak-dependencies-version", "poetry-plugin-drop-python-upper-constraint"]
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning[plugin]", "poetry-plugin-tweak-dependencies-version", "poetry-plugin-drop-python-upper-constraint"]
 build-backend = "poetry.core.masonry.api"

--- a/geoportal/pyproject.toml
+++ b/geoportal/pyproject.toml
@@ -129,5 +129,5 @@ c2cgeoportal = "c2cgeoportal_geoportal.lib.loader:Loader"
 "c2cgeoportal+egg" = "c2cgeoportal_geoportal.lib.loader:Loader"
 
 [build-system]
-requires = ["poetry-core==2.4.0", "poetry-dynamic-versioning[plugin]==1.10.0", "poetry-plugin-tweak-dependencies-version==1.5.6", "poetry-plugin-drop-python-upper-constraint==1.0.1"]
+requires = ["poetry-core==2.0.1", "poetry-dynamic-versioning[plugin]==1.10.0", "poetry-plugin-tweak-dependencies-version==1.5.6", "poetry-plugin-drop-python-upper-constraint==1.0.1"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
Restore the `[plugin]` extra of `poetry-dynamic-versioning` and pin `poetry-core` to 2.0.1 in `[build-system].requires`.

## Context
- A previous change dropped the `[plugin]` extra from `poetry-dynamic-versioning`; without the extra, poetry-dynamic-versioning is not installed as a poetry-core build plugin in the PEP 517 isolated build environment.
- The build plugins `poetry-plugin-tweak-dependencies-version` and `poetry-plugin-drop-python-upper-constraint` require `poetry<2.1.0`; Poetry always depends on the exact matching poetry-core version, so the build environment resolves Poetry 2.0.1, which requires `poetry-core==2.0.1`.

## Implementation Details
- Edit `[build-system].requires` in `pyproject.toml`; existing version pins are kept.
- No change to project dependencies or to the lock file.

## Testing & Validation
- The CI build and publish flows validate the packaging configuration.

## Impact/Risks
- Restores a working, fully pinned build configuration; no runtime impact, no configuration change.