### PR TITLE
Fix error when deleting entry in the cache

### DIFF
--- a/geoportal/c2cgeoportal_geoportal/lib/caching.py
+++ b/geoportal/c2cgeoportal_geoportal/lib/caching.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2012-2025, Camptocamp SA
+# Copyright (c) 2012-2026, Camptocamp SA
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without

--- a/geoportal/c2cgeoportal_geoportal/lib/caching.py
+++ b/geoportal/c2cgeoportal_geoportal/lib/caching.py
@@ -160,11 +160,11 @@ class HybridRedisBackend(CacheBackend):
 
     def delete(self, key: str) -> None:
         self._memory.delete(key)
-        self._redis.delete(key)
+        self._redis.delete(sha1_mangle_key(key.encode()))
 
     def delete_multi(self, keys: Iterable[str]) -> None:
-        self._memory.delete_multi(keys)
-        self._redis.delete_multi(keys)
+        for key in keys:
+            self.delete(key)
 
 
 class HybridRedisSentinelBackend(HybridRedisBackend):


### PR DESCRIPTION
The delete methods of the class `HybridRedisBackend` are not deleting correctly entries from redis cache, because the entry key is hashed in the `set` method, but not in the `delete` method.

This PR should fix it.