### PR TITLE
Filter the search capabilities by user, language and interface

### DIFF
--- a/doc/developer/webservices.rst
+++ b/doc/developer/webservices.rst
@@ -465,7 +465,8 @@ URL: ``.../search/capabilities``
 Parameters
 ----------
 
-None.
+* ``lang``: Language used to filter the categories (optional). If not provided, the locale negotiated from the request is used.
+* ``interface``: Filter categories to a specific interface (optional). If not provided, only entries without interface are considered.
 
 Result
 ------
@@ -480,6 +481,10 @@ Result
     }
 
 The list contains all distinct non-null ``category`` values (``layer_name`` in the table) sorted alphabetically.
+
+Like for the search endpoint, the categories are filtered to what the current user can see
+(public entries, entries without role for registered users, and entries of the user roles)
+and to the used language (entries without language are always kept).
 
 
 Layers

--- a/geoportal/c2cgeoportal_geoportal/views/fulltextsearch.py
+++ b/geoportal/c2cgeoportal_geoportal/views/fulltextsearch.py
@@ -72,6 +72,34 @@ class FullTextSearchView:
 
         return DBSession.query(Interface).filter_by(name=interface).one().id
 
+    def _get_user_filter(self) -> ColumnElement[bool]:
+        """Get the filter on the entries visible by the current user."""
+        if self.request.user is None:
+            return or_(
+                FullTextSearch.public.is_(True),
+                FullTextSearch.role_id.in_(get_roles_id(self.request)),
+            )
+        return or_(
+            FullTextSearch.public.is_(True),
+            FullTextSearch.role_id.is_(None),
+            FullTextSearch.role_id.in_(get_roles_id(self.request)),
+        )
+
+    def _get_interface_filter(self) -> ColumnElement[bool]:
+        """Get the filter on the interface requested by the user."""
+        if "interface" in self.request.params:
+            return or_(
+                FullTextSearch.interface_id.is_(None),
+                FullTextSearch.interface_id == self._get_interface_id(self.request.params["interface"]),
+            )
+        interface_filter: ColumnElement[bool] = FullTextSearch.interface_id.is_(None)
+        return interface_filter
+
+    @staticmethod
+    def _get_lang_filter(lang: str) -> ColumnElement[bool]:
+        """Get the filter on the language used by the user."""
+        return or_(FullTextSearch.lang.is_(None), FullTextSearch.lang == lang)
+
     @view_config(route_name="fulltextsearch", renderer="geojson")  # type: ignore[misc]
     def fulltextsearch(self) -> FeatureCollection:
         assert DBSession is not None
@@ -106,36 +134,12 @@ class FullTextSearchView:
         ]
         terms_ts = "&".join(w + ":*" for w in terms_array if w != "")
         _filter: ColumnElement[bool] = FullTextSearch.ts.op("@@")(func.to_tsquery(language, terms_ts))
-        if self.request.user is None:
-            _filter = and_(
-                _filter,
-                or_(
-                    FullTextSearch.public.is_(True),
-                    FullTextSearch.role_id.in_(get_roles_id(self.request)),
-                ),
-            )
-        else:
-            _filter = and_(
-                _filter,
-                or_(
-                    FullTextSearch.public.is_(True),
-                    FullTextSearch.role_id.is_(None),
-                    FullTextSearch.role_id.in_(get_roles_id(self.request)),
-                ),
-            )
-
-        if "interface" in self.request.params:
-            _filter = and_(
-                _filter,
-                or_(
-                    FullTextSearch.interface_id.is_(None),
-                    FullTextSearch.interface_id == self._get_interface_id(self.request.params["interface"]),
-                ),
-            )
-        else:
-            _filter = and_(_filter, FullTextSearch.interface_id.is_(None))
-
-        _filter = and_(_filter, or_(FullTextSearch.lang.is_(None), FullTextSearch.lang == lang))
+        _filter = and_(
+            _filter,
+            self._get_user_filter(),
+            self._get_interface_filter(),
+            self._get_lang_filter(lang),
+        )
 
         null_category = self.request.params.get("null_category", "false").lower() in ("true", "1", "yes")
         if "categories" in self.request.params:
@@ -235,11 +239,19 @@ class FullTextSearchView:
     def capabilities(self) -> dict[str, Any]:
         """Full text search capabilities."""
         assert DBSession is not None
+
+        lang = locale_negotiator(self.request)
+        _filter = and_(
+            self._get_user_filter(),
+            self._get_interface_filter(),
+            self._get_lang_filter(lang),
+        )
         categories = [
             category[0]
             for category in (
                 DBSession.query(FullTextSearch.layer_name)
                 .distinct(FullTextSearch.layer_name)
+                .filter(_filter)
                 .order_by(FullTextSearch.layer_name)
                 .all()
             )

--- a/geoportal/tests/functional/test_fulltextsearch.py
+++ b/geoportal/tests/functional/test_fulltextsearch.py
@@ -616,11 +616,98 @@ class TestFulltextsearchView(TestCase):
     def test_capabilities(self) -> None:
         from c2cgeoportal_geoportal.views.fulltextsearch import FullTextSearchView
 
+        # Anonymous: only the categories of public entries (entry2 is private without
+        # role and entry3 is private with role2, both are excluded)
         request = self._create_dummy_request()
         fts = FullTextSearchView(request)
         response = fts.capabilities()
         assert set(response.keys()) == {"categories"}
+        assert set(response["categories"]) == {"layer1"}
+
+        # Registered user1: also the private entries without role (entry2)
+        request = self._create_dummy_request(username="__test_user1")
+        fts = FullTextSearchView(request)
+        response = fts.capabilities()
+        assert set(response["categories"]) == {"layer1", "layer2"}
+
+        # Registered user2: also the entries of its role2 (entry3)
+        request = self._create_dummy_request(username="__test_user2")
+        fts = FullTextSearchView(request)
+        response = fts.capabilities()
         assert set(response["categories"]) == {"layer1", "layer2", "layer3"}
+
+    def test_capabilities_lang(self) -> None:
+        import transaction
+        from sqlalchemy import func
+
+        from c2cgeoportal_commons.models import DBSession
+        from c2cgeoportal_commons.models.main import FullTextSearch
+        from c2cgeoportal_geoportal.views.fulltextsearch import FullTextSearchView
+
+        entry_fr = FullTextSearch()
+        entry_fr.label = "label_fr"
+        entry_fr.layer_name = "layer_fr"
+        entry_fr.ts = func.to_tsvector("french", "capacities_fr")
+        entry_fr.public = True
+        entry_fr.lang = "fr"
+
+        entry_en = FullTextSearch()
+        entry_en.label = "label_en"
+        entry_en.layer_name = "layer_en"
+        entry_en.ts = func.to_tsvector("french", "capacities_en")
+        entry_en.public = True
+        entry_en.lang = "en"
+
+        DBSession.add_all([entry_fr, entry_en])
+        transaction.commit()
+
+        # The negotiated language is fr by default
+        request = self._create_dummy_request()
+        fts = FullTextSearchView(request)
+        response = fts.capabilities()
+        assert "layer_fr" in response["categories"]
+        assert "layer_en" not in response["categories"]
+        # Entries without language are always present
+        assert "layer1" in response["categories"]
+
+        request = self._create_dummy_request(params={"lang": "en"})
+        fts = FullTextSearchView(request)
+        response = fts.capabilities()
+        assert "layer_en" in response["categories"]
+        assert "layer_fr" not in response["categories"]
+        assert "layer1" in response["categories"]
+
+    def test_capabilities_interface(self) -> None:
+        import transaction
+        from sqlalchemy import func
+
+        from c2cgeoportal_commons.models import DBSession
+        from c2cgeoportal_commons.models.main import FullTextSearch, Interface
+        from c2cgeoportal_geoportal.views.fulltextsearch import FullTextSearchView
+
+        entry_iface = FullTextSearch()
+        entry_iface.label = "label_iface"
+        entry_iface.layer_name = "layer_iface"
+        entry_iface.ts = func.to_tsvector("french", "capacities_iface")
+        entry_iface.public = True
+        entry_iface.interface = DBSession.query(Interface).filter_by(name="main").one()
+
+        DBSession.add(entry_iface)
+        transaction.commit()
+
+        # No interface parameter: only the entries without interface
+        request = self._create_dummy_request()
+        fts = FullTextSearchView(request)
+        response = fts.capabilities()
+        assert "layer_iface" not in response["categories"]
+        assert "layer1" in response["categories"]
+
+        # interface=main: entries without interface and entries of the main interface
+        request = self._create_dummy_request(params={"interface": "main"})
+        fts = FullTextSearchView(request)
+        response = fts.capabilities()
+        assert "layer_iface" in response["categories"]
+        assert "layer1" in response["categories"]
 
     def test_duplicate_entries(self):
         import transaction


### PR DESCRIPTION
## Summary

Filter the `/search/capabilities` endpoint by user rights, language and interface, the same way the `/search` endpoint does, and refactor the filter construction to share the code between the two endpoints.

## Context

- The capabilities endpoint returned all the distinct categories (`layer_name` of the `tsearch` table), including categories coming from private entries not visible by the current user, from entries of other languages or bound to an interface.
- The search endpoint already applied those filters, but the code was inline and could not be reused.

## Implementation Details

- Extract three filter builders in `FullTextSearchView`: `_get_user_filter()` (public entries, entries without role for registered users and entries of the user roles), `_get_interface_filter()` (entries without interface, or entries without interface plus the requested one) and `_get_lang_filter()` (entries without language or of the given language).
- Both `fulltextsearch()` and `capabilities()` now use these methods, so the filter code is no longer duplicated.
- Document the filtering behavior and the `lang` / `interface` parameters of the capabilities endpoint in the web services documentation.

## Testing & Validation

- Extend the functional tests of the capabilities endpoint: categories returned for an anonymous user, for registered users with different roles, with the `lang` parameter and with the `interface` parameter.
- Steps to reproduce: call `/search/capabilities` as an anonymous user, the categories of private entries are no longer listed; call it with `?lang=en` or `?interface=<name>` to filter accordingly.

## Impact/Risks

- Behavior change: `/search/capabilities` now returns only the categories visible by the current user, for the negotiated language and interface, instead of all the categories of the table. Clients using this endpoint will get a reduced, user-specific list.
- No migration and no configuration change.


<!-- pull request links -->
See JIRA issue: [GSBLGEOS-47](https://camptocamp.atlassian.net/browse/GSBLGEOS-47).

[GSBLGEOS-47]: https://camptocamp.atlassian.net/browse/GSBLGEOS-47?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ